### PR TITLE
feat(auth): Query and submit additional fields when authorizing a session

### DIFF
--- a/packages/auth/graphql/resolvers/_mutations/authorizeSession.js
+++ b/packages/auth/graphql/resolvers/_mutations/authorizeSession.js
@@ -4,7 +4,8 @@ module.exports = async (_, args, { pgdb, req, user: me, signInHooks }) => {
   const {
     email,
     tokens = [],
-    consents
+    consents,
+    fields
   } = args
 
   const user = await authorizeSession({
@@ -13,6 +14,7 @@ module.exports = async (_, args, { pgdb, req, user: me, signInHooks }) => {
     email,
     signInHooks,
     consents,
+    fields,
     req,
     me
   })

--- a/packages/auth/graphql/resolvers/_mutations/authorizeSession.js
+++ b/packages/auth/graphql/resolvers/_mutations/authorizeSession.js
@@ -5,7 +5,7 @@ module.exports = async (_, args, { pgdb, req, user: me, signInHooks }) => {
     email,
     tokens = [],
     consents,
-    fields
+    requiredFields
   } = args
 
   const user = await authorizeSession({
@@ -14,7 +14,7 @@ module.exports = async (_, args, { pgdb, req, user: me, signInHooks }) => {
     email,
     signInHooks,
     consents,
-    fields,
+    requiredFields,
     req,
     me
   })

--- a/packages/auth/graphql/resolvers/_queries/unauthorizedSession.js
+++ b/packages/auth/graphql/resolvers/_queries/unauthorizedSession.js
@@ -1,13 +1,12 @@
 const { unauthorizedSession } = require('../../../lib/Users')
 const { missingConsents } = require('../../../lib/Consents')
+const { getMissingFields } = require('../../../lib/Fields')
 
 module.exports = async (_, args, { pgdb, req, user: me }) => {
   const { email, token } = args
   const session = await unauthorizedSession({ pgdb, token, email, me })
 
-  const user = await pgdb.public.users.findOne({
-    email
-  })
+  const user = await pgdb.public.users.findOne({ email })
 
   const requiredConsents = await missingConsents({
     userId: user && user.id,
@@ -15,10 +14,13 @@ module.exports = async (_, args, { pgdb, req, user: me }) => {
     consents: session.sess.consents
   })
 
+  const requiredFields = await getMissingFields({ user, email, pgdb })
+
   return {
     session,
     enabledSecondFactors: (user && user.enabledSecondFactors) || [],
     requiredConsents,
+    requiredFields,
     newUser: !user || !user.verified
   }
 }

--- a/packages/auth/graphql/schema-types.js
+++ b/packages/auth/graphql/schema-types.js
@@ -75,6 +75,11 @@ input SignInToken {
   payload: String!
 }
 
+input RequiredUserFields {
+  firstName: String!
+  lastName: String!
+}
+
 type RequestInfo {
   ipAddress: String!
   userAgent: String

--- a/packages/auth/graphql/schema-types.js
+++ b/packages/auth/graphql/schema-types.js
@@ -17,6 +17,7 @@ type UnauthorizedSession {
   session: Session!
   enabledSecondFactors: [SignInTokenType]!
   requiredConsents: [String!]!
+  requiredFields: [String!]!
   newUser: Boolean
 }
 

--- a/packages/auth/graphql/schema.js
+++ b/packages/auth/graphql/schema.js
@@ -44,7 +44,12 @@ type mutations {
   startChallenge(sessionId: ID!, type: SignInTokenType!): Boolean!
 
   # authorize a token sent by mail to convert a login request to a valid user session
-  authorizeSession(email: String!, tokens: [SignInToken!]!, consents: [String!]): Boolean!
+  authorizeSession(
+    email: String!
+    tokens: [SignInToken!]!
+    consents: [String!]
+    fields: UserInput
+  ): Boolean!
 
   # deny a session via token challenge
   denySession(email: String!, token: SignInToken!): Boolean!

--- a/packages/auth/graphql/schema.js
+++ b/packages/auth/graphql/schema.js
@@ -48,7 +48,7 @@ type mutations {
     email: String!
     tokens: [SignInToken!]!
     consents: [String!]
-    fields: RequiredUserFields
+    requiredFields: RequiredUserFields
   ): Boolean!
 
   # deny a session via token challenge

--- a/packages/auth/graphql/schema.js
+++ b/packages/auth/graphql/schema.js
@@ -48,7 +48,7 @@ type mutations {
     email: String!
     tokens: [SignInToken!]!
     consents: [String!]
-    fields: UserInput
+    fields: RequiredUserFields
   ): Boolean!
 
   # deny a session via token challenge

--- a/packages/auth/lib/Fields.js
+++ b/packages/auth/lib/Fields.js
@@ -1,0 +1,61 @@
+const moment = require('moment')
+
+const { newAuthError } = require('./AuthError')
+const Roles = require('./Roles')
+
+const MissingFieldsError = newAuthError(
+  'missing-fields',
+  'api/fields/missing'
+)
+
+const getMissingFields = async ({ user, email, pgdb }) => {
+  const missingFields = []
+  const unassignedGrants = await pgdb.public.accessGrants.find({
+    email,
+    recipientUserId: null,
+    'beginAt <=': moment(),
+    'endAt >': moment(),
+    invalidatedAt: null
+  })
+
+  if (
+    Roles.userHasRole(user, 'member') ||
+    (!user && unassignedGrants.length > 0)
+  ) {
+    missingFields.push('firstName')
+    missingFields.push('lastName')
+  }
+
+  return missingFields
+}
+
+const ensureRequiredFields = async ({ user, email, providedFields, pgdb }) => {
+  const missingFields = []
+  const fields = {}
+
+  const expectedFields = await getMissingFields({ user, email, pgdb })
+
+  expectedFields
+    .forEach(expectedField => {
+      if (!providedFields[expectedField]) {
+        missingFields.push(expectedField)
+        return false
+      }
+
+      fields[expectedField] = providedFields[expectedField]
+    })
+
+  if (missingFields.length > 0) {
+    throw new MissingFieldsError(
+      missingFields,
+      { fields: missingFields.join(', ') }
+    )
+  }
+
+  return fields
+}
+
+module.exports = {
+  getMissingFields,
+  ensureRequiredFields
+}

--- a/packages/auth/lib/Fields.js
+++ b/packages/auth/lib/Fields.js
@@ -47,7 +47,7 @@ const getMissingFields = async ({ user, email, pgdb }) => {
 
 const ensureRequiredFields = async ({ user, email, providedFields, pgdb }) => {
   const missingFields = []
-  const fields = {}
+  const requiredFields = {}
 
   const expectedFields = await getMissingFields({ user, email, pgdb })
 
@@ -58,7 +58,7 @@ const ensureRequiredFields = async ({ user, email, providedFields, pgdb }) => {
         return false
       }
 
-      fields[expectedField] = providedFields[expectedField]
+      requiredFields[expectedField] = providedFields[expectedField]
     })
 
   if (missingFields.length > 0) {
@@ -68,7 +68,7 @@ const ensureRequiredFields = async ({ user, email, providedFields, pgdb }) => {
     )
   }
 
-  return fields
+  return requiredFields
 }
 
 module.exports = {

--- a/packages/auth/lib/Fields.js
+++ b/packages/auth/lib/Fields.js
@@ -18,9 +18,18 @@ const getMissingFields = async ({ user, email, pgdb }) => {
     invalidatedAt: null
   })
 
+  const isMember = !!user && Roles.userHasRole(user, 'member')
+  const hasNames = !!user && (
+    user.firstName &&
+    user.firstName.trim().length > 1 &&
+    user.lastName &&
+    user.lastName.trim().length > 1
+  )
+  const hasGrants = unassignedGrants.length > 0
+
   if (
-    Roles.userHasRole(user, 'member') ||
-    (!user && unassignedGrants.length > 0)
+    (user && isMember && !hasNames) ||
+    (!user && hasGrants)
   ) {
     missingFields.push('firstName')
     missingFields.push('lastName')

--- a/packages/auth/lib/Users.js
+++ b/packages/auth/lib/Users.js
@@ -275,7 +275,7 @@ const denySession = async ({ pgdb, token, email: emailFromQuery, me }) => {
   return true
 }
 
-const authorizeSession = async ({ pgdb, tokens, email: emailFromQuery, signInHooks = [], consents = [], fields = [], req, me }) => {
+const authorizeSession = async ({ pgdb, tokens, email: emailFromQuery, signInHooks = [], consents = [], requiredFields = [], req, me }) => {
   // validate the challenges
   const existingUser = await pgdb.public.users.findOne({ email: emailFromQuery })
   const tokenTypes = []
@@ -325,7 +325,7 @@ const authorizeSession = async ({ pgdb, tokens, email: emailFromQuery, signInHoo
       pgdb: transaction,
       email: session.sess.email,
       consents,
-      fields,
+      requiredFields,
       req
     }))
   } catch (error) {
@@ -400,7 +400,7 @@ const authorizeSession = async ({ pgdb, tokens, email: emailFromQuery, signInHoo
   return user
 }
 
-const upsertUserAndConsents = async ({ pgdb, email, consents, fields, req }) => {
+const upsertUserAndConsents = async ({ pgdb, email, consents, requiredFields, req }) => {
   const existingUser = await pgdb.public.users.findOne({ email })
   let user = existingUser
 
@@ -414,7 +414,7 @@ const upsertUserAndConsents = async ({ pgdb, email, consents, fields, req }) => 
   const userFields = await ensureRequiredFields({
     user,
     email,
-    providedFields: fields,
+    providedFields: requiredFields,
     pgdb
   })
 

--- a/packages/auth/lib/Users.js
+++ b/packages/auth/lib/Users.js
@@ -333,8 +333,6 @@ const authorizeSession = async ({ pgdb, tokens, email: emailFromQuery, signInHoo
     throw error
   }
 
-  // throw new Error('Breakpoint')
-
   try {
     // log in the session and delete token
     await transaction.public.sessions.updateOne({

--- a/servers/publikator/script/db-migrate-all.js
+++ b/servers/publikator/script/db-migrate-all.js
@@ -12,7 +12,8 @@ const migrationDirs = [
   '../../packages/auth/migrations',
   '../republik/migrations/crowdfunding',
   '../republik/migrations',
-  '../../packages/notifications/migrations'
+  '../../packages/notifications/migrations',
+  '../../packages/access/migrations'
 ]
 
 dbMigrateAll(migrationDirs)


### PR DESCRIPTION
This Pull Request provides information on additional fields required to authorize a session not unlike `requiredConsents` field.

Query `unauthorizedSession` first:

```gql
{ unauthorizedSession(
  email: ...
  token: ...
) {
  requiredFields
} }
```

This query will result in something as follows:

```gql
{
  "data": {
    "unauthorizedSession": {
      "requiredFields": [
        "firstName",
        "lastName"
      ]
    }
  }
}
```

Authorize a session with additional required fields like so:

```gql
mutation {
  authorizeSession(
    email: ...
    tokens: ...,
    ...
    fields: {
      firstName: "Peter"
      lastName: "Parker"
    }
  )
}
```

It requires UI to updated https://github.com/orbiting/republik-frontend/pull/183