### PR TITLE
Additions to search, documents query

### DIFF
--- a/packages/documents/graphql/resolvers/Document.js
+++ b/packages/documents/graphql/resolvers/Document.js
@@ -10,6 +10,8 @@ const {
 } = require('../../lib/process')
 const { getMeta } = require('../../lib/meta')
 
+const getDocuments = require('./_queries/documents')
+
 const { lib: { webp: {
   addSuffix: addWebpSuffix
 } } } = require('@orbiting/backend-modules-assets')
@@ -108,5 +110,37 @@ module.exports = {
       totalCount,
       nodes
     }
+  },
+  linkedDocuments (doc, args, context, info) {
+    const hasDossierRepoId =
+      doc.meta.template === 'dossier' &&
+      doc.meta.repoId
+
+    const hasFormatRepoId =
+      doc.meta.template === 'format' &&
+      doc.meta.repoId
+
+    if (!hasDossierRepoId && !hasFormatRepoId) {
+      return {
+        pageInfo: {
+          endCursor: null,
+          startCursor: null,
+          hasNextPage: false,
+          hasPreviousPage: false
+        },
+        totalCount: 0,
+        nodes: []
+      }
+    }
+
+    if (hasDossierRepoId) {
+      args.dossier = doc.id
+    }
+
+    if (hasFormatRepoId) {
+      args.format = doc.id
+    }
+
+    return getDocuments(doc, args, context, info)
   }
 }

--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -52,6 +52,11 @@ type Meta {
   audioSource: AudioSource
 }
 
+input DocumentInput {
+  # AST of /article.md
+  content: JSON!
+}
+
 type Document {
   id: ID!
   # AST of /article.md

--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -52,18 +52,7 @@ type Meta {
   audioSource: AudioSource
 }
 
-# implements FileInterface
-input DocumentInput {
-  # AST of /article.md
-  content: JSON!
-}
-
-interface FileInterface {
-  content: JSON!
-  meta: Meta!
-}
-
-type Document implements FileInterface {
+type Document {
   id: ID!
   # AST of /article.md
   content: JSON!
@@ -74,6 +63,12 @@ type Document implements FileInterface {
     before: ID
     after: ID
   ): DocumentNodeConnection!
+  linkedDocuments(
+    first: Int
+    last: Int
+    before: ID
+    after: ID
+  ): DocumentConnection!
 }
 
 type DocumentNode {

--- a/packages/documents/graphql/schema.js
+++ b/packages/documents/graphql/schema.js
@@ -12,6 +12,8 @@ type queries {
     dossier: String
     format: String
     template: String
+    hasDossier: Boolean
+    hasFormat: Boolean
     first: Int
     last: Int
     before: String

--- a/packages/search/graphql/schema-types.js
+++ b/packages/search/graphql/schema-types.js
@@ -45,13 +45,14 @@ input SearchFilterInput {
   feed: Boolean
   # repoId
   dossier: String
+  hasDossier: Boolean
   # repoId
   format: String
+  hasFormat: Boolean
   template: String
   publishedAt: DateRangeInput
   userId: ID
   author: String
-
   discussion: Boolean
   isSeriesMaster: Boolean
   isSeriesEpisode: Boolean

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -70,10 +70,18 @@ const schema = {
     agg: valueCountAggBuilder('meta.dossier'),
     parser: documentIdParser
   },
+  hasDossier: {
+    criteria: hasCriteriaBuilder('meta.dossier'),
+    agg: existsCountAggBuilder('meta.dossier')
+  },
   format: {
     criteria: termCriteriaBuilder('meta.format'),
     agg: valueCountAggBuilder('meta.format'),
     parser: documentIdParser
+  },
+  hasFormat: {
+    criteria: hasCriteriaBuilder('meta.format'),
+    agg: existsCountAggBuilder('meta.format')
   },
   kind: termEntry('resolved.meta.format.meta.kind'),
   repoId: {


### PR DESCRIPTION
This Pull Request adds ability to query for `Document` entities which belong to a "format" or "dossier", like so:

```gql
{
  documents(hasFormat: true) {
    nodes {
      meta {
        title
        path
        format {
          meta {
            title
            path
          }
        }
      }
    }
  }
}
```

`hasFormat` and `hasDossier` are available as flags in `documents` query and as filters in `search` query:

```gql
{
  search (filter: {hasFormat: true}) {
    nodes {
      entity {
        ... on Document {
          meta {
            title
            path
            format {
              meta {
                title
                path
              } 
            }
          }
        }
      }
    }
  }
}
```

This Pull Request also reinstates broken `nodes.linkedDocuments` for `Document` entities to query for children documents, like so:

```gql
{
  documents(template: "format") {
    totalCount
    nodes {
      meta {
        title
        path
      }
      linkedDocuments {
        totalCount
      }
    }
  }
}
```

Linked documents are available as full blown `Document` entities, like so:

```gql
{
  documents(template: "format") {
    totalCount
    nodes {
      meta {
        title
        path
      }
      linkedDocuments {
        nodes {
          meta {
            path
            title
          }
        }
      }
    }
  }
}
```

This Pull Request also removes interface `FileInterface` as it did not serve meaningful value. 

It is [a 2nd attempt due me not having understood](https://github.com/orbiting/backends/pull/86) what `Document.children` was for.