### PR TITLE
fix(documents): Retrieve meta.credits properly

### DIFF
--- a/packages/documents/lib/meta.js
+++ b/packages/documents/lib/meta.js
@@ -1,5 +1,3 @@
-const visit = require('unist-util-visit')
-
 const { metaFieldResolver } = require('./resolve')
 
 const getMeta = doc => {
@@ -12,16 +10,7 @@ const getMeta = doc => {
     ? metaFieldResolver(doc.content.meta, doc._all)
     : { }
 
-  let credits = []
-  visit(doc.content, 'zone', node => {
-    if (node.identifier === 'TITLE') {
-      const paragraphs = node.children
-        .filter(child => child.type === 'paragraph')
-      if (paragraphs.length >= 2) {
-        credits = paragraphs[paragraphs.length - 1].children
-      }
-    }
-  })
+  const credits = doc.content.meta.credits
 
   const { audioSourceMp3, audioSourceAac, audioSourceOgg } = doc.content.meta
   const audioSource = audioSourceMp3 || audioSourceAac || audioSourceOgg ? {


### PR DESCRIPTION
This ensures `meta.credits` is populated with (pre-)indexed document data.

To improve `search` query speed, some queries [are fired to retrieve documents without `doc.content.children`](https://github.com/orbiting/backends/blob/master/packages/search/graphql/resolvers/_queries/search.js#L350-L357).

packages/documents/lib/meta.js hereafter extracted credits [from non-existant `doc.content.children`](https://github.com/orbiting/backends/compare/fix-documents-meta-credits?expand=1#diff-6913b048f1a657df99bb40440fa3bdeeL16), and returned an empty array `credits` prop.

However, a document in ElasticSearch is stored with `doc.content.meta.credits` "pre-resolved" on publish and can be used.

It is a regression probably introduced back on June 26, 2018.

```gql
{
  search(filter: {type: Document}) {
    nodes {
      entity {
        ... on Document {
          meta {
            credits
          }
        }
      }
    }
  }
}

```

... returned before fix

```gql
{
  "data": {
    "search": {
      "nodes": [
        {
          "entity": {
            "meta": {
              "credits": []
            }
          }
        },
...
```

... and after fix


```gql
{
  "data": {
    "search": {
      "nodes": [
        {
          "entity": {
            "meta": {
              "credits": [
                {
                  "type": "text",
                  "value": "Von Peter Park, 29.09.2018"
                }
              ]
            }
          }
        },
...
```