### PR TITLE
fix(Discussion): comment preview for unpublished comments

### DIFF
--- a/servers/republik/graphql/resolvers/Comment.js
+++ b/servers/republik/graphql/resolvers/Comment.js
@@ -88,10 +88,7 @@ module.exports = {
   preview: (comment, { length = 500 }, context) => {
     const text = textForComment(comment, context && context.user)
     if (!text) {
-      return {
-        string: text,
-        more: false
-      }
+      return null
     }
     return mdastToHumanString(remark.parse(text), length)
   },


### PR DESCRIPTION
According to the schema preview can be null but `Preview.string` not:
https://github.com/orbiting/backends/blob/ad8170c7899a071f7da6cb9af15b9cdc781dea0c/servers/republik/graphql/schema-types.js#L304-L307

https://github.com/orbiting/backends/blob/ad8170c7899a071f7da6cb9af15b9cdc781dea0c/servers/republik/graphql/schema-types.js#L323-L326

The current implementation explodes with unpublished text with `Cannot return null for non-nullable field Preview.string`.

However it looks like `preview` might be called somewhere else, for notifications?, too but I couldn't find it to verify if that can handle null instead of `{text: null: more: false}` (which is not gql schema compliant). Alt would be to return `{text: '', more: false}`.