### PR TITLE
fix(auth): Encode/decode email in verification URL

### DIFF
--- a/packages/auth/lib/Sessions.js
+++ b/packages/auth/lib/Sessions.js
@@ -1,5 +1,5 @@
 const { NoSessionError, QueryEmailMismatchError, DestroySessionError } = require('./errors')
-const urlsafeBase64 = require('urlsafe-base64')
+const { decode, match } = require('@orbiting/backend-modules-base64u')
 
 const destroySession = async (req) => {
   return new Promise((resolve, reject) => {
@@ -18,10 +18,8 @@ const sessionByToken = async ({ pgdb, token, email: emailFromQuery, ...meta }) =
     'sess @>': { token }
   })
 
-  if (urlsafeBase64.validate(emailFromQuery)) {
-    emailFromQuery =
-      urlsafeBase64.decode(Buffer.from(emailFromQuery)).toString()
-  }
+  // Recognize and decode urlsafe base64 encoded email address.
+  if (match(emailFromQuery)) emailFromQuery = decode(emailFromQuery)
 
   if (!session) {
     throw new NoSessionError({ token, emailFromQuery, ...meta })

--- a/packages/auth/lib/Sessions.js
+++ b/packages/auth/lib/Sessions.js
@@ -1,4 +1,5 @@
 const { NoSessionError, QueryEmailMismatchError, DestroySessionError } = require('./errors')
+const urlsafeBase64 = require('urlsafe-base64')
 
 const destroySession = async (req) => {
   return new Promise((resolve, reject) => {
@@ -16,6 +17,12 @@ const sessionByToken = async ({ pgdb, token, email: emailFromQuery, ...meta }) =
   const session = await Sessions.findOne({
     'sess @>': { token }
   })
+
+  if (urlsafeBase64.validate(emailFromQuery)) {
+    emailFromQuery =
+      urlsafeBase64.decode(Buffer.from(emailFromQuery)).toString()
+  }
+
   if (!session) {
     throw new NoSessionError({ token, emailFromQuery, ...meta })
   }

--- a/packages/auth/lib/Sessions.js
+++ b/packages/auth/lib/Sessions.js
@@ -19,7 +19,9 @@ const sessionByToken = async ({ pgdb, token, email: emailFromQuery, ...meta }) =
   })
 
   // Recognize and decode urlsafe base64 encoded email address.
-  if (match(emailFromQuery)) emailFromQuery = decode(emailFromQuery)
+  if (match(emailFromQuery)) {
+    emailFromQuery = decode(emailFromQuery)
+  }
 
   if (!session) {
     throw new NoSessionError({ token, emailFromQuery, ...meta })

--- a/packages/auth/lib/signIn.js
+++ b/packages/auth/lib/signIn.js
@@ -2,6 +2,7 @@ const uuid = require('uuid/v4')
 const querystring = require('querystring')
 const validator = require('validator')
 const kraut = require('kraut')
+const urlsafeBase64 = require('urlsafe-base64')
 const geoForIP = require('./geoForIP')
 const checkEnv = require('check-env')
 const t = require('./t')
@@ -75,7 +76,7 @@ module.exports = async (_email, context, pgdb, req) => {
     `${FRONTEND_BASE_URL}/mitteilung?` +
     querystring.stringify({
       type: 'token-authorization',
-      email,
+      email: urlsafeBase64.encode(Buffer.from(email)),
       context,
       token
     })

--- a/packages/auth/lib/signIn.js
+++ b/packages/auth/lib/signIn.js
@@ -2,7 +2,6 @@ const uuid = require('uuid/v4')
 const querystring = require('querystring')
 const validator = require('validator')
 const kraut = require('kraut')
-const urlsafeBase64 = require('urlsafe-base64')
 const geoForIP = require('./geoForIP')
 const checkEnv = require('check-env')
 const t = require('./t')
@@ -12,6 +11,7 @@ const {
   sendMail,
   sendMailTemplate
 } = require('@orbiting/backend-modules-mail')
+const { encode } = require('@orbiting/backend-modules-base64u')
 
 checkEnv([
   'FRONTEND_BASE_URL',
@@ -76,7 +76,7 @@ module.exports = async (_email, context, pgdb, req) => {
     `${FRONTEND_BASE_URL}/mitteilung?` +
     querystring.stringify({
       type: 'token-authorization',
-      email: urlsafeBase64.encode(Buffer.from(email)),
+      email: encode(email),
       context,
       token
     })

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -43,7 +43,6 @@
     "pogi": "^2.5.8",
     "querystring": "^0.2.0",
     "rw": "^1.3.3",
-    "urlsafe-base64": "^1.0.0",
     "useragent": "^2.3.0",
     "uuid": "^3.2.1",
     "validator": "^9.4.1"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -43,6 +43,7 @@
     "pogi": "^2.5.8",
     "querystring": "^0.2.0",
     "rw": "^1.3.3",
+    "urlsafe-base64": "^1.0.0",
     "useragent": "^2.3.0",
     "uuid": "^3.2.1",
     "validator": "^9.4.1"

--- a/packages/base64u/index.js
+++ b/packages/base64u/index.js
@@ -1,0 +1,38 @@
+const urlDecode = base64u =>
+  `${base64u}${'==='.slice((base64u.length + 3) % 4)}`
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+
+const urlEncode = string => string
+  .replace(/\+/g, '-')
+  .replace(/\//g, '_')
+  .replace(/=/g, '')
+
+// see https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding, section about "Unicode Problem"
+const toUnicode = string => encodeURIComponent(string).replace(
+  /%([0-9A-F]{2})/g,
+  function toSolidBytes (match, p1) {
+    return String.fromCharCode('0x' + p1)
+  }
+)
+
+// see https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding, section about "Unicode Problem"
+const fromUnicode = string => decodeURIComponent(
+  string.split('').map(function (c) {
+    return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+  }).join('')
+)
+
+module.exports = {
+  decode: base64u => {
+    return typeof window === 'object'
+      ? fromUnicode(window.atob(urlDecode(base64u)))
+      : Buffer.from(urlDecode(base64u), 'base64').toString('utf8')
+  },
+  encode: string => urlEncode(
+    typeof window === 'object'
+      ? window.btoa(toUnicode(string))
+      : Buffer.from(string, 'utf8').toString('base64')
+  ),
+  match: base64u => /^[A-Za-z0-9\-_]+$/.test(base64u)
+}

--- a/packages/base64u/index.test.js
+++ b/packages/base64u/index.test.js
@@ -1,0 +1,127 @@
+const { encode, decode, match } = require('./index')
+const abab = require('abab')
+const test = require('tape')
+
+const testSeries = (env, runEnv) => {
+  [
+    { string: 'heidi', base64u: 'aGVpZGk' },
+    { string: 'peter?_', base64u: 'cGV0ZXI_Xw' }, // Not urlsafe: cGV0ZXI/Xw
+    { string: '12345><', base64u: 'MTIzNDU-PA' }, // Not urlsafe: MTIzNDU+PA
+    { string: 'äöüáàâéèê', base64u: 'w6TDtsO8w6HDoMOiw6nDqMOq' },
+    { string: 'π', base64u: 'z4A' },
+    { string: '😈', base64u: '8J-YiA' }, // Not urlsafe: 8J+YiA
+    { string: '\n', base64u: 'Cg' }
+  ]
+    .forEach(({ title, string, base64u }) => {
+      test(
+        `(${env}) base64u ${string} <-> ${base64u}`,
+        assert => runEnv(
+          assert,
+          assert => {
+            const encoded = encode(string)
+            assert.equal(encoded, base64u)
+
+            const decoded = decode(encoded)
+            assert.equal(decoded, string)
+
+            assert.end()
+          }
+        )
+      )
+    })
+
+  test(
+    `(${env}) base64u.decode w/ block padding "="`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(decode('a2xhcmE='), 'klara')
+        assert.end()
+      }
+    )
+  )
+
+  test(
+    `(${env}) base64u.decode w/o block padding "="`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(decode('a2xhcmE'), 'klara')
+        assert.end()
+      }
+    )
+  )
+
+  test(
+    `(${env}) base64u.match "a2xhcmE=" -> false`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('a2xhcmE='), false)
+        assert.end()
+      }
+    )
+  )
+
+  test(
+    `(${env}) base64u.match "a2xhcmE" -> true`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('a2xhcmE'), true)
+        assert.end()
+      }
+    )
+  )
+
+  test(
+    `(${env}) base64u.match "cGV0ZXI_Xw" -> true`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('cGV0ZXI_Xw'), true)
+        assert.end()
+      }
+    )
+  )
+
+  test(
+    `(${env}) base64u.match "cGV0ZXI/Xw" -> false`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('cGV0ZXI/Xw'), false)
+        assert.end()
+      }
+    )
+  )
+
+  test(
+    `(${env}) base64u.match "cGV0ZXI/Xw" -> false`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('cGV0ZXI/Xw'), false)
+        assert.end()
+      }
+    )
+  )
+}
+
+// Test Node.JS path
+testSeries(
+  'node',
+  (assert, asserationFn) => {
+    asserationFn(assert)
+  }
+)
+
+// Test (emulated) Browser window global variable
+testSeries(
+  'browser',
+  (assert, asserationFn) => {
+    global.window = abab
+    asserationFn(assert)
+    global.window = undefined
+  }
+)

--- a/packages/base64u/package.json
+++ b/packages/base64u/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@orbiting/backend-modules-base64u",
+  "version": "1.0.0",
+  "description": "Encode and decode strings to base64 in an urlsafe manner",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/orbiting/backends.git"
+  },
+  "author": "Patrick Venetz <patrick.venetz@republik.ch>",
+  "license": "AGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/orbiting/backends/issues"
+  },
+  "homepage": "https://github.com/orbiting/backends#readme",
+  "devDependencies": {
+    "abab": "^2.0.0",
+    "faucet": "^0.0.1",
+    "tape": "^4.9.0"
+  },
+  "scripts": {
+    "test": "NODE_ENV=development tape \"**/*.test.js\" | faucet"
+  }
+}

--- a/packages/base64u/package.json
+++ b/packages/base64u/package.json
@@ -15,10 +15,9 @@
   "homepage": "https://github.com/orbiting/backends#readme",
   "devDependencies": {
     "abab": "^2.0.0",
-    "faucet": "^0.0.1",
     "tape": "^4.9.0"
   },
   "scripts": {
-    "test": "NODE_ENV=development tape \"**/*.test.js\" | faucet"
+    "test": "NODE_ENV=development tape \"**/*.test.js\""
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6866,6 +6866,10 @@ url@0.10.3:
     punycode "1.3.2"
     querystring "0.2.0"
 
+urlsafe-base64@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz#23f89069a6c62f46cf3a1d3b00169cefb90be0c6"
+
 use@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/use/-/use-2.0.2.tgz#ae28a0d72f93bf22422a18a2e379993112dec8e8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,6 +252,10 @@
     "@types/events" "*"
     "@types/node" "*"
 
+abab@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1634,6 +1638,10 @@ deep-diff@^0.3.8:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
 
+deep-equal@~0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.1.2.tgz#b246c2b80a570a47c11be1d9bd1070ec878b87ce"
+
 deep-equal@~0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.2.2.tgz#84b745896f34c684e98f2ce0e42abaf43bba017d"
@@ -1678,6 +1686,10 @@ define-property@^1.0.0:
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
   dependencies:
     is-descriptor "^1.0.0"
+
+defined@0.0.0, defined@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-0.0.0.tgz#f35eea7d705e933baf13b2f03b3f83d921403b3e"
 
 defined@~1.0.0:
   version "1.0.0"
@@ -2347,6 +2359,18 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+faucet@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/faucet/-/faucet-0.0.1.tgz#597dcf1d2189a2c062321b591e8f151ed2039d9c"
+  dependencies:
+    defined "0.0.0"
+    duplexer "~0.1.1"
+    minimist "0.0.5"
+    sprintf "~0.1.3"
+    tap-parser "~0.4.0"
+    tape "~2.3.2"
+    through2 "~0.2.3"
+
 fault@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.1.tgz#de8d350dfd48be24b5dc1b02867e0871b9135092"
@@ -2643,7 +2667,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1, function-bind@~1.1.0:
+function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1, function-bind@~1.1.0, function-bind@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -3590,6 +3614,10 @@ is-word-character@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.1.tgz#5a03fa1ea91ace8a6eb0c7cd770eb86d65c8befb"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -4355,6 +4383,10 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -4646,9 +4678,17 @@ object-inspect@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"
 
+object-inspect@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
+
 object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-keys@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -5465,6 +5505,15 @@ readable-stream@^2.0.0, readable-stream@^2.3.5:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@~1.1.11, readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -5734,7 +5783,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.1.6, resolve@^1.1.7:
+resolve@^1.1.6, resolve@^1.1.7, resolve@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
@@ -6152,6 +6201,10 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
+sprintf@~0.1.3:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/sprintf/-/sprintf-0.1.5.tgz#8f83e39a9317c1a502cb7db8050e51c679f6edcf"
+
 ssh2-streams@~0.1.15:
   version "0.1.20"
   resolved "https://registry.yarnpkg.com/ssh2-streams/-/ssh2-streams-0.1.20.tgz#51118d154555df5469ee1f67e0cf1e7e8a2c0e3a"
@@ -6272,6 +6325,10 @@ string.prototype.trim@~1.1.2:
     define-properties "^1.1.2"
     es-abstract "^1.5.0"
     function-bind "^1.0.2"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.0.3:
   version "1.0.3"
@@ -6451,6 +6508,13 @@ tap-parser@^1.2.2:
   optionalDependencies:
     readable-stream "^2"
 
+tap-parser@~0.4.0:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-0.4.3.tgz#a4eae190c10d76c7a111921ff38bbe4d58f09eea"
+  dependencies:
+    inherits "~2.0.1"
+    readable-stream "~1.1.11"
+
 tape-async@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tape-async/-/tape-async-2.3.0.tgz#1759c72e6d53ac5d8e5b8598272818acc54a887d"
@@ -6477,6 +6541,35 @@ tape@^4.5.0:
     resumer "~0.0.0"
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
+
+tape@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-4.9.0.tgz#855c08360395133709d34d3fbf9ef341eb73ca6a"
+  dependencies:
+    deep-equal "~1.0.1"
+    defined "~1.0.0"
+    for-each "~0.3.2"
+    function-bind "~1.1.1"
+    glob "~7.1.2"
+    has "~1.0.1"
+    inherits "~2.0.3"
+    minimist "~1.2.0"
+    object-inspect "~1.5.0"
+    resolve "~1.5.0"
+    resumer "~0.0.0"
+    string.prototype.trim "~1.1.2"
+    through "~2.3.8"
+
+tape@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-2.3.3.tgz#2e7ce0a31df09f8d6851664a71842e0ca5057af7"
+  dependencies:
+    deep-equal "~0.1.0"
+    defined "~0.0.0"
+    inherits "~2.0.1"
+    jsonify "~0.0.0"
+    resumer "~0.0.0"
+    through "~2.3.4"
 
 tar-fs@^1.13.0:
   version "1.16.0"
@@ -6551,6 +6644,13 @@ through2@^2.0.0:
   dependencies:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
+
+through2@~0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.2.3.tgz#eb3284da4ea311b6cc8ace3653748a52abf25a3f"
+  dependencies:
+    readable-stream "~1.1.9"
+    xtend "~2.1.1"
 
 through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
@@ -7117,6 +7217,12 @@ xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+xtend@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
+  dependencies:
+    object-keys "~0.4.0"
 
 yallist@^2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,10 +1638,6 @@ deep-diff@^0.3.8:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
 
-deep-equal@~0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.1.2.tgz#b246c2b80a570a47c11be1d9bd1070ec878b87ce"
-
 deep-equal@~0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.2.2.tgz#84b745896f34c684e98f2ce0e42abaf43bba017d"
@@ -1686,10 +1682,6 @@ define-property@^1.0.0:
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
   dependencies:
     is-descriptor "^1.0.0"
-
-defined@0.0.0, defined@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/defined/-/defined-0.0.0.tgz#f35eea7d705e933baf13b2f03b3f83d921403b3e"
 
 defined@~1.0.0:
   version "1.0.0"
@@ -2358,18 +2350,6 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-
-faucet@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/faucet/-/faucet-0.0.1.tgz#597dcf1d2189a2c062321b591e8f151ed2039d9c"
-  dependencies:
-    defined "0.0.0"
-    duplexer "~0.1.1"
-    minimist "0.0.5"
-    sprintf "~0.1.3"
-    tap-parser "~0.4.0"
-    tape "~2.3.2"
-    through2 "~0.2.3"
 
 fault@^1.0.1:
   version "1.0.1"
@@ -3614,10 +3594,6 @@ is-word-character@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.1.tgz#5a03fa1ea91ace8a6eb0c7cd770eb86d65c8befb"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -4383,10 +4359,6 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
-
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -4685,10 +4657,6 @@ object-inspect@~1.5.0:
 object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
-
-object-keys@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -5505,15 +5473,6 @@ readable-stream@^2.0.0, readable-stream@^2.3.5:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@~1.1.11, readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -6201,10 +6160,6 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sprintf@~0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/sprintf/-/sprintf-0.1.5.tgz#8f83e39a9317c1a502cb7db8050e51c679f6edcf"
-
 ssh2-streams@~0.1.15:
   version "0.1.20"
   resolved "https://registry.yarnpkg.com/ssh2-streams/-/ssh2-streams-0.1.20.tgz#51118d154555df5469ee1f67e0cf1e7e8a2c0e3a"
@@ -6325,10 +6280,6 @@ string.prototype.trim@~1.1.2:
     define-properties "^1.1.2"
     es-abstract "^1.5.0"
     function-bind "^1.0.2"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.0.3:
   version "1.0.3"
@@ -6508,13 +6459,6 @@ tap-parser@^1.2.2:
   optionalDependencies:
     readable-stream "^2"
 
-tap-parser@~0.4.0:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-0.4.3.tgz#a4eae190c10d76c7a111921ff38bbe4d58f09eea"
-  dependencies:
-    inherits "~2.0.1"
-    readable-stream "~1.1.11"
-
 tape-async@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tape-async/-/tape-async-2.3.0.tgz#1759c72e6d53ac5d8e5b8598272818acc54a887d"
@@ -6559,17 +6503,6 @@ tape@^4.9.0:
     resumer "~0.0.0"
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
-
-tape@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-2.3.3.tgz#2e7ce0a31df09f8d6851664a71842e0ca5057af7"
-  dependencies:
-    deep-equal "~0.1.0"
-    defined "~0.0.0"
-    inherits "~2.0.1"
-    jsonify "~0.0.0"
-    resumer "~0.0.0"
-    through "~2.3.4"
 
 tar-fs@^1.13.0:
   version "1.16.0"
@@ -6644,13 +6577,6 @@ through2@^2.0.0:
   dependencies:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
-
-through2@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-0.2.3.tgz#eb3284da4ea311b6cc8ace3653748a52abf25a3f"
-  dependencies:
-    readable-stream "~1.1.9"
-    xtend "~2.1.1"
 
 through@2, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
@@ -7213,12 +7139,6 @@ xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-
-xtend@~2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
-  dependencies:
-    object-keys "~0.4.0"
 
 yallist@^2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6966,10 +6966,6 @@ url@0.10.3:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urlsafe-base64@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz#23f89069a6c62f46cf3a1d3b00169cefb90be0c6"
-
 use@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/use/-/use-2.0.2.tgz#ae28a0d72f93bf22422a18a2e379993112dec8e8"


### PR DESCRIPTION
Ensures `email` query parameter in verification URL is encoded as base64 in an url-safe manner and ensures `emailFromQuery` in `Session::sessionByToken()` is a plain string.

URLs containin `email=<email>` or `email=<urlencoded email>` instead of `email=<base64-encoded email>` let to double-encoding conflicts in some email clients, and resulted in URLs being invalid:

`heidi@wiese.tld` is encoded to `heidi%40wiese.tld` (`@` => `%40`). Some email clients would re-encode and generate a link with `heidi%2540wiese.tld` (`%` => `%25`).

⚠️ This is a breaking change and requires https://github.com/orbiting/republik-frontend/pull/101 ~to be merged an deployed first.~ Deployed.

Introduces [urlsafe-base64](https://www.npmjs.com/package/urlsafe-base64) as a dependency.