### PR TITLE
keepalive middleware for /graphql

### DIFF
--- a/packages/base/express/graphql.js
+++ b/packages/base/express/graphql.js
@@ -11,6 +11,8 @@ const redis = require('../lib/redis')
 const elasticsearch = require('../lib/elastic')
 const { runHttpQuery } = require('apollo-server-core')
 
+const keepaliveMiddleware = require('./keepalive')
+
 checkEnv([
   'PUBLIC_WS_URL_BASE',
   'PUBLIC_WS_URL_PATH'
@@ -20,7 +22,8 @@ const {
   PUBLIC_WS_URL_PATH,
   NODE_ENV,
   ENGINE_API_KEY,
-  WS_KEEPALIVE_INTERVAL
+  WS_KEEPALIVE_INTERVAL,
+  RES_KEEPALIVE
 } = process.env
 
 // Custom Request Handler for clean way to intercept and modify response
@@ -45,11 +48,13 @@ function graphqlExpress (options) {
           gqlResponse = gqlResponse.replace(/\u2028/g, '')
         }
 
-        res.setHeader('Content-Type', 'application/json')
-        res.setHeader(
-          'Content-Length',
-          Buffer.byteLength(gqlResponse, 'utf8').toString()
-        )
+        if (!res.headersSent) {
+          res.setHeader('Content-Type', 'application/json')
+          res.setHeader(
+            'Content-Length',
+            Buffer.byteLength(gqlResponse, 'utf8').toString()
+          )
+        }
         res.write(gqlResponse)
         res.end()
       },
@@ -145,8 +150,11 @@ module.exports = (
   })
 
   server.use('/graphql',
-    bodyParser.json({limit: '128mb'}),
-    graphqlMiddleware
+    [
+      RES_KEEPALIVE ? keepaliveMiddleware : null,
+      bodyParser.json({limit: '128mb'}),
+      graphqlMiddleware
+    ].filter(Boolean)
   )
   server.use('/graphiql', graphiqlExpress({
     endpointURL: '/graphql',

--- a/packages/base/express/keepalive.js
+++ b/packages/base/express/keepalive.js
@@ -1,0 +1,53 @@
+// https://spin.atomicobject.com/2018/05/15/extending-heroku-timeout-node/
+const debug = require('debug')('base:keepalive')
+
+const {
+  RES_KEEPALIVE_MS = 15000
+} = process.env
+
+module.exports = (req, res, next) => {
+  const space = ' '
+  let isFinished = false
+  let isDataSent = false
+
+  res.once('finish', () => {
+    isFinished = true
+  })
+
+  res.once('end', () => {
+    isFinished = true
+  })
+
+  res.once('close', () => {
+    isFinished = true
+  })
+
+  res.on('data', (data) => {
+    // Look for something other than our blank space to indicate that real
+    // data is now being sent back to the client.
+    if (data !== space) {
+      isDataSent = true
+    }
+  })
+
+  const waitAndSend = () => {
+    setTimeout(() => {
+      // If the response hasn't finished and hasn't sent any data back....
+      if (!isFinished && !isDataSent) {
+        // Need to write the status code/headers if they haven't been sent yet.
+        if (!res.headersSent) {
+          res.writeHead(202)
+        }
+
+        res.write(space)
+        debug('sent keepalive')
+
+        // Wait another TIMEOUT_MS
+        waitAndSend()
+      }
+    }, RES_KEEPALIVE_MS)
+  }
+
+  waitAndSend()
+  next()
+}


### PR DESCRIPTION
enable with RES_KEEPALIVE=true env
sends (headers and) whitespace until response is ready

used to trick into heroku to think a response is being sent and thus avoids that the request gets rescheduled to other workers

source: https://spin.atomicobject.com/2018/05/15/extending-heroku-timeout-node/