### PR TITLE
feat(documents): Expose prepublication prop in a Document

### DIFF
--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -36,6 +36,7 @@ type Meta {
   twitterTitle: String
   twitterImage: String
   twitterDescription: String
+  prepublication: Boolean
   publishDate: DateTime
   template: String
   feed: Boolean


### PR DESCRIPTION
This Pull Request exposes `prepublication` prop in `Document` type which reveals if a document has been pre-published internally.