### PR TITLE
fix: auth confirmation email with visible button and improved inline styling

### DIFF
--- a/packages/auth/seeds/email_templates/signin.html
+++ b/packages/auth/seeds/email_templates/signin.html
@@ -12,53 +12,72 @@
       </o:officedocumentsettings>
     </xml>
     <![endif]-->
+    <!--[if mso]>
+    <style>
+      strong {
+      font-weight:bold !important;
+      }
+    </style>
+    <![endif]-->
+    <style type="text/css">
+    @font-face {font-family:"GT-America-Standard-Regular";src:url(https://cdn.republik.space/s3/republik-assets/fonts/gt-america-standard-regular.eot);src:url(https://cdn.republik.space/s3/republik-assets/fonts/gt-america-standard-regular.eot?#iefix) format("embedded-opentype"),url(https://cdn.republik.space/s3/republik-assets/fonts/gt-america-standard-regular.woff) format("woff"),url(https://cdn.republik.space/s3/republik-assets/fonts/gt-america-standard-regular.ttf) format("truetype");}
+    @font-face {font-family:"GT-America-Standard-Medium";src:url(https://cdn.republik.space/s3/republik-assets/fonts/gt-america-standard-medium.eot);src:url(https://cdn.republik.space/s3/republik-assets/fonts/gt-america-standard-medium.eot?#iefix) format("embedded-opentype"),url(https://cdn.republik.space/s3/republik-assets/fonts/gt-america-standard-medium.woff) format("woff"),url(https://cdn.republik.space/s3/republik-assets/fonts/gt-america-standard-medium.ttf) format("truetype");}
+    </style>
   </head>
   <body style="margin: 0; padding: 0; background-color: #fff;">
     <table border="0" cellpadding="0" cellspacing="0" width="100%">
       <tbody>
         <tr>
           <td align="center" valign="top">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:640px;color:#444;font-size:18px;font-family:Times, 'Times New Roman', serif;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:640px;color:#282828;font-size:17px;line-height:24px;font-family:'GT-America-Standard-Regular', 'Helvetica-Neue-Regular', 'Arial-Regular', 'Roboto-Regular', sans-serif;">
               <tbody>
                 <tr>
                   <td style="padding:20px;">
-                    <p>Guten Tag!</p>
-                    <p>Bestätigen Sie Ihr Mail!</p>
-                    <p>Hier noch einmal die drei seltsamen Worte:</p>
+                    <p style="color:#282828;font-size:17px;line-height:24px;font-family:'GT-America-Standard-Regular', 'Helvetica-Neue-Regular', 'Arial-Regular', 'Roboto-Regular', sans-serif;">Guten Tag!</p>
+                    <p style="color:#282828;font-size:17px;line-height:24px;font-family:'GT-America-Standard-Regular', 'Helvetica-Neue-Regular', 'Arial-Regular', 'Roboto-Regular', sans-serif;">Bitte bestätigen Sie Ihre E-Mail-Adresse. Hier noch einmal die drei seltsamen Worte:</p>
                     <p>
-                    <b>*|SECRET_WORDS|*</b>
+                    <strong style="font-family:'GT-America-Standard-Medium', 'Helvetica-Neue-Medium', 'Arial-Bold', 'Roboto-Medium', sans-serif;font-weight:normal;">«*|SECRET_WORDS|*»</strong>
                   </p>
-                  <p>Sind es dieselben? Wenn ja, dann ist alles perfekt. Klicken Sie auf den Link unten.</p>
-                  <p>
-                  <a href="*|LOGIN_LINK|*"> Link</a>
-                </p>
-                <p>Vielen Dank!</p>
-                <p>Die Crew von Project R und Republik</p>
-                <p>PS: Falls Sie die drei Worte noch nie gesehen haben, ignorieren Sie dieses Mail.</p>
-                *|IF:LOCATION|*
-                <p>PPS: Falls Sie nicht in *|LOCATION|* sind, ignorieren Sie diese Mail ebenfalls.</p>
-                *|END:IF|*
-              </td>
-            </tr>
-            <tr>
-              <td style="padding:20px;">
-                <p>
-                <img height="79" src="https://gallery.mailchimp.com/650c1ec9003c7d8567eef4c5e/images/feb6bdde-83da-4211-bcf8-b09d3d3d012a.png" style="border: 0px  ; width: 180px !important; height: 79px !important; margin: 0px;" width="180" alt="feb6bdde-83da-4211-bcf8-b09d3d3d012a.png">
-                <br>
-                Republik<br>
-                c/o Project R Genossenschaft<br>
-                Sihlhallenstrasse 1<br>
-                8004 Zürich<br>
-                Schweiz<br>
-                <a href="mailto:kontakt@republik.ch">kontakt@republik.ch</a>
-              </p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </td>
-  </tr>
-</tbody>
-</table>
+                  <p style="color:#282828;font-size:17px;line-height:24px;font-family:'GT-America-Standard-Regular', 'Helvetica-Neue-Regular', 'Arial-Regular', 'Roboto-Regular', sans-serif;">Sind es dieselben wie auf unserer Webseite? Wenn ja, klicken Sie auf den Button:</p>
+                  <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                    <tr>
+                      <td>
+                        <table border="0" cellspacing="0" cellpadding="0">
+                          <tr>
+                            <td align="center" bgcolor="#3CAD00">
+                              <a href="*|LOGIN_LINK|*" style="font-size:20px;font-family:Helvetica, Arial, sans-serif;color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;">E-Mail bestätigen und einloggen</a>
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                  <p style="color:#282828;font-size:17px;line-height:24px;font-family:'GT-America-Standard-Regular', 'Helvetica-Neue-Regular', 'Arial-Regular', 'Roboto-Regular', sans-serif;">Vielen Dank!</p>
+                  <p style="color:#282828;font-size:17px;line-height:24px;font-family:'GT-America-Standard-Regular', 'Helvetica-Neue-Regular', 'Arial-Regular', 'Roboto-Regular', sans-serif;">Die Crew von Project R und Republik</p>
+                  <p style="color:#282828;font-size:17px;line-height:24px;font-family:'GT-America-Standard-Regular', 'Helvetica-Neue-Regular', 'Arial-Regular', 'Roboto-Regular', sans-serif;">PS: Falls Sie die drei Worte noch nie gesehen haben, ignorieren Sie dieses Mail.</p>
+                  *|IF:LOCATION|*
+                  <p style="color:#282828;font-size:17px;line-height:24px;font-family:'GT-America-Standard-Regular', 'Helvetica-Neue-Regular', 'Arial-Regular', 'Roboto-Regular', sans-serif;">PPS: Falls Sie nicht in *|LOCATION|* sind, ignorieren Sie diese Mail ebenfalls.</p>
+                  *|END:IF|*
+                </td>
+              </tr>
+              <tr>
+                <td style="padding:20px;">
+                  <p style="color:#282828;font-size:17px;line-height:24px;font-family:'GT-America-Standard-Regular', 'Helvetica-Neue-Regular', 'Arial-Regular', 'Roboto-Regular', sans-serif;">
+                    <img height="79" src="https://gallery.mailchimp.com/650c1ec9003c7d8567eef4c5e/images/feb6bdde-83da-4211-bcf8-b09d3d3d012a.png" style="border: 0px  ; width: 180px !important; height: 79px !important; margin: 0px;" width="180" alt="REPUBLIK">
+                    <br>
+                    Republik<br>
+                    c/o Project R Genossenschaft<br>
+                    Sihlhallenstrasse 1<br>
+                    8004 Zürich<br>
+                    Schweiz<br><a href="mailto:kontakt@republik.ch">kontakt@republik.ch</a>
+                  </p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </body>
 </html>


### PR DESCRIPTION
Already updated on mailchimp, major changes:
- visible button instead of low-profile text link
- Republik-style typography instead of ProjectRs grey Times New Roman
- more robust inline styles

Apple Mail screenshot:
<img width="758" alt="screen shot 2018-02-26 at 16 58 12" src="https://user-images.githubusercontent.com/23520051/36680534-50dc77f4-1b16-11e8-8ea3-4bb6b0c642b5.png">
