### PR TITLE
Link PostFinance payments to receiving bank account

### DIFF
--- a/servers/republik/migrations/20190109074657-paymentslip-bank-accounts.js
+++ b/servers/republik/migrations/20190109074657-paymentslip-bank-accounts.js
@@ -1,0 +1,47 @@
+'use strict'
+
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20190109074657-paymentslip-bank-accounts-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20190109074657-paymentslip-bank-accounts-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+
+      resolve(data)
+    })
+  })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
+
+exports._meta = {
+  'version': 1
+}

--- a/servers/republik/migrations/sqls/20190109074657-paymentslip-bank-accounts-down.sql
+++ b/servers/republik/migrations/sqls/20190109074657-paymentslip-bank-accounts-down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "postfinancePayments" DROP COLUMN "bankAccountId";
+DROP TABLE "bankAccounts";

--- a/servers/republik/migrations/sqls/20190109074657-paymentslip-bank-accounts-up.sql
+++ b/servers/republik/migrations/sqls/20190109074657-paymentslip-bank-accounts-up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "bankAccounts" (
+  "id" uuid DEFAULT uuid_generate_v4(),
+  "companyId" uuid
+    REFERENCES companies(id)
+      ON DELETE SET NULL ON UPDATE CASCADE,
+  "iban" citext,
+  "label" text,
+  "createdAt" timestamp with time zone DEFAULT now(),
+  "updateAt" timestamp with time zone DEFAULT now(),
+  PRIMARY KEY ("id"),
+  UNIQUE ("iban")
+);
+
+ALTER TABLE "postfinancePayments"
+  ADD COLUMN "bankAccountId" uuid,
+  ADD FOREIGN KEY ("bankAccountId")
+    REFERENCES "public"."bankAccounts"("id")
+      ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/importPostfinanceCSV.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/importPostfinanceCSV.js
@@ -4,7 +4,7 @@ const matchPayments = require('../../../lib/payments/matchPayments')
 const {dsvFormat} = require('d3-dsv')
 const csvParse = dsvFormat(';').parse
 
-const parsePostfinanceExport = (inputFile) => {
+const parsePostfinanceExport = async (inputFile, pgdb) => {
   // sanitize input
   // trash first 5 lines as they contain another table with (Buchungsart, Konto, etc)
   // keys to lower case
@@ -15,11 +15,36 @@ const parsePostfinanceExport = (inputFile) => {
   const parseDate = ['Buchungsdatum', 'Valuta']
   const parseAmount = ['Gutschrift']
 
-  return csvParse(inputFile.split(/\r\n/).slice(3).join('\n'))
+  const delimitedFile = inputFile.split(/\r\n/)
+
+  const iban = delimitedFile.slice(0, 5).reduce((acc, row) => {
+    const parsedRow = row.match(/^Konto:;([A-Z0-9]{5,34})/)
+
+    if (!parsedRow) {
+      return acc
+    }
+
+    return parsedRow[1]
+  }, false)
+
+  console.log(iban)
+
+  if (!iban) {
+    throw new Error('Unable to find IBAN in provided file.')
+  }
+
+  const bankAccount = await pgdb.public.bankAccounts.findOne({ iban })
+  if (!bankAccount) {
+    throw new Error(
+      `Unable to determine bank account for IBAN "${iban}" in provided file.`
+    )
+  }
+
+  return csvParse(delimitedFile.slice(3).join('\n'))
     .filter(row => row.Gutschrift) // trash rows without gutschrift (such as lastschrift and footer)
     .filter(row => !/^EINZAHLUNGSSCHEIN/g.exec(row.Avisierungstext)) // trash useless EINZAHLUNGSSCHEIN
     .filter(row => !/^GUTSCHRIFT E-PAYMENT TRANSAKTION POSTFINANCE CARD/g.exec(row.Avisierungstext)) // trash PF CARD
-    .filter(row => !/^GUTSCHRIFT VON FREMDBANK (.*?) AUFTRAGGEBER: STRIPE/g.exec(row.Avisierungstext)) // trash stripe payments
+    .filter(row => !/^GUTSCHRIFT VON FREMDBANK AUFTRAGGEBER: STRIPE/ig.exec(row.Avisierungstext)) // trash stripe payments
     .map(row => {
       let newRow = {}
       Object.keys(row).forEach(key => {
@@ -43,6 +68,7 @@ const parsePostfinanceExport = (inputFile) => {
           }
         }
       })
+      newRow.bankAccountId = bankAccount.id
       return newRow
     })
 }
@@ -81,7 +107,7 @@ module.exports = async (_, args, {pgdb, req, t}) => {
 
   const input = Buffer.from(csv, 'base64').toString()
 
-  const paymentsInput = parsePostfinanceExport(input)
+  const paymentsInput = await parsePostfinanceExport(input, pgdb)
   if (paymentsInput.length === 0) {
     return 'input empty. done nothing.'
   }

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_queries/postfinancePayments.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_queries/postfinancePayments.js
@@ -17,49 +17,47 @@ module.exports = async (
     : '"createdAt" ASC'
 
   const filterActive = (dateRangeFilter || stringArrayFilter || booleanFilter)
-  const items = !(search || filterActive)
-    ? await pgdb.public.postfinancePayments.findAll({
-      limit,
-      offset,
-      orderBy: orderByTerm
-    })
-    : await pgdb.query(`
-        SELECT
-          pfp.id AS id,
-          pfp.buchungsdatum AS buchungsdatum,
-          pfp.valuta AS valuta,
-          pfp.avisierungstext AS avisierungstext,
-          pfp.gutschrift AS gutschrift,
-          pfp.mitteilung AS mitteilung,
-          pfp.matched AS matched,
-          pfp.hidden AS hidden,
-          pfp."createdAt" AS "createdAt",
-          pfp."updatedAt" AS "updatedAt",
-          concat_ws(' ',
-            pfp.mitteilung::text,
-            pfp.avisierungstext::text
-          ) <->> :search AS word_sim
-        FROM
-          "postfinancePayments" pfp
-        ${filterActive ? 'WHERE' : ''}
-          ${andFilters([
-            dateRangeFilterWhere(dateRangeFilter),
-            stringArrayFilterWhere(stringArrayFilter),
-            booleanFilterWhere(booleanFilter)
-          ])}
-        ORDER BY
-          ${search ? 'word_sim' : orderByTerm}
-        OFFSET :offset
-        LIMIT :limit
-      `, {
-        search: search ? search.trim() : null,
-        fromDate: dateRangeFilter ? dateRangeFilter.from : null,
-        toDate: dateRangeFilter ? dateRangeFilter.to : null,
-        stringArray: stringArrayFilter ? stringArrayFilter.values : null,
-        booleanValue: booleanFilter ? booleanFilter.value : null,
-        limit,
-        offset
-      })
+  const items = await pgdb.query(`
+    SELECT
+      pfp.id AS id,
+      ba.label AS konto,
+      ba.iban AS iban,
+      pfp.buchungsdatum AS buchungsdatum,
+      pfp.valuta AS valuta,
+      pfp.avisierungstext AS avisierungstext,
+      pfp.gutschrift AS gutschrift,
+      pfp.mitteilung AS mitteilung,
+      pfp.matched AS matched,
+      pfp.hidden AS hidden,
+      pfp."createdAt" AS "createdAt",
+      pfp."updatedAt" AS "updatedAt",
+      concat_ws(' ',
+        pfp.mitteilung::text,
+        pfp.avisierungstext::text
+      ) <->> :search AS word_sim
+    FROM
+      "postfinancePayments" pfp
+    LEFT OUTER JOIN "bankAccounts" ba
+      ON ba.id = pfp."bankAccountId"
+    ${filterActive ? 'WHERE' : ''}
+      ${andFilters([
+    dateRangeFilterWhere(dateRangeFilter),
+    stringArrayFilterWhere(stringArrayFilter),
+    booleanFilterWhere(booleanFilter)
+  ])}
+    ORDER BY
+      ${search ? 'word_sim' : orderByTerm}
+    OFFSET :offset
+    LIMIT :limit
+  `, {
+    search: search ? search.trim() : null,
+    fromDate: dateRangeFilter ? dateRangeFilter.from : null,
+    toDate: dateRangeFilter ? dateRangeFilter.to : null,
+    stringArray: stringArrayFilter ? stringArrayFilter.values : null,
+    booleanValue: booleanFilter ? booleanFilter.value : null,
+    limit,
+    offset
+  })
 
   const count = await pgdb.public.postfinancePayments.count()
   return { items, count }

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_queries/postfinancePayments.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_queries/postfinancePayments.js
@@ -17,6 +17,11 @@ module.exports = async (
     : '"createdAt" ASC'
 
   const filterActive = (dateRangeFilter || stringArrayFilter || booleanFilter)
+  const andFiltersStmt = andFilters([
+    dateRangeFilterWhere(dateRangeFilter),
+    stringArrayFilterWhere(stringArrayFilter),
+    booleanFilterWhere(booleanFilter)
+  ])
   const items = await pgdb.query(`
     SELECT
       pfp.id AS id,
@@ -40,11 +45,7 @@ module.exports = async (
     LEFT OUTER JOIN "bankAccounts" ba
       ON ba.id = pfp."bankAccountId"
     ${filterActive ? 'WHERE' : ''}
-      ${andFilters([
-    dateRangeFilterWhere(dateRangeFilter),
-    stringArrayFilterWhere(stringArrayFilter),
-    booleanFilterWhere(booleanFilter)
-  ])}
+      ${andFiltersStmt}
     ORDER BY
       ${search ? 'word_sim' : orderByTerm}
     OFFSET :offset

--- a/servers/republik/modules/crowdfundings/graphql/schema-types.js
+++ b/servers/republik/modules/crowdfundings/graphql/schema-types.js
@@ -376,6 +376,8 @@ type PostfinancePayment {
   id: ID!
   buchungsdatum: Date!
   valuta: Date!
+  konto: String!
+  iban: String!
   avisierungstext: String!
   gutschrift: Int!
   mitteilung: String


### PR DESCRIPTION
This Pull Request creates table `bankAccounts` with an `iban` and `label` prop. It then attempts to recognize in uploaded PostFinance payment files to which account import belongs to and will link them in `postfinancePayments`.

It does not (yet) validate if payment was expected on a bank account.