### PR TITLE
feat(republik): Add invoice related fields to companies

### DIFF
--- a/servers/republik/migrations/20180717161308-company-details.js
+++ b/servers/republik/migrations/20180717161308-company-details.js
@@ -1,0 +1,47 @@
+'use strict'
+
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20180717161308-company-details-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20180717161308-company-details-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  'version': 1
+}

--- a/servers/republik/migrations/sqls/20180717161308-company-details-down.sql
+++ b/servers/republik/migrations/sqls/20180717161308-company-details-down.sql
@@ -1,4 +1,5 @@
 ALTER TABLE "companies"
   DROP COLUMN IF EXISTS "invoiceAddress",
   DROP COLUMN IF EXISTS "invoiceVatin",
-  DROP COLUMN IF EXISTS "invoiceBankdetails";
+  DROP COLUMN IF EXISTS "invoiceBankdetails",
+  DROP COLUMN IF EXISTS "invoiceNumPrefix";

--- a/servers/republik/migrations/sqls/20180717161308-company-details-down.sql
+++ b/servers/republik/migrations/sqls/20180717161308-company-details-down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "companies"
+  DROP COLUMN IF EXISTS "invoiceAddress",
+  DROP COLUMN IF EXISTS "invoiceVatin",
+  DROP COLUMN IF EXISTS "invoiceBankdetails";

--- a/servers/republik/migrations/sqls/20180717161308-company-details-up.sql
+++ b/servers/republik/migrations/sqls/20180717161308-company-details-up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "companies"
+  ADD COLUMN "invoiceAddress" text,
+  ADD COLUMN "invoiceVatin" text,
+  ADD COLUMN "invoiceBankdetails" text;

--- a/servers/republik/migrations/sqls/20180717161308-company-details-up.sql
+++ b/servers/republik/migrations/sqls/20180717161308-company-details-up.sql
@@ -1,4 +1,5 @@
 ALTER TABLE "companies"
   ADD COLUMN "invoiceAddress" text,
   ADD COLUMN "invoiceVatin" text,
-  ADD COLUMN "invoiceBankdetails" text;
+  ADD COLUMN "invoiceBankdetails" text,
+  ADD COLUMN "invoiceNumPrefix" text;


### PR DESCRIPTION
This Pull Request is a mini-migration. It adds free-text fields required to generate invoices:
- An (invoice sender) address
- A VAT Identification Number
- Bank details (e.g. IBAN)
- An invoice numbering prefix (e.g. `FOO-123123`)

When generating invoices, data if these files is copied to in to (immutable) invoice tables. While this company invoice information may be stored in translation files, putting attaching them to `companies` in database seemed more strict.