### PR TITLE
fix(mail): Query with lower-cased, hashed email address

### DIFF
--- a/packages/mail/MailchimpInterface.js
+++ b/packages/mail/MailchimpInterface.js
@@ -26,7 +26,6 @@ const MailchimpInterface = ({ logger }) => {
         .createHash('md5')
         .update(email.toLowerCase())
         .digest('hex')
-        .toLowerCase()
 
       return this.buildApiUrl(`/members/${hash}`)
     },

--- a/packages/mail/MailchimpInterface.js
+++ b/packages/mail/MailchimpInterface.js
@@ -24,7 +24,7 @@ const MailchimpInterface = ({ logger }) => {
     buildMembersApiUrl (email) {
       const hash = crypto
         .createHash('md5')
-        .update(email)
+        .update(email.toLowerCase())
         .digest('hex')
         .toLowerCase()
 


### PR DESCRIPTION
MailChimp stores, however added, email addresses all lower-cased. This Pull Request makes sure `MailchimpInterface` is querying MailChimp API with a MD5-hashed, _lower-cased_ email address.

It fixes a bug in which we did query API with a case-sensitive email address and did not receive any results.