### PR TITLE
fix(search): Expect n * 2 related documents

### DIFF
--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -268,7 +268,7 @@ const addRelatedDocs = async ({ connection, scheduledAt, context }) => {
       recursive: true,
       withoutContent: true,
       scheduledAt,
-      first: seriesRepoIds.length,
+      first: seriesRepoIds.length * 2,
       filter: {
         repoId: seriesRepoIds,
         type: 'Document'

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -294,7 +294,7 @@ const addRelatedDocs = async ({ connection, scheduledAt, context }) => {
       recursive: true,
       withoutContent: true,
       scheduledAt,
-      first: sanitizedRepoIds.length,
+      first: sanitizedRepoIds.length * 2,
       filter: {
         repoId: sanitizedRepoIds,
         type: 'Document'


### PR DESCRIPTION
An article may have one published document and a scheduled document.
Query is build in a manner that can not "distinct" that at the moment.

As an example: We query database for max 9 documents (ES `size` parameter) as we are looking up 9 repositories. A fair but wrong assumption. 1 repository may however return up to 2 documents. This fix multiplies expected result by 2, so we'd expect up to 18 documents for 9 repositories.