### PR TITLE
Value-Added-Tax for package options

### DIFF
--- a/servers/republik/migrations/20180703153921-package-options-vat.js
+++ b/servers/republik/migrations/20180703153921-package-options-vat.js
@@ -1,0 +1,47 @@
+'use strict'
+
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20180703153921-package-options-vat-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20180703153921-package-options-vat-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  'version': 1
+}

--- a/servers/republik/migrations/sqls/20180703153921-package-options-vat-down.sql
+++ b/servers/republik/migrations/sqls/20180703153921-package-options-vat-down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pledgeOptions" DROP COLUMN IF EXISTS "vat" ;
+ALTER TABLE "packageOptions" DROP COLUMN IF EXISTS "vat" ;

--- a/servers/republik/migrations/sqls/20180703153921-package-options-vat-up.sql
+++ b/servers/republik/migrations/sqls/20180703153921-package-options-vat-up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "packageOptions" ADD COLUMN "vat" integer DEFAULT 0 ;
+ALTER TABLE "pledgeOptions" ADD COLUMN "vat" integer DEFAULT 0 ;

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/Pledge.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/Pledge.js
@@ -12,6 +12,7 @@ module.exports = {
       pko.amount = plo.amount
       pko.templateId = plo.templateId
       pko.price = plo.price
+      pko.vat = plo.vat
       pko.createdAt = plo.createdAt
       pko.updatedAt = plo.updatedAt
       return pko

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/generateMembership.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/generateMembership.js
@@ -43,6 +43,7 @@ module.exports = async (_, { userId }, { pgdb, req, t, user: me, mail: { enforce
       pledgeId: pledge.id,
       amount: 1,
       price: total,
+      vat: pkgOption.vat,
       createdAt: now,
       updatedAt: now
     })

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/submitPledge.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/submitPledge.js
@@ -185,6 +185,8 @@ module.exports = async (_, args, {pgdb, req, t}) => {
     // insert pledgeOptions
     const newPledgeOptions = await Promise.all(pledge.options.map((plo) => {
       plo.pledgeId = newPledge.id
+      const pko = packageOptions.find((pko) => pko.id === plo.templateId)
+      plo.vat = pko.vat
       return transaction.public.pledgeOptions.insertAndGet(plo)
     }))
     newPledge.packageOptions = newPledgeOptions

--- a/servers/republik/modules/crowdfundings/graphql/schema-types.js
+++ b/servers/republik/modules/crowdfundings/graphql/schema-types.js
@@ -57,6 +57,7 @@ type PackageOption {
   maxAmount: Int
   defaultAmount: Int!
   price: Int!
+  vat: Int!
   minUserPrice: Int!
   userPrice: Boolean!
   createdAt: DateTime!


### PR DESCRIPTION
This Pull Request adds a `vat` attribute to `packageOptions` table. It's value is an integer. 100 would represent 1%. Default value is 0.

When creating a pledge and it's options, VAT value of package option is copied into `vat` attribute in `pledgeOptions` table.

It further exposes VAT value in GraphQL `PackageOption` type.

This enables to create invoices (upcoming changes), taking VAT into account.

A migration for existing pledge options is run manually.