### PR TITLE
fix(Commit): handle article.md bigger than 500kb

### DIFF
--- a/servers/publikator/graphql/resolvers/Commit.js
+++ b/servers/publikator/graphql/resolvers/Commit.js
@@ -78,14 +78,21 @@ module.exports = {
         repo: repoName,
         file_sha: repository.blob.oid
       }
-      const blobResult = await githubRest.gitdata.getBlob(blobParams)
 
-      if (!blobResult || !blobResult.data || !blobResult.data.content) {
+      let blobResult, error
+      try {
+        blobResult = await githubRest.gitdata.getBlob(blobParams)
+      } catch (e) {
+        error = e
+        blobResult = null
+      }
+
+      if (error || !blobResult || !blobResult.data || !blobResult.data.content) {
         console.error(
           'getBlob failed for ',
-          blobParams
+          { ...blobParams, commitId, error }
         )
-        throw new Error(`getBlob failed sha ${repository.blob.oid}`)
+        throw new Error(`getBlob failed for sha ${repository.blob.oid}`)
       }
 
       try {


### PR DESCRIPTION
GitHub GraphlQL-API truncated text after 500kb, the exact limit is not documented but an `isTruncated` flag is provided: https://developer.github.com/v4/object/blob/

This uses the rest API, which has a documented limit of 100mb:
https://developer.github.com/v3/git/blobs/

Perf:
`gql` with text: 1500 – 1700ms  
`gql` without text: 480 – 630ms  
`rest` 2000 – 2100ms

I'd always do `gql` & `rest`, as implemented now. Adds ~1s to all (uncached) commit fetching. Other option would add 2s to documents over 500kb and no delay to regular. But since mostly large documents (aka magazin) have perf issue I'd prefer adding 1s to all.