### PR TITLE
Fix pdf

### DIFF
--- a/packages/assets/express/frontend.js
+++ b/packages/assets/express/frontend.js
@@ -50,7 +50,8 @@ module.exports = (server) => {
       headers: result.headers,
       options: {
         ...req.query,
-        webp: !!webp
+        webp: !!webp,
+        cacheTags: ['frontend']
       }
     })
   })

--- a/packages/assets/express/frontend.js
+++ b/packages/assets/express/frontend.js
@@ -29,7 +29,7 @@ module.exports = (server) => {
       method: 'GET',
       headers: {
         Authorization: BASIC_AUTH_USER && BASIC_AUTH_PASS
-          ? Buffer.from(`${BASIC_AUTH_USER}:${BASIC_AUTH_PASS}`).toString('base64')
+          ? `Basic ${Buffer.from(`${BASIC_AUTH_USER}:${BASIC_AUTH_PASS}`).toString('base64')}`
           : undefined
       }
     })

--- a/packages/assets/express/github.js
+++ b/packages/assets/express/github.js
@@ -60,7 +60,8 @@ module.exports = (server) => {
       headers: result.headers,
       options: {
         ...req.query,
-        webp
+        webp,
+        cacheTags: ['github']
       }
     })
   })

--- a/packages/assets/express/pdf.js
+++ b/packages/assets/express/pdf.js
@@ -35,7 +35,10 @@ module.exports = (server) => {
       response: res,
       stream: result.body,
       headers: result.headers,
-      options: req.query
+      options: {
+        ...req.query,
+        cacheTags: ['pdf-proxy']
+      }
     })
   })
 }

--- a/packages/assets/express/proxy.js
+++ b/packages/assets/express/proxy.js
@@ -9,7 +9,7 @@ module.exports = (server) => {
   server.get('/proxy(.:webp)?', async (req, res) => {
     const {
       originalURL: url,
-      mac,
+      mac
     } = req.query
 
     if (!url) {
@@ -40,7 +40,8 @@ module.exports = (server) => {
       headers: result.headers,
       options: {
         ...req.query,
-        webp: !!req.params.webp
+        webp: !!req.params.webp,
+        cacheTags: ['proxy']
       }
     })
   })

--- a/packages/assets/express/render.js
+++ b/packages/assets/express/render.js
@@ -35,7 +35,10 @@ module.exports = (server) => {
       response: res,
       stream: result.body,
       headers: result.headers,
-      options: req.query
+      options: {
+        ...req.query,
+        cacheTags: ['render']
+      }
     })
   })
 }

--- a/packages/assets/express/s3.js
+++ b/packages/assets/express/s3.js
@@ -1,5 +1,4 @@
 const fetch = require('isomorphic-unfetch')
-const debug = require('debug')('assets:s3')
 const { returnImage } = require('../lib')
 const {
   AWS_BUCKET_WHITELIST
@@ -20,7 +19,6 @@ if (!AWS_BUCKET_WHITELIST) {
     )
 }
 
-
 module.exports = (server) => {
   server.get('/s3/:bucket/:path(*)', async (req, res) => {
     const {
@@ -33,6 +31,7 @@ module.exports = (server) => {
       return res.status(403).end()
     }
 
+    // eslint-disable-next-line no-unused-vars
     const [_, sanitizedPath, webp] = new RegExp(/(.*?)(\.webp)?$/, 'g').exec(path)
 
     const region = buckets[bucket]
@@ -54,7 +53,8 @@ module.exports = (server) => {
       headers: result.headers,
       options: {
         ...req.query,
-        webp: !!webp
+        webp: !!webp,
+        cacheTags: ['s3']
       }
     })
   })

--- a/packages/assets/lib/returnImage.js
+++ b/packages/assets/lib/returnImage.js
@@ -43,7 +43,7 @@ module.exports = async ({
   headers,
   options = {}
 }) => {
-  const { resize, bw, webp, format } = options
+  const { resize, bw, webp, format, cacheTags = [] } = options
   let width, height
   if (resize) {
     try {
@@ -84,6 +84,12 @@ module.exports = async ({
     if (mime) {
       res.set('Content-Type', mime)
     }
+    res.set('Cache-Tag',
+      cacheTags
+        .concat(mime && mime.split('/'))
+        .filter(Boolean)
+        .join(' ')
+    )
 
     const forceFormat = supportedFormats.indexOf(format) !== -1
 


### PR DESCRIPTION
Messed up the auth header.

This also adds cache tags for mass purging. Mime type based and proxy/method based. Can be helpful to purge all pdf after deploying a fix/improvement.