### PR TITLE
Fix: Sending preview email did not work

### DIFF
--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -120,7 +120,7 @@ const createShould = function (
 
     const filter = _.mergeWith(
       {},
-      search.filter,
+      search.filter.default(searchFilter),
       createElasticFilter(searchFilter),
       rolebasedFilter,
       deepMergeArrays

--- a/packages/search/lib/indices/comments.js
+++ b/packages/search/lib/indices/comments.js
@@ -19,18 +19,20 @@ module.exports = {
       'resolved.user.facebookId': {}
     },
     filter: {
-      bool: {
-        must: [
-          { term: { __type: type } },
-          { term: { published: true } },
-          { term: { adminUnpublished: false } }
-        ],
-        must_not: [
-          { terms: { discussionId: [
-            '3c625fe4-788f-44d5-ad5e-ac93bd9a6292' // Crowdfunding discussions
-          ] } }
-        ]
-      }
+      default: () => ({
+        bool: {
+          must: [
+            { term: { __type: type } },
+            { term: { published: true } },
+            { term: { adminUnpublished: false } }
+          ],
+          must_not: [
+            { terms: { discussionId: [
+              '3c625fe4-788f-44d5-ad5e-ac93bd9a6292' // Crowdfunding discussions
+            ] } }
+          ]
+        }
+      })
     }
   },
   mapping: {

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -61,22 +61,24 @@ module.exports = {
       'resolved.meta.format.meta.description': {}
     },
     filter: {
-      bool: {
-        must: [
-          { term: { __type: type } }
-        ],
-        // return all editorialNewsletters with feed:true or everything
-        // that is not editorialNewsletters. Brainfuck.
-        should: [
-          { bool: { must: [
-            { term: { 'meta.template': 'editorialNewsletter' } },
-            { term: { 'meta.feed': true } }
-          ] } },
-          { bool: { must_not: [
-            { term: { 'meta.template': 'editorialNewsletter' } }
-          ] } }
-        ]
-      }
+      default: () => ({
+        bool: {
+          must: [
+            { term: { __type: type } }
+          ],
+          // return all editorialNewsletters with feed:true or everything
+          // that is not editorialNewsletters. Brainfuck.
+          should: [
+            { bool: { must: [
+              { term: { 'meta.template': 'editorialNewsletter' } },
+              { term: { 'meta.feed': true } }
+            ] } },
+            { bool: { must_not: [
+              { term: { 'meta.template': 'editorialNewsletter' } }
+            ] } }
+          ]
+        }
+      })
     },
     rolebasedFilter: {
       // Default filter

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -26,6 +26,8 @@ const mdastPartial = {
 
 const type = 'Document'
 
+const { PREVIEW_MAIL_REPO_ID } = process.env
+
 module.exports = {
   type,
   name: type.toLowerCase(),
@@ -61,24 +63,33 @@ module.exports = {
       'resolved.meta.format.meta.description': {}
     },
     filter: {
-      default: () => ({
-        bool: {
-          must: [
-            { term: { __type: type } }
-          ],
-          // return all editorialNewsletters with feed:true or everything
-          // that is not editorialNewsletters. Brainfuck.
-          should: [
-            { bool: { must: [
-              { term: { 'meta.template': 'editorialNewsletter' } },
-              { term: { 'meta.feed': true } }
-            ] } },
-            { bool: { must_not: [
-              { term: { 'meta.template': 'editorialNewsletter' } }
-            ] } }
-          ]
+      default: () => {
+        const filter = {
+          bool: {
+            must: [
+              { term: { __type: type } }
+            ],
+            // return all editorialNewsletters with feed:true or everything
+            // that is not editorialNewsletters. Brainfuck.
+            should: [
+              { bool: { must: [
+                { term: { 'meta.template': 'editorialNewsletter' } },
+                { term: { 'meta.feed': true } }
+              ] } },
+              { bool: { must_not: [
+                { term: { 'meta.template': 'editorialNewsletter' } }
+              ] } }
+            ]
+          }
         }
-      })
+
+        if (PREVIEW_MAIL_REPO_ID) {
+          // Allow repo w/ preview email to be retrieved nomatter other filter
+          filter.bool.should.push({ bool: { must: [
+            { term: { 'meta.repoId': PREVIEW_MAIL_REPO_ID } }
+          ] } })
+        }
+      }
     },
     rolebasedFilter: {
       // Default filter

--- a/packages/search/lib/indices/users.js
+++ b/packages/search/lib/indices/users.js
@@ -33,13 +33,15 @@ module.exports = {
       'resolved.credential': {}
     },
     filter: {
-      bool: {
-        must: [
-          { term: { __type: type } },
-          { term: { hasPublicProfile: true } },
-          { term: { verified: true } }
-        ]
-      }
+      default: () => ({
+        bool: {
+          must: [
+            { term: { __type: type } },
+            { term: { hasPublicProfile: true } },
+            { term: { verified: true } }
+          ]
+        }
+      })
     }
   },
   mapping: {

--- a/servers/republik/graphql/resolvers/_mutations/requestPreview.js
+++ b/servers/republik/graphql/resolvers/_mutations/requestPreview.js
@@ -5,6 +5,7 @@ const { lib: { html: { get: getHTML } } } = require('@orbiting/backend-modules-d
 const { descending } = require('d3-array')
 const moment = require('moment')
 const querystring = require('querystring')
+const debug = require('debug')('republik:graphql:_mutations:requestPreview')
 
 const {
   DEFAULT_MAIL_FROM_ADDRESS,
@@ -28,6 +29,8 @@ module.exports = async (_, args, context) => {
     }
   }
 
+  debug('PREVIEW_MAIL_REPO_ID', { PREVIEW_MAIL_REPO_ID })
+
   if (!PREVIEW_MAIL_REPO_ID) {
     throw new Error('api/preview/mail/404')
   }
@@ -36,9 +39,13 @@ module.exports = async (_, args, context) => {
     { repoId: PREVIEW_MAIL_REPO_ID },
     context
   )
+
+  debug('doc', { PREVIEW_MAIL_REPO_ID, found: !!doc.length })
+
   if (!doc) {
     throw new Error(t('api/preview/mail/404'))
   }
+
   // resolve Document
   const docResolverArgs = {
     urlPrefix: FRONTEND_BASE_URL,


### PR DESCRIPTION
A preview newsletter is a `Document` in ElasticSearch, having `meta.template:editorialNewsletter` set but not in feed (`meta.feed:false`). Default search query does not return newsletters.

`getDocument` can't, and should neither be allowed, to retrieve preview email via `repoId`.

This Pull Request changes [Document filter query to allow returning preview newsletter](dd56238), set in environment variable `PREVIEW_MAIL_REPO_ID`.

It does [functionalize `filters`](51fec56) (like `rolebasedFilter` is already)

