### PR TITLE
feat(search): Create search tracking index per day

### DIFF
--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -30,7 +30,7 @@ const _ = require('lodash')
 const uuid = require('uuid/v4')
 
 const indices = require('../../../lib/indices')
-const { getIndexAlias, getDatedIndex } = require('../../../lib/utils')
+const { getIndexAlias, getDateIndex } = require('../../../lib/utils')
 
 const reduceFilters = filterReducer(documentSchema)
 const createElasticFilter = elasticFilterBuilder(documentSchema)
@@ -460,7 +460,7 @@ const search = async (__, args, context, info) => {
         : []
 
       await elastic.index({
-        index: getDatedIndex('searches'),
+        index: getDateIndex('searches'),
         type: 'Search',
         body: {
           date: new Date(),

--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -30,7 +30,7 @@ const _ = require('lodash')
 const uuid = require('uuid/v4')
 
 const indices = require('../../../lib/indices')
-const { getIndexAlias } = require('../../../lib/utils')
+const { getIndexAlias, getDatedIndex } = require('../../../lib/utils')
 
 const reduceFilters = filterReducer(documentSchema)
 const createElasticFilter = elasticFilterBuilder(documentSchema)
@@ -447,6 +447,7 @@ const search = async (__, args, context, info) => {
       const total = result.hits.total
       const hits = result.hits.hits
         .map(hit => _.omit(hit, '_source'))
+      const aggs = result.aggregations
 
       const filters = options.filters
         ? options.filters.map(filter => {
@@ -459,17 +460,19 @@ const search = async (__, args, context, info) => {
         : []
 
       await elastic.index({
-        index: getIndexAlias('searches'),
+        index: getDatedIndex('searches'),
         type: 'Search',
         body: {
+          date: new Date(),
+          trackingId,
+          roles: user.roles,
           took,
           cache: cacheHIT,
           options: Object.assign({}, options, { filters }),
           query,
           total,
           hits,
-          date: new Date(),
-          trackingId
+          aggs
         }
       })
     } catch (err) {

--- a/packages/search/lib/utils.js
+++ b/packages/search/lib/utils.js
@@ -6,8 +6,15 @@ const ES_INDEX_PREFIX = 'republik' // TODO: Put into config
  * @example "2018-05-24-17-05-23"
  * @return {String} [description]
  */
-const sanitizedDate =
+const getDateTime =
   () => new Date().toISOString().slice(0, -5).replace(/[^\d]/g, '-')
+
+/**
+ * @example "2018-05-24"
+ * @return {String} [description]
+ */
+const getDate =
+  () => new Date().toISOString().slice(0, -14).replace(/[^\d]/g, '-')
 
 /**
  * @param  {String} name An index name without prefix
@@ -21,8 +28,15 @@ const getIndexAlias =
  * @param  {String} name An index name without prefix
  * @return {String}      An index name with a date timestamp
  */
-const getIndexDated =
-  (name) => [ES_INDEX_PREFIX, name, sanitizedDate()].filter(Boolean).join('-')
+const getDatetimeIndex =
+  (name) => [ES_INDEX_PREFIX, name, getDateTime()].filter(Boolean).join('-')
+
+/**
+ * @param  {String} name An index name without prefix
+ * @return {String}      An index name with a date
+ */
+const getDatedIndex =
+  (name) => [ES_INDEX_PREFIX, name, getDate()].filter(Boolean).join('-')
 
 /**
  * A filter to remove nodes from an mdast with a predicate. Will remove a node
@@ -54,6 +68,7 @@ const mdastFilter = function (node, predicate = () => false) {
 
 module.exports = {
   getIndexAlias,
-  getIndexDated,
+  getDatetimeIndex,
+  getDatedIndex,
   mdastFilter
 }

--- a/packages/search/lib/utils.js
+++ b/packages/search/lib/utils.js
@@ -28,14 +28,14 @@ const getIndexAlias =
  * @param  {String} name An index name without prefix
  * @return {String}      An index name with a date timestamp
  */
-const getDatetimeIndex =
+const getDateTimeIndex =
   (name) => [ES_INDEX_PREFIX, name, getDateTime()].filter(Boolean).join('-')
 
 /**
  * @param  {String} name An index name without prefix
  * @return {String}      An index name with a date
  */
-const getDatedIndex =
+const getDateIndex =
   (name) => [ES_INDEX_PREFIX, name, getDate()].filter(Boolean).join('-')
 
 /**
@@ -68,7 +68,7 @@ const mdastFilter = function (node, predicate = () => false) {
 
 module.exports = {
   getIndexAlias,
-  getDatetimeIndex,
-  getDatedIndex,
+  getDateTimeIndex,
+  getDateIndex,
   mdastFilter
 }

--- a/packages/search/script/pullElasticsearch.js
+++ b/packages/search/script/pullElasticsearch.js
@@ -8,7 +8,7 @@ const PgDb = require('@orbiting/backend-modules-base/lib/pgdb')
 
 const inserts = require('./inserts')
 const mappings = require('../lib/indices')
-const { getIndexAlias, getDatetimeIndex } = require('../lib/utils')
+const { getIndexAlias, getDateTimeIndex } = require('../lib/utils')
 
 const timeout = ms => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -44,7 +44,7 @@ PgDb.connect().then(async pgdb => {
   await Promise.all(indices.map(async ({ type, name, analysis, mapping }) => {
     const readAlias = getIndexAlias(name, 'read')
     const writeAlias = getIndexAlias(name, 'write')
-    const index = getDatetimeIndex(name)
+    const index = getDateTimeIndex(name)
 
     if (argv.switch) {
       debug('remove write alias', { writeAlias, index })

--- a/packages/search/script/pullElasticsearch.js
+++ b/packages/search/script/pullElasticsearch.js
@@ -8,7 +8,7 @@ const PgDb = require('@orbiting/backend-modules-base/lib/pgdb')
 
 const inserts = require('./inserts')
 const mappings = require('../lib/indices')
-const { getIndexAlias, getIndexDated } = require('../lib/utils')
+const { getIndexAlias, getDatetimeIndex } = require('../lib/utils')
 
 const timeout = ms => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -44,7 +44,7 @@ PgDb.connect().then(async pgdb => {
   await Promise.all(indices.map(async ({ type, name, analysis, mapping }) => {
     const readAlias = getIndexAlias(name, 'read')
     const writeAlias = getIndexAlias(name, 'write')
-    const index = getIndexDated(name)
+    const index = getDatetimeIndex(name)
 
     if (argv.switch) {
       debug('remove write alias', { writeAlias, index })


### PR DESCRIPTION
Creates search tracking indices with this pattern: `republik-searches-<YYYY-mm-dd>`. Data can be aggregated with wildcarded index queries like `republik-searches-*` (or via Kibana index patterns).

This prevents indices to grow too big to handle and allows to remove data over time more easily by removing a date range.

It also adds aggregation results, and user roles. Latter should allow to separate internal traffic from external.