### PR TITLE
Ignore prepublished document version on publish

### DIFF
--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -53,7 +53,7 @@ const deepMergeArrays = function (objValue, srcValue) {
 }
 
 const createShould = function (
-  searchTerm, searchFilter, indicesList, user, scheduledAt
+  searchTerm, searchFilter, indicesList, user, scheduledAt, ignorePrepublished
 ) {
   const queries = []
 
@@ -102,7 +102,7 @@ const createShould = function (
 
     const rolbasedFilterArgs = Object.assign(
       {},
-      { scheduledAt },
+      { scheduledAt, ignorePrepublished },
       getFilterObj(searchFilter)
     )
 
@@ -161,12 +161,12 @@ const createHighlight = (indicesList) => {
 
 const defaultExcludes = [ 'contentString', 'resolved' ]
 const createQuery = (
-  searchTerm, filter, sort, indicesList, user, scheduledAt, withoutContent, withoutAggs
+  searchTerm, filter, sort, indicesList, user, scheduledAt, withoutContent, withoutAggs, ignorePrepublished
 ) => ({
   query: {
     bool: {
       should: createShould(
-        searchTerm, filter, indicesList, user, scheduledAt
+        searchTerm, filter, indicesList, user, scheduledAt, ignorePrepublished
       )
     }
   },
@@ -343,6 +343,7 @@ const search = async (__, args, context, info) => {
     before,
     recursive = false,
     scheduledAt,
+    ignorePrepublished,
     trackingId = uuid(),
     withoutContent: _withoutContent,
     withoutRelatedDocs = false,
@@ -396,7 +397,7 @@ const search = async (__, args, context, info) => {
     index: indicesList.map(({ name }) => getIndexAlias(name, 'read')),
     from,
     size: first,
-    body: createQuery(search, filter, sort, indicesList, user, scheduledAt, withoutContent, withoutAggs)
+    body: createQuery(search, filter, sort, indicesList, user, scheduledAt, withoutContent, withoutAggs, ignorePrepublished)
   }
   debug('ES query', JSON.stringify(query))
 

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -192,7 +192,12 @@ const {
 const visit = require('unist-util-visit')
 const isUUID = require('is-uuid')
 
-const addRelatedDocs = async ({ connection, scheduledAt, context }) => {
+const addRelatedDocs = async ({
+  connection,
+  scheduledAt,
+  ignorePrepublished,
+  context
+}) => {
   const search = require('../graphql/resolvers/_queries/search')
   const { pgdb } = context
 
@@ -277,6 +282,7 @@ const addRelatedDocs = async ({ connection, scheduledAt, context }) => {
       recursive: true,
       withoutContent: true,
       scheduledAt,
+      ignorePrepublished,
       first: sanitizedSeriesRepoIds.length * 2,
       filter: {
         repoId: sanitizedSeriesRepoIds,
@@ -303,6 +309,7 @@ const addRelatedDocs = async ({ connection, scheduledAt, context }) => {
       recursive: true,
       withoutContent: true,
       scheduledAt,
+      ignorePrepublished,
       first: sanitizedRepoIds.length * 2,
       filter: {
         repoId: sanitizedRepoIds,

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -96,13 +96,10 @@ module.exports = {
       default: () => ({ bool: { must: [
         { term: { '__state.published': true } }
       ] } }),
+
       // Adopted filter when role "editor" is present
-      editor: ({ scheduledAt, id, ids } = {}) => {
+      editor: ({ scheduledAt, ignorePrepublished, id, ids } = {}) => {
         const should = [
-          { bool: { must: [
-            { term: { '__state.published': false } },
-            { term: { '__state.prepublished': true } }
-          ] } },
           { bool: { must: [
             { term: { '__state.published': true } },
             { term: { '__state.prepublished': true } }
@@ -113,6 +110,13 @@ module.exports = {
           should.push({ bool: { must: [
             { term: { 'meta.prepublication': false } },
             { range: { 'meta.scheduledAt': { lte: scheduledAt } } }
+          ] } })
+        }
+
+        if (!ignorePrepublished) {
+          should.push({ bool: { must: [
+            { term: { '__state.published': false } },
+            { term: { '__state.prepublished': true } }
           ] } })
         }
 

--- a/servers/publikator/graphql/resolvers/_mutations/publish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/publish.js
@@ -139,7 +139,12 @@ module.exports = async (
     ]
   })
 
-  await addRelatedDocs({ connection, scheduledAt, context })
+  await addRelatedDocs({
+    connection,
+    scheduledAt,
+    ignorePrepublished: !prepublication,
+    context
+  })
 
   const { _all, _usernames } = connection.nodes[0].entity
 


### PR DESCRIPTION
This Pull Request changes publikator publish mutation.

It now gathers related document versions which are published or scheduled to be published, and ignores prepublished ones. This should only render "healthy" article URLs when pushing a newsletter to MailChimp.

If a document is prepublished, it will include prepublished related document versions.