### PR TITLE
fix(meta): add subject to document meta data

### DIFF
--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -29,6 +29,7 @@ type Meta {
   image: String
   emailSubject: String
   description: String
+  subject: String
   facebookTitle: String
   facebookImage: String
   facebookDescription: String


### PR DESCRIPTION
We need this in Publikator for filling the feuilleton subject (Spitzmarke) when importing teaser content from an article on the feuilleton front. It's analogue to `description` which is used for filling the lead of the teaser.

Publikator already writes it, e.g.
https://github.com/republik-test/article-spitzmarke-ahoi/blob/master/article.md

<img width="667" alt="screen shot 2018-08-23 at 18 14 15" src="https://user-images.githubusercontent.com/23520051/44537974-61f3b400-a700-11e8-953a-8ae4c04a9c91.png">
