### PR TITLE
fix(newsletter): bump styleguide, skip empty covers

### DIFF
--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -23,7 +23,7 @@
     "isomorphic-unfetch": "^2.0.0"
   },
   "dependencies": {
-    "@project-r/styleguide": "^5.81.1",
+    "@project-r/styleguide": "^5.81.7",
     "@project-r/template-newsletter": "^1.5.0",
     "apollo-modules-node": "^0.1.4",
     "check-env": "^1.3.0",

--- a/servers/republik/package.json
+++ b/servers/republik/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "license": "AGPL-3.0",
   "dependencies": {
-    "@project-r/styleguide": "^5.81.1",
+    "@project-r/styleguide": "^5.81.7",
     "@slack/client": "^4.2.2",
     "apollo-modules-node": "^0.1.4",
     "d3-array": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,9 +41,9 @@
     stringify-entities "^1.3.1"
     unified "^6.1.5"
 
-"@project-r/styleguide@^5.81.1":
-  version "5.81.1"
-  resolved "https://registry.yarnpkg.com/@project-r/styleguide/-/styleguide-5.81.1.tgz#20bd65b9574d9e14c9f6efbd09a626d4715cb938"
+"@project-r/styleguide@^5.81.7":
+  version "5.81.7"
+  resolved "https://registry.yarnpkg.com/@project-r/styleguide/-/styleguide-5.81.7.tgz#095d81debd1245973c407c59f74c9f282bfb41d9"
   dependencies:
     react-icons "^2.2.7"
 


### PR DESCRIPTION
Styleguide Bump for: https://github.com/orbiting/styleguide/pull/148

Fixes this:
<img width="803" alt="screen shot 2018-07-12 at 12 14 34" src="https://user-images.githubusercontent.com/410211/42628720-4686b9c4-85d1-11e8-920a-07a4a044e32d.png">

@patrickvenetz is `republik-publikator-api` deploy-able? Is it ok if I push this out?