### PR TITLE
fix(documents): Retrieve credits in a more appropriate manner

### DIFF
--- a/packages/documents/lib/meta.js
+++ b/packages/documents/lib/meta.js
@@ -3,42 +3,42 @@ const visit = require('unist-util-visit')
 const { metaFieldResolver } = require('./resolve')
 
 /**
- * If not available already, assign credits to doc.content.meta.
+ * Obtain credits from either {doc.content.children} or {doc.meta}.
  *
  * @param  {Object} doc An MDAST tree
- * @return {Object}     Returns maybe altered {doc}
+ * @return {Array}      MDAST children
  */
-const ensureCredits = doc => {
-  if (!doc.content.meta.credits) {
+const getCredits = doc => {
+  // If {doc.content} is available, always obtain credits from it.
+  if (doc.content && doc.content.children) {
+    let credits = []
+
     visit(doc.content, 'zone', node => {
       if (node.identifier === 'TITLE') {
         const paragraphs = node.children
           .filter(child => child.type === 'paragraph')
         if (paragraphs.length >= 2) {
-          Object.assign(
-            doc.content.meta,
-            { credits: paragraphs[paragraphs.length - 1].children }
-          )
+          credits = paragraphs[paragraphs.length - 1].children
         }
       }
     })
+
+    return credits
   }
 
-  return doc
+  // Due to perfomance considerations a {doc} might come in without
+  // {doc.content}, or only {doc.content.meta} without credits is provided (to
+  // resolve). In such a case, we look for {doc.meta.credits} to obtain credits.
+  return (doc.meta && doc.meta.credits) || []
 }
 
-const getMeta = doc => {
-  if (doc._meta) {
-    return doc._meta
-  }
-
-  // see _all note in Document.content resolver
-  const resolvedFields = doc._all
-    ? metaFieldResolver(doc.content.meta, doc._all)
-    : { }
-
-  ensureCredits(doc)
-
+/**
+ * Builds and an audioSource object from {doc.content.meta} for use in meta.
+ *
+ * @param  {Object}      doc An MDAST tree
+ * @return {Object|null}     e.g. { mp3: true, aac: null, ogg: null }
+ */
+const getAudioSource = doc => {
   const { audioSourceMp3, audioSourceAac, audioSourceOgg } = doc.content.meta
   const audioSource = audioSourceMp3 || audioSourceAac || audioSourceOgg ? {
     mp3: audioSourceMp3,
@@ -46,10 +46,35 @@ const getMeta = doc => {
     ogg: audioSourceOgg
   } : null
 
+  return audioSource
+}
+
+/**
+ * Prepares meta information and resolves linked documents in meta which are
+ * not available in original {doc.content.meta} fields.
+ *
+ * @param  {Object}      doc An MDAST tree
+ * @return {Object|null}     e.g. { audioSource: null, auto: true, [...] }
+ */
+const getMeta = doc => {
+  // If {doc._meta} is present, this indicates meta information was retrieved
+  // already.
+  if (doc._meta) {
+    return doc._meta
+  }
+
+  // see _all note in Document.content resolver
+  const resolvedFields = doc._all
+    ? metaFieldResolver(doc.content.meta, doc._all)
+    : {}
+
+  // Populate {doc._meta}. Is used to recognize provided {doc} for which meta
+  // information was retrieved already.
   doc._meta = {
     ...doc.content.meta,
-    ...resolvedFields,
-    audioSource
+    credits: getCredits(doc),
+    audioSource: getAudioSource(doc),
+    ...resolvedFields
   }
 
   return doc._meta

--- a/packages/documents/lib/meta.js
+++ b/packages/documents/lib/meta.js
@@ -39,6 +39,9 @@ const getCredits = doc => {
  * @return {Object|null}     e.g. { mp3: true, aac: null, ogg: null }
  */
 const getAudioSource = doc => {
+  if (!doc.content && doc.meta && doc.meta.audioSource) {
+    return doc.meta.audioSource
+  }
   const { audioSourceMp3, audioSourceAac, audioSourceOgg } = doc.content.meta
   const audioSource = audioSourceMp3 || audioSourceAac || audioSourceOgg ? {
     mp3: audioSourceMp3,


### PR DESCRIPTION
This Pull Request rewrites changes made in https://github.com/orbiting/backends/pull/103. I only came hereafter to understand concept of `doc.meta.credits` and `doc.content` and credit nodes.

There are two paths retrieving credits for documents:

- via `doc.content` and retrieving (visiting) meta children (Publikator and Search, default path) 
- Search may sometimes not provide (`doc.content`) due to performance considerations. In that case we attempt to retrieve credits via `doc.meta` (data stored in ElasticSearch).

Latter is currently the case when using search in frontend.