### PR TITLE
Email Tracking

### DIFF
--- a/servers/publikator/README.md
+++ b/servers/publikator/README.md
@@ -57,6 +57,17 @@ Setup (for dev environment):
 - On the page of your new GitHub-App you also find the **ID**. This values needs to be provided as `GITHUB_APP_ID` env var.
 - [Install the GitHub-App](https://help.github.com/articles/installing-an-app-in-your-organization/) in your organization. On the page of the installation (settings -> Installed GitHub Apps -> App) copy the last part of the URL (e.g `41809`), it needs to be provided as `GITHUB_INSTALLATION_ID` env var.
 
+## Email Tracking
+
+You can add our own open beacon to newsletters by setting following environment variables:
+
+```
+PIWIK_URL_BASE=https://piwik.example.com
+PIWIK_SITE_ID=1
+```
+
+_MailChimp tracking is automatically disabled when creating a new campaign._
+
 ## Embeds
 
 The `embed` root query depends on 3rd party API calls and in order for them to work, you have to create apps on the respective platforms and put your credentials into your `.env` file.

--- a/servers/publikator/graphql/resolvers/_mutations/publish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/publish.js
@@ -354,7 +354,7 @@ module.exports = async (
         bots: 1,
         action_name: `Email: ${doc.content.meta.emailSubject}`,
         ...utmParams
-      })}`
+      })}&uid=*|URL:EMAIL|*`
       html = html.replace(
         '</body>',
         `<img src="${openBeacon}" height="1" width="1"></body>`

--- a/servers/publikator/graphql/resolvers/_mutations/publish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/publish.js
@@ -354,7 +354,7 @@ module.exports = async (
         bots: 1,
         action_name: `Email: ${doc.content.meta.emailSubject}`,
         ...utmParams
-      })}&uid=*|URL:EMAIL|*`
+      })}&_id=*|DATE:ymd|**|UNIQID|*`
       html = html.replace(
         '</body>',
         `<img src="${openBeacon}" height="1" width="1"></body>`

--- a/servers/publikator/graphql/resolvers/_mutations/publish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/publish.js
@@ -47,7 +47,11 @@ const { lib: {
 } } = require('@orbiting/backend-modules-assets')
 const uniq = require('lodash/uniq')
 
-const { FRONTEND_BASE_URL } = process.env
+const {
+  FRONTEND_BASE_URL,
+  PIWIK_URL_BASE,
+  PIWIK_SITE_ID
+} = process.env
 
 module.exports = async (
   _,
@@ -106,11 +110,12 @@ module.exports = async (
   const allUsernames = firstDoc._usernames
 
   const resolvedDoc = JSON.parse(JSON.stringify(doc))
-  const searchString = '?' + querystring.stringify({
+  const utmParams = {
     'utm_source': 'newsletter',
     'utm_medium': 'email',
     'utm_campaign': repoId
-  })
+  }
+  const searchString = '?' + querystring.stringify(utmParams)
   contentUrlResolver(resolvedDoc, allDocs, allUsernames, unresolvedRepoIds, FRONTEND_BASE_URL, searchString)
   metaUrlResolver(resolvedDoc.content.meta, allDocs, allUsernames, unresolvedRepoIds, FRONTEND_BASE_URL, searchString)
   metaFieldResolver(resolvedDoc.content.meta, allDocs, unresolvedRepoIds)
@@ -339,7 +344,22 @@ module.exports = async (
 
   // do the mailchimp update
   if (campaignId) {
-    const html = getHTML(resolvedDoc)
+    let html = getHTML(resolvedDoc)
+
+    if (PIWIK_URL_BASE && PIWIK_SITE_ID) {
+      const openBeacon = `${PIWIK_URL_BASE}/piwik.php?${querystring.stringify({
+        idsite: PIWIK_SITE_ID,
+        url: FRONTEND_BASE_URL + doc.content.meta.path,
+        rec: 1,
+        bots: 1,
+        action_name: `Email: ${doc.content.meta.emailSubject}`,
+        ...utmParams
+      })}`
+      html = html.replace(
+        '</body>',
+        `<img src="${openBeacon}" height="1" width="1"></body>`
+      )
+    }
 
     const updateResponse = await updateCampaignContent({
       campaignId,

--- a/servers/publikator/lib/mailchimp/createCampaign.js
+++ b/servers/publikator/lib/mailchimp/createCampaign.js
@@ -22,6 +22,11 @@ module.exports = async ({ title, subject }) => {
         content_type: 'html',
         from_name: MAILCHIMP_FROM_NAME,
         reply_to: MAILCHIMP_REPLY_TO
+      },
+      tracking: {
+        opens: false,
+        html_clicks: false,
+        text_clicks: false
       }
     })
   })


### PR DESCRIPTION
Disable all MailChimp tracking and add a Piwik open beacon.

I followed this guide: https://matomo.org/faq/how-to/faq_25454/ and customised it for our Piwik setup.

The most controversial is the `uid`: https://github.com/orbiting/backends/commit/0993b927d8933a0f99b334fd8a162cb891fd9be3

However without an `uid` it will be impossible to calculate an open rate. We could pseudo anonymise the `uid` but since it needs to be stable we would always be able to resolve it—whats the point?