### PR TITLE
feat(republik): Respect anon when posting to slack

### DIFF
--- a/servers/republik/graphql/resolvers/_mutations/discussion/editComment.js
+++ b/servers/republik/graphql/resolvers/_mutations/discussion/editComment.js
@@ -1,13 +1,11 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
 const slack = require('../../../../lib/slack')
 
-module.exports = async (_, args, { pgdb, user, req, t, pubsub }) => {
-  Roles.ensureUserHasRole(user, 'member')
+module.exports = async (_, args, context) => {
+  const { id, content } = args
+  const { pgdb, user, t, pubsub } = context
 
-  const {
-    id,
-    content
-  } = args
+  Roles.ensureUserHasRole(user, 'member')
 
   if (!content || !content.trim().length) {
     throw new Error(t('api/comment/empty'))
@@ -51,7 +49,7 @@ module.exports = async (_, args, { pgdb, user, req, t, pubsub }) => {
       node: newComment
     }})
 
-    await slack.publishCommentUpdate(user, newComment, comment, discussion)
+    await slack.publishCommentUpdate(newComment, comment, discussion, context)
 
     return newComment
   } catch (e) {

--- a/servers/republik/graphql/resolvers/_mutations/discussion/submitComment.js
+++ b/servers/republik/graphql/resolvers/_mutations/discussion/submitComment.js
@@ -103,7 +103,7 @@ module.exports = async (_, args, context) => {
       node: comment
     }})
 
-    slack.publishComment(user, comment, discussion)
+    slack.publishComment(comment, discussion, context)
 
     return comment
   } catch (e) {

--- a/servers/republik/lib/slack.js
+++ b/servers/republik/lib/slack.js
@@ -40,20 +40,20 @@ const getCommentLink = (comment, discussion) => discussion.documentPath
   ? `${FRONTEND_BASE_URL}${discussion.documentPath}?focus=${comment.id}`
   : comment.id
 
-const getProfileLInk = (author) => author.username
+const getProfileLink = (author) => author.username
   ? `<${FRONTEND_BASE_URL}/~${author.username}|${author.name}>`
   : author.name
 
 exports.publishComment = async (comment, discussion, context) => {
   const author = await getDisplayAuthor(comment, {}, context)
-  const content = `:love_letter: *${getProfileLInk(author)}* wrote in <${getCommentLink(comment, discussion)}|${discussion.title}>:\n${comment.content}`
+  const content = `:love_letter: *${getProfileLink(author)}* wrote in <${getCommentLink(comment, discussion)}|${discussion.title}>:\n${comment.content}`
   return publish(SLACK_CHANNEL_COMMENTS, content)
 }
 
 exports.publishCommentUpdate =
   async (comment, oldComment, discussion, context) => {
     const author = await getDisplayAuthor(comment, {}, context)
-    const content = `:pencil2: *${getProfileLInk(author)}* edited in <${getCommentLink(comment, discussion)}|${discussion.title}>:\n*old:*\n${oldComment.content}\n*new:*\n${comment.content}`
+    const content = `:pencil2: *${getProfileLink(author)}* edited in <${getCommentLink(comment, discussion)}|${discussion.title}>:\n*old:*\n${oldComment.content}\n*new:*\n${comment.content}`
     return publish(SLACK_CHANNEL_COMMENTS, content)
   }
 
@@ -62,8 +62,8 @@ exports.publishCommentUnpublish =
     const author = await getDisplayAuthor(comment, {}, context)
 
     const action = update.adminUnpublished
-      ? `:point_up: *${user.name}* unupblished comment by *${getProfileLInk(author)}*`
-      : `:put_litter_in_its_place: *${getProfileLInk(author)}* unpublished`
+      ? `:point_up: *${user.name}* unupblished comment by *${getProfileLink(author)}*`
+      : `:put_litter_in_its_place: *${getProfileLink(author)}* unpublished`
 
     const content = `${action} in <${getCommentLink(comment, discussion)}|${discussion.title}>:\n${comment.content}`
     return publish(SLACK_CHANNEL_COMMENTS, content)


### PR DESCRIPTION
This Pull Request respects current anonymize settings when posting notification about new, edited or unpublished comments to Slack.

Also beautified Slack postings, including links to profiles, discussions and emojis.

- 💌 A new comment
- ✏️ An edited comment
- 🚮 An unpublished comment
- ☝️ A comment unpublished by an admin user

<img width="661" alt="Samples" src="https://user-images.githubusercontent.com/331800/43771578-f95eed32-9a3f-11e8-92e2-2c4856067718.png">
