### PR TITLE
feat(election): Send candidacy confirmation email

### DIFF
--- a/packages/election/graphql/resolvers/_mutations/createElection.js
+++ b/packages/election/graphql/resolvers/_mutations/createElection.js
@@ -18,7 +18,7 @@ module.exports = async (_, { electionInput }, { pgdb, user: me, req }) => {
   } = electionInput
 
   const start = moment(beginDate)
-  const rawDiscussion = await upsert(pgdb.public.discussions,
+  const { entity: rawDiscussion } = await upsert(pgdb.public.discussions,
     {
       title: description,
       documentPath: `${start.format('/YYYY/MM/DD')}/${slug}`
@@ -26,7 +26,7 @@ module.exports = async (_, { electionInput }, { pgdb, user: me, req }) => {
     { title: description }
   )
 
-  const rawElection = await upsert(pgdb.public.elections, {
+  const { entity: rawElection } = await upsert(pgdb.public.elections, {
     ...electionInput,
     discussionId: rawDiscussion.id
   },

--- a/packages/election/graphql/schema-types.js
+++ b/packages/election/graphql/schema-types.js
@@ -11,6 +11,8 @@ type Election {
   candidates: [Candidate!]!
   discussion: Discussion!
 
+  shortSlug: String
+
   turnout: ElectionTurnout
   result: ElectionResult
   # current user (me) is eligible to submit a ballot
@@ -26,6 +28,7 @@ input ElectionInput {
   beginDate: DateTime!
   endDate: DateTime!
   numSeats: Int!
+  shortSlug: String
 }
 
 type ElectionTurnout {

--- a/packages/election/lib/db.js
+++ b/packages/election/lib/db.js
@@ -1,11 +1,18 @@
 module.exports = {
   upsert: async (table, data, condition) => {
     const where = condition || {id: data.id}
+
     try {
       if (Object.values(where).every(Boolean) && await table.findFirst(where)) {
-        return table.updateAndGetOne(where, data)
-      } else {
-        return table.insertAndGet(data)
+        return {
+          entity: await table.updateAndGetOne(where, data),
+          isNew: false
+        }
+      }
+
+      return {
+        entity: await table.insertAndGet(data),
+        isNew: true
       }
     } catch (e) {
       console.error(e.detail)

--- a/packages/election/migrations/sqls/20180912181821-election-up.sql
+++ b/packages/election/migrations/sqls/20180912181821-election-up.sql
@@ -8,6 +8,7 @@ create table if not exists "elections" (
   "endDate"      timestamptz      not null,
   "numSeats"     integer          not null,
   "discussionId" uuid             not null references "discussions" on update cascade on delete cascade,
+  "shortSlug"    varchar,
   "active"       boolean          not null default true,
   "result"       jsonb,
   "createdAt"    timestamptz               default now(),
@@ -87,4 +88,3 @@ EXECUTE PROCEDURE refresh_associate_role_trigger_function();
 
 --Run once for all users
 SELECT refresh_associate_role(id) FROM users;
-


### PR DESCRIPTION
This Pull Request will send a candidacy confirmation email when submitting a candidacy for the first time.

Introduced an additional field to `elections` table: `shortSlug`.

It appears that election mails are surprisingly non-generic thus will get their own mailing templates. Template names are glued with regular template name and appends `_{shortSlug}` to it. It will use a "default" template without that slug. (Not using `elections.slug` or `id` as those strings are too long for MailChimp template names.)

Altered _lib/db.js_ to return `{ entity, isNew }` instead of `entity` only. Allows to understand if an entity was added or updated. Also adopted already existing code.