### PR TITLE
feat(access): Get past campaigns, grants (admin only)

### DIFF
--- a/packages/access/graphql/resolvers/User.js
+++ b/packages/access/graphql/resolvers/User.js
@@ -5,24 +5,40 @@ const { Roles } = require('@orbiting/backend-modules-auth')
 const grantsLib = require('../../lib/grants')
 const campaignsLib = require('../../lib/campaigns')
 
+const PRIVILEDGED_ROLES = ['admin', 'supporter']
+
 module.exports = {
-  accessGrants: async (user, args, { user: me, pgdb }) => {
-    if (!Roles.userIsMeOrInRoles(user, me, ['admin', 'supporter'])) {
+  accessGrants: async (user, { withPast }, { user: me, pgdb }) => {
+    if (!Roles.userIsMeOrInRoles(user, me, PRIVILEDGED_ROLES)) {
       return null
     }
 
-    const grants = await grantsLib.findByRecipient(user, pgdb)
+    if (!Roles.userIsInRoles(me, PRIVILEDGED_ROLES)) {
+      withPast = false
+    }
+
+    const grants = await grantsLib.findByRecipient(
+      user,
+      { withPast, pgdb }
+    )
 
     debug('accessGrants', { user: user.id, grants: grants.length })
 
     return grants
   },
-  accessCampaigns: async (user, args, { user: me, pgdb }) => {
-    if (!Roles.userIsMeOrInRoles(user, me, ['admin', 'supporter'])) {
+  accessCampaigns: async (user, { withPast }, { user: me, pgdb }) => {
+    if (!Roles.userIsMeOrInRoles(user, me, PRIVILEDGED_ROLES)) {
       return null
     }
 
-    const campaigns = await campaignsLib.findForGrantee(user, pgdb)
+    if (!Roles.userIsInRoles(me, PRIVILEDGED_ROLES)) {
+      withPast = false
+    }
+
+    const campaigns = await campaignsLib.findForGrantee(
+      user,
+      { withPast, pgdb }
+    )
 
     debug('accessCampaigns', { user: user.id, campaigns: campaigns.length })
 

--- a/packages/access/graphql/schema-types.js
+++ b/packages/access/graphql/schema-types.js
@@ -4,12 +4,12 @@ extend type User {
   """
   List of memberships a User was granted
   """
-  accessGrants: [AccessGrant!]
+  accessGrants(withPast: Boolean): [AccessGrant!]
 
   """
   List of granted memberships by User
   """
-  accessCampaigns: [AccessCampaign!]
+  accessCampaigns(withPast: Boolean): [AccessCampaign!]
 }
 
 """
@@ -26,6 +26,10 @@ type AccessCampaign {
     withInvalidated: Boolean
   ): [AccessGrant!]!
   slots: AccessCampaignSlots
+  "Begin of campaign"
+  beginAt: DateTime!
+  "End of campaign"
+  endAt: DateTime!
 }
 
 """

--- a/packages/access/lib/campaigns.js
+++ b/packages/access/lib/campaigns.js
@@ -14,6 +14,15 @@ const findAvailable = async (pgdb) => {
   return campaigns
 }
 
+const findAll = async (pgdb) => {
+  debug('findAll')
+  const campaigns = await pgdb.public.accessCampaigns.find({
+    'beginAt <=': moment()
+  })
+
+  return campaigns
+}
+
 const findByGrant = (grant, pgdb) => {
   debug('findByGrant')
   return pgdb.public.accessCampaigns.findOne({
@@ -30,11 +39,11 @@ const findOne = (id, pgdb) => {
   })
 }
 
-const findForGrantee = async (grantee, pgdb) => {
-  debug('findForGrantee')
+const findForGrantee = async (grantee, { withPast, pgdb }) => {
+  debug('findForGrantee', { withPast })
   const campaigns =
     await Promise.map(
-      await findAvailable(pgdb),
+      withPast ? await findAll(pgdb) : await findAvailable(pgdb),
       getContraintMeta.bind(null, grantee, pgdb)
     )
       .then(filterInvisibleCampaigns)

--- a/packages/access/lib/grants.js
+++ b/packages/access/lib/grants.js
@@ -220,14 +220,20 @@ const findByGrantee = async (
   )
 }
 
-const findByRecipient = async (recipient, pgdb) => {
+const findByRecipient = async (recipient, { withPast, pgdb }) => {
+  debug('findByRecipient', { withPast })
+  const condition = {
+    recipientUserId: recipient.id,
+    'beginAt <=': moment(),
+    invalidatedAt: null
+  }
+
+  if (!withPast) {
+    condition['endAt >'] = moment()
+  }
+
   const grants =
-    await pgdb.public.accessGrants.find({
-      recipientUserId: recipient.id,
-      'beginAt <=': moment(),
-      'endAt >': moment(),
-      invalidatedAt: null
-    })
+    await pgdb.public.accessGrants.find(condition)
 
   return grants
 }

--- a/packages/access/lib/mail.js
+++ b/packages/access/lib/mail.js
@@ -181,7 +181,7 @@ const getGlobalMergeVars = async (
 ) => {
   const safeGrantee = transformUser(grantee)
   const recipientCampaigns =
-    !!recipient && await campaignsLib.findForGrantee(recipient, pgdb)
+    !!recipient && await campaignsLib.findForGrantee(recipient, { pgdb })
   const recipientHasMemberships =
     !!recipient && await membershipsLib.hasUserActiveMembership(recipient, pgdb)
 

--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -61,7 +61,7 @@ const getInterestsForUser = async ({
   })) : false
 
   const user = !!userId && await pgdb.public.users.findOne({ id: userId })
-  const accessGrants = !!user && await grants.findByRecipient(user, pgdb)
+  const accessGrants = !!user && await grants.findByRecipient(user, { pgdb })
   const hasGrantedAccess = !!user && !!accessGrants && accessGrants.length > 0
 
   debug({


### PR DESCRIPTION
This Pull Request allows users with privileged roles, namely supporter and admin, to query campaigns and grants in the past.