### PR TITLE
split basic auth config in assets package

### DIFF
--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -24,7 +24,7 @@ Check [assets-backend](https://github.com/orbiting/assets-backend) for a deploya
 
   renders :url with a viewport of :width x :hight to a png. webp conversion not supported.
 
-  ENVs: `PHANTOMJSCLOUD_API_KEY`, `RENDER_URL_WHITELIST`: comma separated, accept: :url.indexOf(whiteUrl) === 0, `BASIC_AUTH_USER`, `BASIC_AUTH_PASS`
+  ENVs: `PHANTOMJSCLOUD_API_KEY`, `RENDER_URL_WHITELIST`: comma separated, accept: :url.indexOf(whiteUrl) === 0, `FRONTEND_BASIC_AUTH_USER`, `FRONTEND_BASIC_AUTH_PASS`
 
 - `/s3/:bucket/:path*(.webp)`
 
@@ -36,7 +36,7 @@ Check [assets-backend](https://github.com/orbiting/assets-backend) for a deploya
 
   fetches :path from `FRONTEND_BASE_URL`
 
-  ENVs: `FRONTEND_BASE_URL`, `BASIC_AUTH_USER`, `BASIC_AUTH_PASS`
+  ENVs: `FRONTEND_BASE_URL`, `FRONTEND_BASIC_AUTH_USER`, `FRONTEND_BASIC_AUTH_PASS`
 
 - `/pdf/:path*`
 

--- a/packages/assets/express/frontend.js
+++ b/packages/assets/express/frontend.js
@@ -2,8 +2,8 @@ const fetch = require('isomorphic-unfetch')
 const { returnImage } = require('../lib')
 const {
   FRONTEND_BASE_URL,
-  BASIC_AUTH_USER,
-  BASIC_AUTH_PASS
+  FRONTEND_BASIC_AUTH_USER,
+  FRONTEND_BASIC_AUTH_PASS
 } = process.env
 
 if (!FRONTEND_BASE_URL) {
@@ -28,8 +28,8 @@ module.exports = (server) => {
     const result = await fetch(frontendUrl, {
       method: 'GET',
       headers: {
-        Authorization: BASIC_AUTH_USER && BASIC_AUTH_PASS
-          ? `Basic ${Buffer.from(`${BASIC_AUTH_USER}:${BASIC_AUTH_PASS}`).toString('base64')}`
+        Authorization: FRONTEND_BASIC_AUTH_USER && FRONTEND_BASIC_AUTH_PASS
+          ? `Basic ${Buffer.from(`${FRONTEND_BASIC_AUTH_USER}:${FRONTEND_BASIC_AUTH_PASS}`).toString('base64')}`
           : undefined
       }
     })

--- a/packages/assets/lib/renderUrl.js
+++ b/packages/assets/lib/renderUrl.js
@@ -1,8 +1,8 @@
 const fetch = require('isomorphic-unfetch')
 const {
   PHANTOMJSCLOUD_API_KEY,
-  BASIC_AUTH_USER,
-  BASIC_AUTH_PASS,
+  FRONTEND_BASIC_AUTH_USER,
+  FRONTEND_BASIC_AUTH_PASS,
   PHANTOM_COOKIE
 } = process.env
 
@@ -39,10 +39,10 @@ module.exports = async (url, width, height, zoomFactor) => {
       'cookie': PHANTOM_COOKIE
     }
   }
-  if (BASIC_AUTH_USER) {
+  if (FRONTEND_BASIC_AUTH_USER) {
     body.requestSettings.authentication = {
-      userName: BASIC_AUTH_USER,
-      password: BASIC_AUTH_PASS
+      userName: FRONTEND_BASIC_AUTH_USER,
+      password: FRONTEND_BASIC_AUTH_PASS
     }
   }
 

--- a/servers/assets/.env.example
+++ b/servers/assets/.env.example
@@ -6,12 +6,14 @@ PORT=5020
 #############
 
 # activate basic auth on this API and
-# send basic auth to frontend (for /render and /frontend, leaks to phantomjscloud)
 #BASIC_AUTH_USER=
 #BASIC_AUTH_PASS=
 # optional:
 #BASIC_AUTH_REALM=
 
+# send basic auth to frontend (for /render and /frontend, leaks to phantomjscloud)
+#FRONTEND_BASIC_AUTH_USER=
+#FRONTEND_BASIC_AUTH_PASS=
 
 #############
 # cluster

--- a/servers/assets/server.js
+++ b/servers/assets/server.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const cors = require('cors')
 const { express: middlewares } = require('@orbiting/backend-modules-assets')
-const { express: { basicAuth: basicAuthMiddleware } } = require('@orbiting/backend-modules-auth')
+const basicAuthMiddleware = require('@orbiting/backend-modules-auth/express/basicAuth')
 
 const DEV = process.env.NODE_ENV && process.env.NODE_ENV !== 'production'
 


### PR DESCRIPTION
set BASIC_AUTH_USER, BASIC_AUTH_PASS to secure the api itself.
set FRONTEND_BASIC_AUTH_USER, FRONTEND_BASIC_AUTH_PASS to authenticate to the frontend (/render, /frontend)