### PR TITLE
feat: audioSources

### DIFF
--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -16,15 +16,10 @@ type Episode {
   document: Document
 }
 
-enum AudioSourceType {
-  mp3
-  aac
-  ogg
-}
-
 type AudioSource {
-  type: AudioSourceType!
-  url: String!
+  mp3: String
+  aac: String
+  ogg: String
 }
 
 type Meta {
@@ -53,7 +48,7 @@ type Meta {
   # the id of the discussion itself
   discussionId: ID
   credits: JSON
-  audioSources: [AudioSource]
+  audioSource: AudioSource
 }
 
 # implements FileInterface

--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -16,6 +16,17 @@ type Episode {
   document: Document
 }
 
+enum AudioSourceType {
+  mp3
+  aac
+  ogg
+}
+
+type AudioSource {
+  type: AudioSourceType!
+  url: String!
+}
+
 type Meta {
   title: String
   slug: String
@@ -42,6 +53,7 @@ type Meta {
   # the id of the discussion itself
   discussionId: ID
   credits: JSON
+  audioSources: [AudioSource]
 }
 
 # implements FileInterface

--- a/packages/documents/lib/meta.js
+++ b/packages/documents/lib/meta.js
@@ -22,10 +22,18 @@ const getMeta = doc => {
     }
   })
 
+  const { audioSourceMp3, audioSourceAac, audioSourceOgg } = doc.content.meta
+  const audioSource = audioSourceMp3 || audioSourceAac || audioSourceOgg ? {
+    mp3: audioSourceMp3,
+    aac: audioSourceAac,
+    ogg: audioSourceOgg
+  } : null
+
   doc._meta = {
     ...doc.content.meta,
     credits,
-    ...resolvedFields
+    ...resolvedFields,
+    audioSource
   }
   return doc._meta
 }

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -177,11 +177,19 @@ const metaFieldResolver = (meta, allDocuments = [], errors) => {
     }
   }
 
+  const { audioSourceMp3, audioSourceAac, audioSourceOgg } = meta
+  const audioSource = audioSourceMp3 || audioSourceAac || audioSourceOgg ? {
+    mp3: audioSourceMp3,
+    aac: audioSourceAac,
+    ogg: audioSourceOgg
+  } : null
+
   return {
     series,
     dossier: resolver(meta.dossier),
     format: resolver(meta.format),
-    discussion: resolver(meta.discussion)
+    discussion: resolver(meta.discussion),
+    audioSource
   }
 }
 

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -23,7 +23,7 @@ const getRepoId = (url, requireQuery) => {
     pathname,
     query
   } = parse(String(url))
-  if (!pathname) { //empty for mailto
+  if (!pathname) { // empty for mailto
     return
   }
   const pathSegments = pathname.split('/').filter(Boolean)
@@ -97,7 +97,7 @@ const createUrlReplacer = (allDocuments = [], usernames = [], errors = [], urlPr
   const linkedDoc = allDocuments
     .find(d => d.repoId === repoId)
   if (linkedDoc) {
-    return urlPrefix+linkedDoc.content.meta.path+searchString
+    return urlPrefix + linkedDoc.content.meta.path + searchString
   } else {
     errors.push(repoId)
   }
@@ -181,7 +181,8 @@ const metaFieldResolver = (meta, allDocuments = [], errors) => {
     series,
     dossier: resolver(meta.dossier),
     format: resolver(meta.format),
-    discussion: resolver(meta.discussion)
+    discussion: resolver(meta.discussion),
+    audioSources: meta.audioSources
   }
 }
 

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -23,7 +23,7 @@ const getRepoId = (url, requireQuery) => {
     pathname,
     query
   } = parse(String(url))
-  if (!pathname) { //empty for mailto
+  if (!pathname) { // empty for mailto
     return
   }
   const pathSegments = pathname.split('/').filter(Boolean)
@@ -97,7 +97,7 @@ const createUrlReplacer = (allDocuments = [], usernames = [], errors = [], urlPr
   const linkedDoc = allDocuments
     .find(d => d.repoId === repoId)
   if (linkedDoc) {
-    return urlPrefix+linkedDoc.content.meta.path+searchString
+    return urlPrefix + linkedDoc.content.meta.path + searchString
   } else {
     errors.push(repoId)
   }
@@ -177,19 +177,11 @@ const metaFieldResolver = (meta, allDocuments = [], errors) => {
     }
   }
 
-  const { audioSourceMp3, audioSourceAac, audioSourceOgg } = meta
-  const audioSource = audioSourceMp3 || audioSourceAac || audioSourceOgg ? {
-    mp3: audioSourceMp3,
-    aac: audioSourceAac,
-    ogg: audioSourceOgg
-  } : null
-
   return {
     series,
     dossier: resolver(meta.dossier),
     format: resolver(meta.format),
-    discussion: resolver(meta.discussion),
-    audioSource
+    discussion: resolver(meta.discussion)
   }
 }
 

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -181,8 +181,7 @@ const metaFieldResolver = (meta, allDocuments = [], errors) => {
     series,
     dossier: resolver(meta.dossier),
     format: resolver(meta.format),
-    discussion: resolver(meta.discussion),
-    audioSources: meta.audioSources
+    discussion: resolver(meta.discussion)
   }
 }
 


### PR DESCRIPTION
Kicking off backend changes for storing a reference to an audio version of an article. The current plan is to have input fields in an article's meta section for entering a URL of a previously uploaded mp3 and optionally aac and/or ogg. These may eventually turn into file upload fields.

Publikator PR: https://github.com/orbiting/publikator-frontend/pull/140
Frontend PR: https://github.com/orbiting/republik-frontend/pull/84