### PR TITLE
publikator: Repo search cache upserts

### DIFF
--- a/servers/publikator/graphql/resolvers/_mutations/publish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/publish.js
@@ -391,6 +391,12 @@ module.exports = async (
   await after()
   await sleep(2 * 1000)
 
+  await repoCacheUpsert({
+    id: repoId,
+    meta: repoMeta,
+    publications: await getLatestPublications({ id: repoId })
+  })
+
   await redis.publishAsync(channelKey, 'refresh')
 
   // release for nice view on github
@@ -433,11 +439,6 @@ module.exports = async (
       throw new Error('Mailchimp: could not update campaign', updateResponse)
     }
   }
-
-  await repoCacheUpsert({
-    id: repoId,
-    publications: await getLatestPublications({ id: repoId })
-  })
 
   await pubsub.publish('repoUpdate', {
     repoUpdate: {

--- a/servers/publikator/lib/publicationScheduler.js
+++ b/servers/publikator/lib/publicationScheduler.js
@@ -8,9 +8,14 @@ const indices = require('@orbiting/backend-modules-search/lib/indices')
 const { getIndexAlias } = require('@orbiting/backend-modules-search/lib/utils')
 const { handleRedirection } = require('./Document')
 const {
+  latestPublications: getLatestPublications,
+  meta: getRepoMeta
+} = require('../graphql/resolvers/Repo')
+const {
   upsertRef,
   deleteRef
 } = require('./github')
+const { upsert: repoCacheUpsert } = require('./cache/upsert')
 
 const elastic = Elastic.client()
 
@@ -153,6 +158,12 @@ const run = async (_lock) => {
           console.error('Error: one or more promises failed:')
           console.error(e)
         })
+
+      await repoCacheUpsert({
+        id: repoId,
+        meta: await getRepoMeta({ id: repoId }),
+        publications: await getLatestPublications({ id: repoId })
+      })
 
       debug(
         'published', {


### PR DESCRIPTION
This Pull Requests extends repo search cache upserts for
- scheduled publications and pre-publications
- on `unpublish`
- on `publish`