### PR TITLE
fix(encoding): strip \u2028 for iOS

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "apollo-engine": "^1.1.0",
     "apollo-modules-node": "^0.1.4",
+    "apollo-server-core": "^1.3.6",
     "apollo-server-express": "^1.3.4",
     "bluebird": "^3.5.1",
     "body-parser": "^1.18.3",


### PR DESCRIPTION
A workaround for https://github.com/orbiting/app/issues/159

Handles all data coming from GraphQL—Publikator and user generated content.

Interception response bodies with express is hard and can easily lead to content length header problems. `apollo-server` does not offer a response hook out of the box but `apollo-server-express` is a thin wrapper which gets the json nicely as a string and is responsible to set the content length. It seemed like the safest and easiest solution to copy that wrapper and modify it.