### PR TITLE
fix(Statements): obey correct order of users

### DIFF
--- a/servers/republik/graphql/resolvers/_queries/statements.js
+++ b/servers/republik/graphql/resolvers/_queries/statements.js
@@ -1,4 +1,5 @@
 const isUUID = require('is-uuid')
+const { ascending } = require('d3-array')
 const {
   transformUser
 } = require('@orbiting/backend-modules-auth')
@@ -48,6 +49,14 @@ module.exports = async (_, args, { pgdb, t }) => {
       WHERE
         ARRAY[u.id] && :ids;
     `, {ids: nodeIds})
+
+    // obey order!
+    // - this ensures firstId comes first
+    // - and that the random order isn't overwritten by the db internal order
+    users.sort((a, b) => ascending(
+      nodeIds.indexOf(a.id),
+      nodeIds.indexOf(b.id)
+    ))
 
     const endId = nodeIds[nodeIds.length - 1]
     const startId = nodeIds[0]


### PR DESCRIPTION
before the `focus` (internally called `firstId`) came in a random spot
<img width="1101" alt="screen shot 2018-05-23 at 11 51 22" src="https://user-images.githubusercontent.com/410211/40417282-adaedede-5e7f-11e8-8f6e-65df5c3b10e5.png">

afterwards it is guaranteed that it comes first
<img width="1101" alt="screen shot 2018-05-23 at 11 51 35" src="https://user-images.githubusercontent.com/410211/40417299-ba39e48c-5e7f-11e8-8e1c-8bf8db372f0f.png">
