### PR TITLE
fix(auth): Remove email base64 decoding

### DIFF
--- a/packages/auth/lib/Sessions.js
+++ b/packages/auth/lib/Sessions.js
@@ -1,5 +1,4 @@
 const { NoSessionError, QueryEmailMismatchError, DestroySessionError } = require('./errors')
-const { decode, match } = require('@orbiting/backend-modules-base64u')
 
 const destroySession = async (req) => {
   return new Promise((resolve, reject) => {
@@ -17,11 +16,6 @@ const sessionByToken = async ({ pgdb, token, email: emailFromQuery, ...meta }) =
   const session = await Sessions.findOne({
     'sess @>': { token }
   })
-
-  // Recognize and decode urlsafe base64 encoded email address.
-  if (match(emailFromQuery)) {
-    emailFromQuery = decode(emailFromQuery)
-  }
 
   if (!session) {
     throw new NoSessionError({ token, emailFromQuery, ...meta })


### PR DESCRIPTION
This Merge Requets reverts "fail safe" about having a decoded `emailFromQuery` as email value passed is to be expected an email address, not a potentially base64, URL-safe encoded email address.