### PR TITLE
Fixes bugs when sending mail templates

### DIFF
--- a/packages/mail/lib/sendMailTemplate.js
+++ b/packages/mail/lib/sendMailTemplate.js
@@ -36,13 +36,18 @@ module.exports = async (mail, context, log) => {
     SEND_MAILS_TAGS && SEND_MAILS_TAGS.split(',')
   ).filter(Boolean)
 
-  const mergeVars = [
-    ...mail.globalMergeVars,
-    ...FRONTEND_BASE_URL
-      ? [{ name: 'frontend_base_url',
-        content: FRONTEND_BASE_URL }]
-      : []
-  ]
+  const mergeVars = []
+
+  if (mail.globalMergeVars) {
+    mergeVars.concat(mail.globalMergeVars)
+  }
+
+  if (FRONTEND_BASE_URL) {
+    mergeVars.push({
+      name: 'frontend_base_url',
+      content: FRONTEND_BASE_URL
+    })
+  }
 
   const message = {
     to: [{email: mail.to}],

--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -292,7 +292,7 @@ mail.sendPledgeConfirmations = async ({ userId, pgdb, t }) => {
     const donation = pledge.donation > 0 ? pledge.donation / 100 : 0
     const total = pledge.total / 100
 
-    return mail.sendMailTemplate({
+    return sendMailTemplate({
       to: user.email,
       fromEmail: process.env.DEFAULT_MAIL_FROM_ADDRESS,
       subject: t(`api/email/${templateName}/subject`),


### PR DESCRIPTION
This Pull Request fixes two bugs:

- Won't use `mail.createMail` wrapper when sending pledge confirmation emails. In fact unnecessary. Bug due to overwritten context when using fn `sendMailTemplate`.

```
error in payPledge after transactionCommit Error: missing input
    at send (backends/packages/mail/lib/mailLog.js:56:11)
    at module.exports (backends/packages/mail/lib/sendMailTemplate.js:69:10)
    at Object.sendMailTemplate (backends/packages/mail/NewsletterSubscription.js:45:20)
    at Promise.all.pledges.map (backends/servers/republik/modules/crowdfundings/lib/Mail.js:295:17)
```

- Spreading into array when `mail.globalMergeVars` is undefined failed. Fixed.

```
(node:65) UnhandledPromiseRejectionWarning: TypeError: mail.globalMergeVars is not iterable
    at module.exports (packages/mail/lib/sendMailTemplate.js:40:13)
    at Object.startChallenge (packages/auth/lib/challenges/AppChallenge.js:66:7)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```