### PR TITLE
fix(series): sanitize repo ids before querying

### DIFF
--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -271,14 +271,15 @@ const addRelatedDocs = async ({ connection, scheduledAt, context }) => {
 
   // If there are any series master repositories, fetch these series master
   // documents and push series episodes onto the related docs stack
-  if (seriesRepoIds.length > 0) {
+  const sanitizedSeriesRepoIds = [...new Set(seriesRepoIds.filter(Boolean))]
+  if (sanitizedSeriesRepoIds.length > 0) {
     const seriesRelatedDocs = await search(null, {
       recursive: true,
       withoutContent: true,
       scheduledAt,
-      first: seriesRepoIds.length * 2,
+      first: sanitizedSeriesRepoIds.length * 2,
       filter: {
-        repoId: seriesRepoIds,
+        repoId: sanitizedSeriesRepoIds,
         type: 'Document'
       }
     }, context)


### PR DESCRIPTION
Following values are in `meta.series`:
```
https://github.com/republik-dev/article-daniels-serienmaster
https://github.com/republik-dev/article-master
https://github.com/republik-dev/article-master
https://github.com/republik/article-intro
```
after passing through `getRepoId` `"https://github.com/republik/article-intro"` becomes `null` because it's not a recognized id (different org).

Querying for "meta.repoId: ["...", null]" leads to an elastic parse error:

```
[parsing_exception] No value specified for terms query, with { line=1 & col=199 }
```