### PR TITLE
feat(github): Enable optional GitHub GraphQL API rate limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,6 +162,9 @@ DISPLAY_AUTHOR_SECRET=RANDOM
 # log ratelimit every 15min to stdout
 #GITHUB_LOG_RATELIMIT=true
 
+# Limit GraphQL request rate
+#GITHUB_GRAPHQL_RATELIMIT=true
+
 # List of all potential GitHub organizations data my stem from (optional)
 #GITHUB_ORGS=organization-one,organization-two
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "roleUser": "node packages/auth/script/roleUser",
     "roleUsers": "node packages/auth/script/roleUsers",
     "pull:redis": "node servers/publikator/script/pullRedis.js",
-    "pull:elasticsearch": "node packages/search/script/pullElasticsearch.js",
+    "pull:elasticsearch": "GITHUB_GRAPHQL_RATELIMIT=true node packages/search/script/pullElasticsearch.js",
     "db:migrate:up": "cd servers/republik && node script/db-migrate-all.js up",
     "sendNotification": "cd servers/republik && node ../../packages/notifications/script/sendNotification.js"
   }

--- a/packages/github/lib/clients.js
+++ b/packages/github/lib/clients.js
@@ -7,6 +7,7 @@ const GitHubApi = require('@octokit/rest')
 const appAuth = require('./appAuth')
 
 const {
+  REDIS_URL,
   GITHUB_GRAPHQL_RATELIMIT,
   GITHUB_LOG_RATELIMIT
 } = process.env
@@ -15,17 +16,42 @@ const DEV = process.env.NODE_ENV && process.env.NODE_ENV !== 'production'
 
 let installationToken
 let nextRateLimitCheck
-
-const limiter = new Bottleneck({
-  maxConcurrent: 1,
-  minTime: 200
-})
+let limiter
 
 if (GITHUB_GRAPHQL_RATELIMIT) {
-  setInterval(
-    () => { debug('bottleneck %o', { counts: limiter.counts() }) },
-    1000 * 10
-  ).unref()
+  debug('using bottleneck to limit GitHub GraphQL requests')
+
+  limiter = new Bottleneck({
+    maxConcurrent: 1,
+    minTime: 100,
+    trackDoneStatus: true,
+    id: 'github-graphql-limiter',
+
+    datastore: 'redis',
+    clientOptions: {
+      url: REDIS_URL
+    },
+
+    timeout: 1000 * 30
+  })
+
+  limiter.on('err', (err) => {
+    console.error(err)
+    debug('bottleneck error', err)
+  })
+
+  const limiterStats = async () => {
+    debug('bottleneck %o', {
+      local: limiter.counts(),
+      all: {
+        running: await limiter.running(),
+        done: await limiter.done()
+      }
+    })
+  }
+
+  // Log bottleneck status
+  setInterval(limiterStats, 1000 * 10).unref()
 }
 
 module.exports = async () => {
@@ -46,19 +72,44 @@ module.exports = async () => {
       options.headers['Accept'] = 'application/vnd.github.machine-man-preview+json'
       next()
     })
-    .useAfter(({ response }, next) => {
-      if (response && response.parsed && response.parsed.errors) {
-        const errors = response.parsed.errors
-        throw new Error(JSON.stringify(errors))
-      }
-      next()
-    })
 
   if (GITHUB_GRAPHQL_RATELIMIT) {
+    // Limit requests
     githubApolloFetch.use(async ({ options }, next) => {
       limiter.schedule(() => next())
     })
+
+    // Log limit if near rate limit
+    githubApolloFetch.useAfter(({ response: { headers } }, next) => {
+      const ratelimit = {
+        limit: headers.get('x-ratelimit-limit'),
+        remaining: headers.get('x-ratelimit-remaining'),
+        reset: headers.get('x-ratelimit-reset')
+      }
+
+      if (ratelimit.remaining < ratelimit.limit / 10) {
+        if (ratelimit.remaining > 0) {
+          console.warn(`Near GitHub GraphQL Rate Limit: ${ratelimit.remaining} request(s) left`)
+          debug('limits', {
+            ...ratelimit,
+            resetDate: new Date(ratelimit.reset * 1000).toString()
+          })
+        } else {
+          console.error(`GitHub GraphQL Rate Limit reached. Reset at ${new Date(ratelimit.reset * 1000).toString()}.`)
+        }
+      }
+
+      next()
+    })
   }
+
+  githubApolloFetch.useAfter(({ response }, next) => {
+    if (response && response.parsed && response.parsed.errors) {
+      const errors = response.parsed.errors
+      throw new Error(JSON.stringify(errors))
+    }
+    next()
+  })
 
   const githubRest = new GitHubApi({
     headers: {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -26,6 +26,7 @@
     "@octokit/rest": "^15.7.0",
     "apollo-fetch": "^0.7.0",
     "await-sleep": "^0.0.1",
+    "bottleneck": "^2.15.0",
     "check-env": "^1.3.0",
     "export-files": "^2.1.1",
     "jsonwebtoken": "^8.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1326,6 +1326,11 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
+bottleneck@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.15.0.tgz#538ec3a32f0e94a06e934bcb2080eb2c4c901c5a"
+  integrity sha512-6acQdvF7HfkbyDQAalnnsY5HGrrDrJ0QYie1/iL/IOch5oxhNVPRjqkIvOeCx4i6QyFi+ubxED/QRB1QWmWCJA==
+
 bowser@^1.7.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.3.tgz#6643ae4d783f31683f6d23156976b74183862162"


### PR DESCRIPTION
This Pull Request limits amount of requests to Github GraphQL.

- No more than 1 concurrent connection
- Wait minimum 200ms before querying again

Uses NPM package [bottleneck](https://www.npmjs.com/package/bottleneck) as a generic job queue. Would allow clustering via Redis.