### PR TITLE
fix(search): Invalidate cache when scheduling a document to publish

### DIFF
--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -401,7 +401,7 @@ const search = async (__, args, context, info) => {
   let cacheHIT = !!result
   if (!result) {
     result = await elastic.search(query)
-    await cache.set(query, result)
+    await cache.set(query, result, options)
   }
 
   const hasNextPage = first > 0 && result.hits.total > from + first

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -514,6 +514,8 @@ const publishScheduled = (elastic, redis, elasticDoc) => ({
       elasticDoc.meta.repoId,
       elasticDoc.id
     )
+
+    await createCache(redis).invalidate()
   },
   afterScheduled: async () => {
     await elastic.update({
@@ -567,6 +569,8 @@ const prepublishScheduled = (elastic, redis, elasticDoc) => ({
       elasticDoc.meta.repoId,
       elasticDoc.id
     )
+
+    await createCache(redis).invalidate()
   },
   afterScheduled: async () => {
     await elastic.update({

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -514,8 +514,6 @@ const publishScheduled = (elastic, redis, elasticDoc) => ({
       elasticDoc.meta.repoId,
       elasticDoc.id
     )
-
-    await createCache(redis).invalidate()
   },
   afterScheduled: async () => {
     await elastic.update({
@@ -569,8 +567,6 @@ const prepublishScheduled = (elastic, redis, elasticDoc) => ({
       elasticDoc.meta.repoId,
       elasticDoc.id
     )
-
-    await createCache(redis).invalidate()
   },
   afterScheduled: async () => {
     await elastic.update({

--- a/packages/search/lib/cache.js
+++ b/packages/search/lib/cache.js
@@ -23,8 +23,9 @@ const createGet = (redis) => async (query) => {
     : payload
 }
 
-const isEligible = (query) => {
+const isEligible = (query, options) => {
   if (
+    !options.scheduledAt &&
     query.index &&
     query.index.length === 1 &&
     query.index[0] === getIndexAlias('document', 'read')
@@ -34,8 +35,8 @@ const isEligible = (query) => {
   return false
 }
 
-const createSet = (redis) => async (query, payload) => {
-  if (isEligible(query)) {
+const createSet = (redis) => async (query, payload, options = {}) => {
+  if (isEligible(query, options)) {
     let payloadString
     try {
       payloadString = JSON.stringify(payload)


### PR DESCRIPTION
Cache should also be invalidated when a document is scheduled to publish. So far cache got only invalidated when a document's status was supposed to change it's `__state` to published, prepublished.