### PR TITLE
Restrict Monthly Activation & Members Only Zones

### DIFF
--- a/packages/documents/graphql/resolvers/Document.js
+++ b/packages/documents/graphql/resolvers/Document.js
@@ -3,6 +3,7 @@ const {
   metaUrlResolver
 } = require('../../lib/resolve')
 const {
+  processMembersOnlyZonesInContent,
   processRepoImageUrlsInContent,
   processRepoImageUrlsInMeta,
   processImageUrlsInContent
@@ -23,7 +24,7 @@ const shouldDeliverWebP = (argument = 'auto', req) => {
 module.exports = {
   content (doc, { urlPrefix, searchString, webp }, context, info) {
     // we only do auto slugging when in a published documents context
-    // - this is easiest dedectable by _all being present from documents resolver
+    // - this is easiest detectable by _all being present from documents resolver
     // - alt check info.path for documents / document being the root
     //   https://gist.github.com/tpreusse/f79833a023706520da53647f9c61c7f6
     if (doc._all) {
@@ -33,6 +34,8 @@ module.exports = {
         processRepoImageUrlsInContent(doc.content, addWebpSuffix)
         processImageUrlsInContent(doc.content, addWebpSuffix)
       }
+
+      processMembersOnlyZonesInContent(doc.content, context.user)
     }
     return doc.content
   },

--- a/packages/documents/lib/process.js
+++ b/packages/documents/lib/process.js
@@ -1,4 +1,13 @@
 const visit = require('unist-util-visit')
+const {
+  Roles: {
+    userIsInRoles
+  }
+} = require('@orbiting/backend-modules-auth')
+
+const {
+  DOCUMENTS_RESTRICT_TO_ROLES
+} = process.env
 
 const processRepoImageUrlsInContent = (mdast, fn) => {
   visit(mdast, 'image', node => {
@@ -39,7 +48,23 @@ const processImageUrlsInContent = (mdast, fn) => {
   })
 }
 
+const processMembersOnlyZonesInContent = (mdast, user) => {
+  if (!DOCUMENTS_RESTRICT_TO_ROLES) {
+    return
+  }
+  visit(mdast, 'zone', node => {
+    if (node.data && node.data.membersOnly) {
+      const roles = DOCUMENTS_RESTRICT_TO_ROLES.split(',')
+
+      if (!userIsInRoles(user, roles)) {
+        node.children = []
+      }
+    }
+  })
+}
+
 module.exports = {
+  processMembersOnlyZonesInContent,
   processRepoImageUrlsInContent,
   processRepoImageUrlsInMeta,
   processImageUrlsInContent

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/reactivateMembership.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/reactivateMembership.js
@@ -29,6 +29,14 @@ module.exports = async (_, args, {pgdb, req, t, mail: {sendMailTemplate, enforce
     const user = await transaction.public.users.findOne({ id: membership.userId })
     Roles.ensureUserIsMeOrInRoles(user, req.user, ['supporter'])
 
+    const activeMemberships = await transaction.public.memberships.find({
+      userId: user.id,
+      active: true
+    })
+    if (activeMemberships.length && !activeMemberships.find(m => m.id === membershipId)) {
+      throw new Error(t('api/membership/reactivate/otherActive'))
+    }
+
     const membershipType = await transaction.public.membershipTypes.findOne({
       id: membership.membershipTypeId
     })

--- a/servers/republik/modules/crowdfundings/lib/translations.json
+++ b/servers/republik/modules/crowdfundings/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-01-22T15:25:59.333Z",
+  "updated": "2018-02-23T13:07:07.469Z",
   "title": "live",
   "data": [
     {
@@ -33,6 +33,10 @@
     {
       "key": "api/membership/monthly/reactivate",
       "value": "Sie können nicht noch einmal ein Monats-Abonnement kaufen. Bitte verlängern sie Ihr Abonnement stattdessen in Ihrem Konto (www.republik.ch/konto)."
+    },
+    {
+      "key": "api/membership/reactivate/otherActive",
+      "value": "Sie haben bereits eine andere, aktive Mitgliedschaft."
     },
     {
       "key": "api/membership/cancel/isInactive",


### PR DESCRIPTION
Prevent user who switched to yearly membership from re-activation their monthly abo (implemented generically—no point in activating two).

<img width="1056" alt="screen shot 2018-02-23 at 17 36 15" src="https://user-images.githubusercontent.com/410211/36605133-19a1425e-18c0-11e8-8d1c-55b14565609d.png">
