### PR TITLE
fix(setup): bump styleguide with relaxed node version requirement

### DIFF
--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@orbiting/backend-modules-auth": "link:../auth",
-    "@project-r/styleguide": "^5.50.6",
+    "@project-r/styleguide": "^5.71.5",
     "@project-r/template-newsletter": "^1.5.0",
     "apollo-modules-node": "^0.1.4",
     "check-env": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@
   version "2.12.0"
   dependencies:
     "@orbiting/backend-modules-auth" "link:packages/auth"
-    "@project-r/styleguide" "^5.50.6"
+    "@project-r/styleguide" "^5.71.5"
     "@project-r/template-newsletter" "^1.5.0"
     apollo-modules-node "^0.1.4"
     check-env "^1.3.0"
@@ -144,9 +144,9 @@
     stringify-entities "^1.3.1"
     unified "^6.1.5"
 
-"@project-r/styleguide@^5.50.6":
-  version "5.52.1"
-  resolved "https://registry.yarnpkg.com/@project-r/styleguide/-/styleguide-5.52.1.tgz#83879a3e260880e398402ede53070d64fb39966c"
+"@project-r/styleguide@^5.71.5":
+  version "5.71.5"
+  resolved "https://registry.yarnpkg.com/@project-r/styleguide/-/styleguide-5.71.5.tgz#c83796ae58aabaecbaaed824b545045745bda56c"
   dependencies:
     react-icons "^2.2.7"
 


### PR DESCRIPTION
We had this error since moving to node 8.10:
```
error @project-r/styleguide@5.52.1: The engine "node" is incompatible with this module. Expected version "8.9.x".
error An unexpected error occurred: "Found incompatible module".
```

I relaxed the node version requirement (anything gte 8.9) in the [styleguide](https://github.com/orbiting/styleguide/releases/tag/v5.71.5).