### PR TITLE
Improve Q Results

### DIFF
--- a/packages/voting/graphql/resolvers/QuestionTypeChoice.js
+++ b/packages/voting/graphql/resolvers/QuestionTypeChoice.js
@@ -6,10 +6,15 @@ module.exports = {
       if (!question.result) {
         return question.result
       }
-      const { top } = args
-      return top
-        ? question.result.slice(0, top)
-        : question.result
+      const { top, min } = args
+      let result = question.result
+      if (min) {
+        result = result.filter(r => r.count >= min)
+      }
+      if (top) {
+        result = result.slice(0, top)
+      }
+      return result
     }
     if (!question.questionnaire.liveResult) {
       return null

--- a/packages/voting/graphql/resolvers/QuestionTypeDocument.js
+++ b/packages/voting/graphql/resolvers/QuestionTypeDocument.js
@@ -6,10 +6,15 @@ module.exports = {
       if (!question.result) {
         return question.result
       }
-      const { top } = args
-      return top
-        ? question.result.slice(0, top)
-        : question.result
+      const { top, min } = args
+      let result = question.result
+      if (min) {
+        result = result.filter(r => r.count >= min)
+      }
+      if (top) {
+        result = result.slice(0, top)
+      }
+      return result
     }
     if (!question.questionnaire.liveResult) {
       return null

--- a/packages/voting/graphql/schema-types.js
+++ b/packages/voting/graphql/schema-types.js
@@ -249,7 +249,7 @@ type QuestionTypeDocument implements QuestionInterface {
 
   template: String
 
-  result(top: Int): [QuestionTypeDocumentResult!]
+  result(top: Int, min: Int): [QuestionTypeDocumentResult!]
 }
 type QuestionTypeDocumentResult {
   # only null if the document doesn exist anymore
@@ -305,7 +305,7 @@ type QuestionTypeChoice implements QuestionInterface {
   cardinality: Int!
   options: [QuestionTypeChoiceOption!]!
 
-  result(top: Int): [QuestionTypeChoiceResult!]
+  result(top: Int, min: Int): [QuestionTypeChoiceResult!]
 }
 type QuestionTypeChoiceOption {
   label: String!

--- a/packages/voting/lib/Question/Choice.js
+++ b/packages/voting/lib/Question/Choice.js
@@ -19,7 +19,7 @@ const validate = (value, question, { t }) => {
   return false
 }
 
-const result = async (question, { top }, context) => {
+const result = async (question, { top, min }, context) => {
   const { pgdb } = context
   const aggs = await pgdb.query(`
     SELECT
@@ -32,12 +32,14 @@ const result = async (question, { top }, context) => {
       "questionId" = :questionId
     GROUP BY
       2
+    ${min ? 'HAVING COUNT(*) >= :min' : ''}
     ORDER BY
       1 DESC
     ${top ? 'LIMIT :top' : ''}
   `, {
     questionId: question.id,
-    top
+    top,
+    min
   })
   const options = question.options
     .map(option => {
@@ -48,9 +50,7 @@ const result = async (question, { top }, context) => {
       }
     })
     .sort((a, b) => descending(a.count, b.count))
-  return top
-    ? options.slice(0, top)
-    : options
+  return options
 }
 
 module.exports = {

--- a/packages/voting/lib/Question/Document.js
+++ b/packages/voting/lib/Question/Document.js
@@ -25,7 +25,7 @@ const validate = async (value, question, context, payload) => {
   return false
 }
 
-const result = async (question, { top }, context) => {
+const result = async (question, { top, min }, context) => {
   const { pgdb } = context
   const docs = await pgdb.query(`
     SELECT
@@ -38,12 +38,14 @@ const result = async (question, { top }, context) => {
       "questionId" = :questionId
     GROUP BY
       2
+    ${min ? 'HAVING COUNT(*) >= :min' : ''}
     ORDER BY
       1 DESC
     ${top ? 'LIMIT :top' : ''}
   `, {
     questionId: question.id,
-    top
+    top,
+    min
   })
     .then(aggs => aggs.map(agg => ({
       count: agg.count,

--- a/packages/voting/lib/Question/Range.js
+++ b/packages/voting/lib/Question/Range.js
@@ -67,11 +67,11 @@ const resultHistogram = async (result, { ticks }, context) => {
   const extent = d3.extent(
     questionTicks.map(t => t.value)
   )
-  const x = d3.scaleLinear()
-    .domain(extent).nice()
   const bins = d3.histogram()
-    .domain(x.domain())
-    .thresholds(x.ticks(numTicks))(values)
+    .domain(extent)
+    .thresholds(
+      d3.ticks(extent[0], extent[1], numTicks).slice(0, -1)
+    )(values)
 
   return bins.map(bin => ({
     ...bin,


### PR DESCRIPTION
Add min count argument for choices and documents. Fix extra bucket for max value.

*Histogram Before*
```json
[
  {
    "count": 8,
    "x0": -1,
    "x1": -0.9
  },
  {
    "count": 3,
    "x0": -0.9,
    "x1": -0.8
  },
  ...
  {
    "count": 276,
    "x0": 0.8,
    "x1": 0.9
  },
  {
    "count": 704,
    "x0": 0.9,
    "x1": 1
  },
  {
    "count": 0,
    "x0": 1,
    "x1": 1
  }
]
```

*After*

```json
[
  {
    "x0": -1,
    "x1": -0.9,
    "count": 4
  },
  {
    "x0": -0.9,
    "x1": -0.8,
    "count": 2
  },
  ...
  {
    "x0": 0.8,
    "x1": 0.9,
    "count": 176
  },
  {
    "x0": 0.9,
    "x1": 1,
    "count": 459
  }
]
```