### PR TITLE
feat(republik): Hide a discussion

### DIFF
--- a/packages/search/lib/indices/comments.js
+++ b/packages/search/lib/indices/comments.js
@@ -24,7 +24,8 @@ module.exports = {
           must: [
             { term: { __type: type } },
             { term: { published: true } },
-            { term: { adminUnpublished: false } }
+            { term: { adminUnpublished: false } },
+            { term: { 'resolved.discussion.hidden': false } }
           ]
         }
       })
@@ -69,6 +70,13 @@ module.exports = {
                 },
                 username: {
                   type: 'keyword'
+                }
+              }
+            },
+            discussion: {
+              properties: {
+                hidden: {
+                  type: 'boolean'
                 }
               }
             }

--- a/packages/search/lib/indices/comments.js
+++ b/packages/search/lib/indices/comments.js
@@ -25,11 +25,6 @@ module.exports = {
             { term: { __type: type } },
             { term: { published: true } },
             { term: { adminUnpublished: false } }
-          ],
-          must_not: [
-            { terms: { discussionId: [
-              '3c625fe4-788f-44d5-ad5e-ac93bd9a6292' // Crowdfunding discussions
-            ] } }
           ]
         }
       })

--- a/packages/search/script/inserts/comment.js
+++ b/packages/search/script/inserts/comment.js
@@ -10,6 +10,7 @@ const transform = function (row) {
     { id: row.discussionId }
   )
   const isAnonymityEnforced = discussion.anonymity === 'ENFORCED'
+  const isHidden = discussion.hidden
 
   const discussionPreferences = _.find(
     this.payload.discussionPreferences,
@@ -24,7 +25,8 @@ const transform = function (row) {
   if (
     user &&
     !isAnonymityEnforced &&
-    !isAnonymous
+    !isAnonymous &&
+    !isHidden
   ) {
     let credential = false
 

--- a/packages/search/script/inserts/comment.js
+++ b/packages/search/script/inserts/comment.js
@@ -10,7 +10,6 @@ const transform = function (row) {
     { id: row.discussionId }
   )
   const isAnonymityEnforced = discussion.anonymity === 'ENFORCED'
-  const isHidden = discussion.hidden
 
   const discussionPreferences = _.find(
     this.payload.discussionPreferences,
@@ -19,14 +18,16 @@ const transform = function (row) {
   const isAnonymous = discussionPreferences && discussionPreferences.anonymous
 
   row.resolved = {
-    user: null
+    user: null,
+    discussion: {
+      hidden: discussion.hidden
+    }
   }
 
   if (
     user &&
     !isAnonymityEnforced &&
-    !isAnonymous &&
-    !isHidden
+    !isAnonymous
   ) {
     let credential = false
 
@@ -85,7 +86,8 @@ const getDefaultResource = async ({ pgdb }) => {
         {
           fields: [
             'id',
-            'anonymity'
+            'anonymity',
+            'hidden'
           ]
         }
       ),

--- a/servers/republik/graphql/resolvers/User.js
+++ b/servers/republik/graphql/resolvers/User.js
@@ -179,6 +179,7 @@ module.exports = {
       WHERE
         c."userId" = :userId AND
         d.anonymity != 'ENFORCED' AND
+        d.hidden = false AND
         (dp IS NULL OR dp.anonymous = false)
       ORDER BY
         c."createdAt" DESC

--- a/servers/republik/graphql/resolvers/_queries/discussions.js
+++ b/servers/republik/graphql/resolvers/_queries/discussions.js
@@ -1,2 +1,2 @@
 module.exports = async (_, args, { pgdb }, info) =>
-  pgdb.public.discussions.find()
+  pgdb.public.discussions.find({ hidden: false })

--- a/servers/republik/migrations/20180928092218-hidden-discussion.js
+++ b/servers/republik/migrations/20180928092218-hidden-discussion.js
@@ -1,0 +1,47 @@
+'use strict'
+
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20180928092218-hidden-discussion-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20180928092218-hidden-discussion-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  'version': 1
+}

--- a/servers/republik/migrations/sqls/20180928092218-hidden-discussion-down.sql
+++ b/servers/republik/migrations/sqls/20180928092218-hidden-discussion-down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE discussions
+  DROP COLUMN hidden
+;

--- a/servers/republik/migrations/sqls/20180928092218-hidden-discussion-up.sql
+++ b/servers/republik/migrations/sqls/20180928092218-hidden-discussion-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE discussions
+  ADD COLUMN hidden boolean NOT NULL DEFAULT false
+;


### PR DESCRIPTION
This Pull Request allows to hide discussions and comments by setting `discussions.hidden = true` in database.

- It won't hide discussions when queried for a specific ID. 
- It will return comments if hidden discussions if queried specifically.
- iIt prevents indexing comments of hidden discussions into search database.