### PR TITLE
Fix auto cancel MONTHLY_ABO, and pledge confirmation email for subscriptions

### DIFF
--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -180,7 +180,7 @@ mail.sendPledgeConfirmations = async ({ userId, pgdb, t }) => {
     const pledgePayment = await pgdb.public.pledgePayments.findFirst({pledgeId: pledge.id}, {orderBy: ['createdAt desc']})
     const payment = pledgePayment
       ? await pgdb.public.payments.findOne({id: pledgePayment.paymentId})
-      : null
+      : {}
 
     const notebook = await pgdb.public.pledgeOptions.count({
       pledgeId: pledge.id,

--- a/servers/republik/modules/crowdfundings/lib/generateMemberships.js
+++ b/servers/republik/modules/crowdfundings/lib/generateMemberships.js
@@ -8,6 +8,8 @@ const { enforceSubscriptions, sendMembershipProlongNotice } = require('./Mail')
 const Promise = require('bluebird')
 const omit = require('lodash/omit')
 
+const MONTHLY_ABO_UPGRADE_PKGS = ['ABO', 'BENEFACTOR']
+
 module.exports = async (pledgeId, pgdb, t, req, logger = console) => {
   const pledge = await pgdb.public.pledges.findOne({id: pledgeId})
   const user = await pgdb.public.users.findOne({id: pledge.userId})
@@ -157,7 +159,7 @@ module.exports = async (pledgeId, pgdb, t, req, logger = console) => {
           } else {
             // Cancel active memberships because bought package (option) contains
             // a better abo.
-            if (['ABO', 'BENEFACTOR_ABO'].includes(membershipType.name)) {
+            if (MONTHLY_ABO_UPGRADE_PKGS.includes(pkg.name)) {
               cancelableMemberships =
                 activeMemberships
                   .filter(m => (m.name === 'MONTHLY_ABO' && m.renew === true))


### PR DESCRIPTION
This Pull Request fixes faulty auto-cancellation. Before this fix we did cancel a `MONTHLY_ABO` membership whenever a `ABO` membershipType was available, hence also for `ABO_GIVE` packages. Code ensures only certain packages can cause an auto-cancellation: `ABO` and `BENEFACTOR`.

It also fixes an error when `payment` entity was not available while attempt to send a pledge confirmation email. It failed to send pledge confirmation as a merge variable accessed `payment.method`. Error occurred when users paid via Stripe, and caused a subscription (`MONTHLY_ABO`) where a payment is not instantly available but added upon a Stripe web hook response. Before pledge confirmations were only sent on hook triggers e.g. a login.