### PR TITLE
Send T-7 email

### DIFF
--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('crowdfundings:lib:Mail')
+const moment = require('moment')
 
 const { createMail, sendMailTemplate } = require('@orbiting/backend-modules-mail')
 const { grants } = require('@orbiting/backend-modules-access')
@@ -579,6 +580,8 @@ mail.prepareMembershipOwnerNotice = async ({ user, endDate, cancelUntilDate, tem
   const customPledgeToken = AccessToken.generateForUser(user, 'CUSTOM_PLEDGE')
 
   const formattedEndDate = dateFormat(endDate)
+  const timeLeft = moment(endDate).diff(moment())
+  const daysLeft = Math.ceil(moment.duration(timeLeft).as('days'))
 
   return ({
     to: user.email,
@@ -594,6 +597,9 @@ mail.prepareMembershipOwnerNotice = async ({ user, endDate, cancelUntilDate, tem
       },
       { name: 'end_date',
         content: formattedEndDate
+      },
+      { name: 'days_left',
+        content: daysLeft >= 1 ? daysLeft : 1
       },
       { name: 'cancel_until_date',
         content: dateFormat(cancelUntilDate)

--- a/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
@@ -36,15 +36,17 @@ const createBuckets = (now) => [
     templateName: 'membership_owner_prolong_notice',
     minEndDate: getMinEndDate(now, 22),
     maxEndDate: getMaxEndDate(now, DAYS_BEFORE_END_DATE),
+    onlyMembershipTypes: ['ABO'],
     users: []
-  }
-  /*
+  },
   {
     templateName: 'membership_owner_prolong_notice_7',
     minEndDate: getMinEndDate(now, 5),
     maxEndDate: getMaxEndDate(now, 7),
+    onlyMembershipTypes: ['ABO'],
     users: []
-  },
+  }
+  /*
   {
     templateName: 'membership_owner_prolong_notice_2',
     minEndDate: getMinEndDate(now, 1),
@@ -58,22 +60,27 @@ const getBuckets = async ({ now }, { pgdb }) => {
   // load users with a membership
   const users = await pgdb.query(`
     SELECT
-      DISTINCT(u.*)
+      u.*,
+      json_agg(DISTINCT mt.name) AS "membershipTypes"
     FROM
-      users u
+      memberships m
+    INNER JOIN
+      users u ON m."userId" = u.id
+    INNER JOIN
+      "membershipTypes" mt ON m."membershipTypeId" = mt.id
     WHERE
-      u.id != :PARKING_USER_ID AND
-      u.id IN (
-        SELECT
-          DISTINCT(m."userId")
-        FROM
-          memberships m
-      )
+      m."userId" != :PARKING_USER_ID
+      AND m.active = true
+      AND m.renew = true
+    GROUP BY 1
   `, {
     PARKING_USER_ID
   })
     .then(users => users
-      .map(user => transformUser(user))
+      .map(user => ({
+        ...transformUser(user),
+        membershipTypes: user.membershipTypes
+      }))
     )
   debug(`investigating ${users.length} users for prolongBeforeDate`)
 
@@ -87,6 +94,8 @@ const getBuckets = async ({ now }, { pgdb }) => {
 
   const buckets = createBuckets(now)
 
+  debug('buckets %O', buckets)
+
   await Promise.each(
     users,
     async (user) => {
@@ -97,10 +106,24 @@ const getBuckets = async ({ now }, { pgdb }) => {
       )
         .then(date => date && moment(date))
 
-      stats.numNeedProlongProgress += 1
+      stats.numNeedProlongProgress++
 
       if (prolongBeforeDate) {
         const dropped = buckets.some(bucket => {
+          // Don't add user to bucket if user.membershipTypes does not contain
+          // any of memberships listed in bucket.onlyMembershipTypes.
+          if (bucket.onlyMembershipTypes) {
+            const hasNecessaryMembershipType = user.membershipTypes
+              .map(type => bucket.onlyMembershipTypes.includes(type))
+              .reduce((acc, cur) => !cur ? acc : cur, false)
+
+            if (!hasNecessaryMembershipType) {
+              return false
+            }
+          }
+
+          // Add user to bucket if prolongBeforeDate is between
+          // bucket.minEndDate and bucket.maxEndDate
           if (
             prolongBeforeDate.isAfter(bucket.minEndDate) &&
             prolongBeforeDate.isBefore(bucket.maxEndDate)
@@ -114,7 +137,7 @@ const getBuckets = async ({ now }, { pgdb }) => {
           return false
         })
         if (dropped) {
-          stats.numNeedProlong += 1
+          stats.numNeedProlong++
         }
       }
     },

--- a/servers/republik/modules/crowdfundings/lib/translations.json
+++ b/servers/republik/modules/crowdfundings/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-12-16T18:03:18.537Z",
+  "updated": "2019-01-08T12:47:33.669Z",
   "title": "live",
   "data": [
     {
@@ -472,6 +472,14 @@
     },
     {
       "key": "api/email/membership_owner_prolong_notice/subject",
+      "value": "Am {endDate} erneuert sich Ihre Mitgliedschaft"
+    },
+    {
+      "key": "api/email/membership_owner_prolong_notice_7/subject",
+      "value": "Am {endDate} erneuert sich Ihre Mitgliedschaft"
+    },
+    {
+      "key": "api/email/membership_owner_prolong_notice_2/subject",
       "value": "Am {endDate} erneuert sich Ihre Mitgliedschaft"
     }
   ]


### PR DESCRIPTION
This Pull Request sends T-7 email to ABO memberships. Other membership types are exempt from this email. Same rule applies to T-30 emails.

It keeps `prolongBeforeDate` query and adds days left as an additional merge variable.