### PR TITLE
Fix: Add resolved into indexed node

### DIFF
--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('search:lib:Documents')
+const _ = require('lodash')
 
 const {
   termEntry,
@@ -160,12 +161,12 @@ const getElasticDoc = (
     __sort: {
       date: meta.publishDate
     },
-    resolved,
     id,
     commitId,
     versionName,
     milestoneCommitId,
     meta,
+    resolved: !_.isEmpty(resolved) ? resolved : undefined,
     content: doc.content,
     contentString: mdastToString(
       mdastFilter(

--- a/servers/publikator/graphql/resolvers/_mutations/publish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/publish.js
@@ -354,7 +354,8 @@ module.exports = async (
       doc.content.meta.dossier
     )
 
-    resolved.dossier = dossiers.pop()
+    if (!resolved.meta) resolved.meta = {}
+    resolved.meta.dossier = dossiers.pop()
   }
 
   if (doc.content.meta.format) {
@@ -364,7 +365,8 @@ module.exports = async (
       doc.content.meta.format
     )
 
-    resolved.format = formats.pop()
+    if (!resolved.meta) resolved.meta = {}
+    resolved.meta.format = formats.pop()
   }
 
   // publish to elasticsearch

--- a/servers/publikator/script/db-migrate-all.js
+++ b/servers/publikator/script/db-migrate-all.js
@@ -10,6 +10,8 @@ const { dbMigrateAll } = require('@orbiting/backend-modules-scripts')
 const migrationDirs = [
   '../../packages/redirections/migrations',
   '../../packages/auth/migrations',
+  '../republik/migrations/crowdfunding',
+  '../republik/migrations',
   '../../packages/notifications/migrations'
 ]
 

--- a/servers/republik/script/db-migrate-all.js
+++ b/servers/republik/script/db-migrate-all.js
@@ -10,8 +10,8 @@ const { dbMigrateAll } = require('@orbiting/backend-modules-scripts')
 const migrationDirs = [
   '../../packages/redirections/migrations',
   '../../packages/auth/migrations',
-  'migrations/crowdfunding',
-  'migrations',
+  './migrations/crowdfunding',
+  './migrations',
   '../../packages/notifications/migrations'
 ]
 


### PR DESCRIPTION
This Pull Request places resolved meta information into `resolved.meta` instead of `resolved` when a document is published. Latter is not indexed and hence was not queryable.

`resolved` data servers mainly search to retrieve documents if e.g. a format title matches.

__Before, a document__

```
{
  [...]
  "resolved": {
    "format": {
      "meta": {
        "template": "format",
        "repoId": "republik/format-example",
        "description": "",
        "title": "Example Format"
      }
    }
  },
  [...]
}
```

`resolved.format` is not mapped and not indexed. This data is not queryable.

__After, a document__

```
{
  [...]
  "resolved": {
    "meta": {
      "format": {
        "meta": {
          "template": "format",
          "repoId": "republik/format-example",
          "description": "",
          "title": "Example Format"
        }
      }
    }
  },
  [...]
}
```

`resolved.meta.format` is mapped and hence indexed and queryable.

This bug affected publishing procedure but not when pulling data into ElasticSearch at once. If data is pulled into ElasticSearch, `resolved` is added properly.

It also makes sure `resolved` node in a document is only added if not empty.