### PR TITLE
feat(access): Send expiration and follow up transactional email

### DIFF
--- a/packages/access/lib/accessScheduler.js
+++ b/packages/access/lib/accessScheduler.js
@@ -105,7 +105,7 @@ const matchGrants = async (pgdb, mail) => {
  * Renders expired grants invalid.
  */
 const expireGrants = async (t, pgdb, mail) => {
-  debug('expireGrants')
+  debug('expireGrants...')
   for (const grant of await grantsLib.findExpired(pgdb)) {
     const transaction = await pgdb.transactionBegin()
 
@@ -120,14 +120,14 @@ const expireGrants = async (t, pgdb, mail) => {
       throw e
     }
   }
-  debug('expireGrant done...')
+  debug('expireGrant done')
 }
 
 /**
  * Runs follow-up on invalidated grants.
  */
 const followupGrants = async (t, pgdb, mail) => {
-  debug('followupGrants')
+  debug('followupGrants...')
   for (const campaign of await campaignsLib.findAll(pgdb)) {
     for (const grant of await grantsLib.findEmptyFollowup(campaign, pgdb)) {
       const transaction = await pgdb.transactionBegin()
@@ -144,5 +144,5 @@ const followupGrants = async (t, pgdb, mail) => {
       }
     }
   }
-  debug('followupGrants done...')
+  debug('followupGrants done')
 }

--- a/packages/access/lib/accessScheduler.js
+++ b/packages/access/lib/accessScheduler.js
@@ -4,15 +4,16 @@ const debug = require('debug')('access:lib:accessScheduler')
 const PgDb = require('@orbiting/backend-modules-base/lib/pgdb')
 const redis = require('@orbiting/backend-modules-base/lib/redis')
 
+const campaignsLib = require('./campaigns')
 const grantsLib = require('./grants')
 
 // Interval in which scheduler runs
-const intervalSecs = 60
+const intervalSecs = 60 * 10
 
 /**
  * Function to initialize scheduler. Provides scheduling.
  */
-const init = async ({ mail }) => {
+const init = async ({ t, mail }) => {
   debug('init')
 
   const pgdb = await PgDb.connect()
@@ -29,7 +30,8 @@ const init = async ({ mail }) => {
         await schedulerLock()
           .lock('locks:access-scheduler', 1000 * intervalSecs)
 
-      await expireGrants(pgdb, mail)
+      await expireGrants(t, pgdb, mail)
+      await followupGrants(t, pgdb, mail)
 
       // Extend lock for a fraction of usual interval to prevent runner to
       // be executed back-to-back to previous run.
@@ -81,16 +83,66 @@ const schedulerLock = () => new Redlock([redis])
  * Matches unassignedGrants
  */
 const matchGrants = async (pgdb, mail) => {
+  debug('matchGrants...')
   for (const grant of await grantsLib.findUnassigned(pgdb)) {
-    await grantsLib.match(grant, pgdb, mail)
+    const transaction = await pgdb.transactionBegin()
+
+    try {
+      await grantsLib.match(grant, transaction, mail)
+      await transaction.transactionCommit()
+    } catch (e) {
+      await transaction.transactionRollback()
+
+      debug('rollback', { grant: grant.id })
+
+      throw e
+    }
   }
+  debug('matchGrants done')
 }
 
 /**
- * Renders expired grants invalid
+ * Renders expired grants invalid.
  */
-const expireGrants = async (pgdb, mail) => {
+const expireGrants = async (t, pgdb, mail) => {
+  debug('expireGrants')
   for (const grant of await grantsLib.findExpired(pgdb)) {
-    await grantsLib.invalidate(grant, 'expired', pgdb, mail)
+    const transaction = await pgdb.transactionBegin()
+
+    try {
+      await grantsLib.invalidate(grant, 'expired', t, transaction, mail)
+      await transaction.transactionCommit()
+    } catch (e) {
+      await transaction.transactionRollback()
+
+      debug('rollback', { grant: grant.id })
+
+      throw e
+    }
   }
+  debug('expireGrant done...')
+}
+
+/**
+ * Runs follow-up on invalidated grants.
+ */
+const followupGrants = async (t, pgdb, mail) => {
+  debug('followupGrants')
+  for (const campaign of await campaignsLib.findAll(pgdb)) {
+    for (const grant of await grantsLib.findEmptyFollowup(campaign, pgdb)) {
+      const transaction = await pgdb.transactionBegin()
+
+      try {
+        await grantsLib.followUp(campaign, grant, t, transaction, mail)
+        await transaction.transactionCommit()
+      } catch (e) {
+        await transaction.transactionRollback()
+
+        debug('rollback', { grant: grant.id })
+
+        throw e
+      }
+    }
+  }
+  debug('followupGrants done...')
 }

--- a/packages/access/lib/campaigns.js
+++ b/packages/access/lib/campaigns.js
@@ -24,14 +24,14 @@ const findAll = async (pgdb) => {
 }
 
 const findByGrant = (grant, pgdb) => {
-  debug('findByGrant')
+  debug('findByGrant', { grant: grant.id })
   return pgdb.public.accessCampaigns.findOne({
     id: grant.accessCampaignId
   })
 }
 
 const findOne = (id, pgdb) => {
-  debug('findOne')
+  debug('findOne', { id })
   return pgdb.public.accessCampaigns.findOne({
     id,
     'beginAt <=': moment(),
@@ -40,7 +40,7 @@ const findOne = (id, pgdb) => {
 }
 
 const findForGrantee = async (grantee, { withPast, pgdb }) => {
-  debug('findForGrantee', { withPast })
+  debug('findForGrantee', { grantee: grantee.id, withPast })
   const campaigns =
     await Promise.map(
       withPast ? await findAll(pgdb) : await findAvailable(pgdb),
@@ -49,13 +49,12 @@ const findForGrantee = async (grantee, { withPast, pgdb }) => {
       .then(filterInvisibleCampaigns)
       .then(mergeConstraintPayloads)
 
-  debug('campaigns', campaigns)
-
   return campaigns
 }
 
 module.exports = {
   findAvailable,
+  findAll,
   findByGrant,
   findOne,
   findForGrantee

--- a/packages/access/lib/events.js
+++ b/packages/access/lib/events.js
@@ -6,13 +6,13 @@ const log = async (grant, event, pgdb) => {
     event
   })
 
-  debug('event logged', eventAdded)
+  debug('log', eventAdded)
 
   return eventAdded
 }
 
 const findByGrant = (grant, pgdb) => {
-  debug('findByGrant')
+  debug('findByGrant', { grant: grant.id })
   return pgdb.public.accessEvents.find(
     { accessGrantId: grant.id },
     { orderBy: { createdAt: 'desc' } }

--- a/packages/access/lib/grants.js
+++ b/packages/access/lib/grants.js
@@ -124,9 +124,10 @@ const revoke = async (id, user, t, pgdb) => {
     throw new Error(t('api/access/revoke/role/error'))
   }
 
+  const updateFields = { revokedAt: moment(), updatedAt: moment() }
   const result = await pgdb.public.accessGrants.update(
     { id: grant.id, revokedAt: null, invalidatedAt: null },
-    { revokedAt: moment(), updatedAt: moment() }
+    updateFields
   )
 
   await eventsLib.log(
@@ -135,15 +136,19 @@ const revoke = async (id, user, t, pgdb) => {
     pgdb
   )
 
-  debug('revoke', { grant })
+  debug('revoke', {
+    id: grant.id,
+    ...updateFields
+  })
 
   return result
 }
 
 const invalidate = async (grant, reason, t, pgdb, mail) => {
+  const updateFields = { invalidatedAt: moment(), updatedAt: moment() }
   const result = await pgdb.public.accessGrants.update(
     { id: grant.id, invalidatedAt: null },
-    { invalidatedAt: moment(), updatedAt: moment() }
+    updateFields
   )
 
   await eventsLib.log(grant, `invalidated.${reason}`, pgdb)
@@ -187,8 +192,7 @@ const invalidate = async (grant, reason, t, pgdb, mail) => {
     id: grant.id,
     reason,
     hasRecipient: !!grant.recipientUserId,
-    invalidatedAt: moment(),
-    updatedAt: moment(),
+    ...updateFields,
     result
   })
 
@@ -196,9 +200,10 @@ const invalidate = async (grant, reason, t, pgdb, mail) => {
 }
 
 const followUp = async (campaign, grant, t, pgdb, mail) => {
+  const updateFields = { followupAt: moment(), updatedAt: moment() }
   const result = await pgdb.public.accessGrants.update(
     { id: grant.id, followupAt: null },
-    { followupAt: moment(), updatedAt: moment() }
+    updateFields
   )
 
   const recipient =
@@ -221,8 +226,7 @@ const followUp = async (campaign, grant, t, pgdb, mail) => {
   debug('followUp', {
     id: grant.id,
     hasRecipient: !!grant.recipientUserId,
-    followUp: moment(),
-    updatedAt: moment(),
+    ...updateFields,
     result
   })
 
@@ -323,15 +327,15 @@ const findExpired = async (pgdb) => {
 }
 
 const setRecipient = async (grant, recipient, pgdb) => {
+  const updateFields = { recipientUserId: recipient.id, updatedAt: moment() }
   const result = await pgdb.public.accessGrants.update(
     { id: grant.id },
-    { recipientUserId: recipient.id, updatedAt: moment() }
+    updateFields
   )
 
   debug('setRecipient', {
     id: grant.id,
-    recipientUserId: recipient.id,
-    updatedAt: moment(),
+    ...updateFields,
     result
   })
 

--- a/packages/access/lib/mail.js
+++ b/packages/access/lib/mail.js
@@ -32,39 +32,9 @@ const sendRecipientOnboarding = async (grantee, campaign, grant, t, pgdb) => {
   )
 }
 
-const sendRecipientExpirationNotice = async (
-  grantee, campaign, grant, t, pgdb
-) => {
-  debug('sendRecipientExpirationNotice')
-
-  const recipient = await pgdb.public.users.findOne({ email: grant.email })
-
-  if (recipient) {
-    return sendMail(
-      recipient.email,
-      'recipient',
-      'expiration_notice',
-      {
-        grantee,
-        recipient,
-        campaign,
-        grant,
-        t,
-        pgdb
-      }
-    )
-  }
-
-  return false
-}
-
-const sendRecipientExpired = async (grantee, campaign, grant, t, pgdb) => {
-  debug('sendRecipientExpired')
-
-  const recipient = await pgdb.public.users.findOne({ email: grant.email })
-
-  if (recipient) {
-    return sendMail(
+const sendRecipientExpired =
+  async (grantee, campaign, recipient, grant, t, pgdb) =>
+    sendMail(
       recipient.email,
       'recipient',
       'expired',
@@ -77,18 +47,10 @@ const sendRecipientExpired = async (grantee, campaign, grant, t, pgdb) => {
         pgdb
       }
     )
-  }
 
-  return false
-}
-
-const sendRecipientFollowup = async (grantee, campaign, grant, t, pgdb) => {
-  debug('sendRecipientFollowup')
-
-  const recipient = await pgdb.public.users.findOne({ email: grant.email })
-
-  if (recipient) {
-    return sendMail(
+const sendRecipientFollowup =
+  async (grantee, campaign, recipient, grant, t, pgdb) =>
+    sendMail(
       recipient.email,
       'recipient',
       'followup',
@@ -101,17 +63,10 @@ const sendRecipientFollowup = async (grantee, campaign, grant, t, pgdb) => {
         pgdb
       }
     )
-  }
-
-  return false
-}
 
 module.exports = {
   // Onboarding
   sendRecipientOnboarding,
-
-  // Expiration Notice
-  sendRecipientExpirationNotice,
 
   // Offboarding when access expired
   sendRecipientExpired,
@@ -237,6 +192,12 @@ const getGlobalMergeVars = async (
     },
     { name: 'LINK_OFFERS',
       content: `${FRONTEND_BASE_URL}/angebote?package=ABO`
+    },
+    { name: 'LINK_OFFER_ABO',
+      content: `${FRONTEND_BASE_URL}/angebote?package=ABO`
+    },
+    { name: 'LINK_OFFER_MONTHLY_ABO',
+      content: `${FRONTEND_BASE_URL}/angebote?package=MONTHLY_ABO`
     },
     { name: 'LINK_PROJECTR',
       content: 'https://project-r.construction/'

--- a/packages/access/lib/memberships.js
+++ b/packages/access/lib/memberships.js
@@ -30,7 +30,7 @@ const hasUserActiveMembership = async (user, pgdb) => {
 }
 
 const addMemberRole = async (grant, user, pgdb) => {
-  debug('addMemberRole')
+  debug('addMemberRole', { grant: grant.id, user: user.id })
 
   const hasMembership = await hasUserActiveMembership(user, pgdb)
 
@@ -52,11 +52,11 @@ const addMemberRole = async (grant, user, pgdb) => {
 }
 
 const removeMemberRole = async (grant, user, findFn, pgdb) => {
-  debug('removeMemberRole')
+  debug('removeMemberRole', { grant: grant.id, user: user.id })
 
   const hasMembership = await hasUserActiveMembership(user, pgdb)
 
-  const allRecipientGrants = await findFn(user, pgdb)
+  const allRecipientGrants = await findFn(user, { pgdb })
   const allOtherRecipientGrants =
     allRecipientGrants.filter(otherGrant => otherGrant.id !== grant.id)
 

--- a/packages/access/migrations/20181001150848-followup.js
+++ b/packages/access/migrations/20181001150848-followup.js
@@ -1,0 +1,47 @@
+'use strict'
+
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20181001150848-followup-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20181001150848-followup-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  'version': 1
+}

--- a/packages/access/migrations/sqls/20181001150848-followup-down.sql
+++ b/packages/access/migrations/sqls/20181001150848-followup-down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "accessGrants"
+  DROP COLUMN "followupAt"
+;

--- a/packages/access/migrations/sqls/20181001150848-followup-up.sql
+++ b/packages/access/migrations/sqls/20181001150848-followup-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "accessGrants"
+  ADD COLUMN "followupAt" timestamp with time zone
+;

--- a/servers/republik/lib/translations.json
+++ b/servers/republik/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-09-29T15:26:39.443Z",
+  "updated": "2018-10-01T14:40:33.676Z",
   "title": "live",
   "data": [
     {
@@ -443,12 +443,8 @@
       "value": "Einladung von {granteeName}"
     },
     {
-      "key": "api/access/email/recipient/expiration_notice/subject",
-      "value": "Zugriff läuft bald ab"
-    },
-    {
       "key": "api/access/email/recipient/expired/subject",
-      "value": "Zugriff abgelaufen"
+      "value": "Ihre Reise ist beendet"
     },
     {
       "key": "api/access/email/recipient/followup/subject",

--- a/servers/republik/server.js
+++ b/servers/republik/server.js
@@ -94,7 +94,7 @@ const runOnce = async (...args) => {
     require('@orbiting/backend-modules-search').notifyListener.run()
   }
 
-  await accessScheduler.init({ mail })
+  await accessScheduler.init({ t, mail })
   await previewScheduler.init({ mail })
 }
 


### PR DESCRIPTION
This Pull Request adds missing pieces to granting access feature:
- send a transactional email at the moment a grant expires
- send a transactional email to follow-up some time later (set in campaign itself)

Other changes include:
- Handle errors in `accessScheduler` more gracefully. Mandrill API proves to be not a reliable and throws frequently 500 HTTP Status Code errors containing not parseable content.
- Includes more verbose debug logging to understand who queried what and when.
- Changed schedulers interval to 10 minutes as matching happens upon sign in.