### PR TITLE
Schedulers to changeover or deactivate memberships

### DIFF
--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -23,6 +23,10 @@ const init = async ({
     console.error(`runFunc not executable, scheduler ${name}`, { name, runFunc })
     throw new Error(`runFunc not executable, scheduler ${name}`)
   }
+  if (runIntervalSecs < lockTtlSecs) {
+    console.error(`lockTtlSecs bigger than runIntervalSecs`, { runIntervalSecs, lockTtlSecs })
+    throw new Error(`lockTtlSecs bigger than runIntervalSecs, scheduler ${name}`)
+  }
 
   const { redis } = context
   if (!redis) {

--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -28,6 +28,10 @@ const init = async ({
     throw new Error(`lockTtlSecs bigger than runIntervalSecs, scheduler ${name}`)
   }
 
+  if (dryRun) {
+    console.warn(`WARNING: dryRun flag enabled, scheduler "${name}"`)
+  }
+
   const { redis } = context
   if (!redis) {
     throw new Error('missing redis')

--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -12,7 +12,7 @@ const init = async ({
   runFunc,
   lockTtlSecs,
   runIntervalSecs,
-  runInitially = false,
+  runInitially = true,
   runDry = false
 }) => {
   if (!name || !context || !runFunc || !lockTtlSecs || !runIntervalSecs) {

--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -19,15 +19,10 @@ const init = async ({
     console.error(`missing input, scheduler ${name}`, { name, context, runFunc, lockTtlSecs, runIntervalSecs })
     throw new Error(`missing input, scheduler ${name}`)
   }
-  if (!Array.isArray(runFunc) && typeof runFunc !== 'function') {
-    console.error(`runFunc not executable, scheduler ${name}`, { name, runFunc })
-    throw new Error(`runFunc not executable, scheduler ${name}`)
-  }
   if (runIntervalSecs < lockTtlSecs) {
     console.error(`lockTtlSecs bigger than runIntervalSecs`, { runIntervalSecs, lockTtlSecs })
     throw new Error(`lockTtlSecs bigger than runIntervalSecs, scheduler ${name}`)
   }
-
   if (dryRun) {
     console.warn(`WARNING: dryRun flag enabled, scheduler "${name}"`)
   }
@@ -76,11 +71,7 @@ const init = async ({
       debug('run started')
 
       try {
-        if (Array.isArray(runFunc)) {
-          await Promise.each(runFunc, f => f({ dryRun }, context))
-        } else if (typeof runFunc === 'function') {
-          await runFunc({ dryRun }, context)
-        }
+        await runFunc({ dryRun }, context)
       } catch (e) {
         console.error('scheduled run failed', e)
       } finally {

--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -1,0 +1,93 @@
+const Redlock = require('redlock')
+
+const LOCK_RETRY_COUNT = 3
+const LOCK_RETRY_DELAY = 600
+const LOCK_RETRY_JITTER = 200
+const MIN_TTL_MS = LOCK_RETRY_COUNT * (LOCK_RETRY_DELAY + LOCK_RETRY_JITTER)
+
+const init = async ({
+  name,
+  context,
+  runFunc,
+  lockTtlSecs,
+  runIntervalSecs,
+  runInitially = false
+}) => {
+  if (!name || !context || !runFunc || !lockTtlSecs || !runIntervalSecs) {
+    throw new Error('missing input', { name, context, runFunc, lockTtlSecs, runIntervalSecs })
+  }
+  const { redis } = context
+  if (!redis) {
+    throw new Error('missing redis')
+  }
+  const debug = require('debug')(`scheduler:${name}`)
+  debug('init')
+
+  const scheduleNextRun = () => {
+    // Set timeout slightly off to usual interval
+    setTimeout(run, 1000 * (runIntervalSecs + 1)).unref()
+  }
+
+  const redlock = () => {
+    return new Redlock(
+      [redis],
+      {
+        driftFactor: 0.01, // time in ms
+        retryCount: LOCK_RETRY_COUNT,
+        retryDelay: LOCK_RETRY_DELAY,
+        retryJitter: LOCK_RETRY_JITTER
+      }
+    )
+  }
+
+  if (lockTtlSecs * 1000 < MIN_TTL_MS) {
+    throw new Error(`lockTtlSecs must be at least ${Math.ceil(MIN_TTL_MS / 1000)})`, { lockTtlSecs })
+  }
+
+  const run = async () => {
+    try {
+      const lock = await redlock()
+        .lock(`locks:${name}-scheduler`, 1000 * lockTtlSecs)
+
+      debug('run started')
+
+      await runFunc({}, context)
+
+      // wait until other processes exceeded waiting time
+      // then give up lock
+      setTimeout(
+        () => {
+          lock.unlock()
+            .then(lock => { debug('unlocked') })
+            .catch(e => { console.warn('unlocking failed', e) })
+        },
+        1.5 * MIN_TTL_MS
+      )
+
+      debug('run completed')
+    } catch (e) {
+      if (e.name === 'LockError') {
+        if (e.attempts && e.attempts > LOCK_RETRY_COUNT) {
+          debug('give up, others are doing the work:', e.message)
+        } else {
+          debug('run failed', e.message)
+        }
+      } else {
+        throw e
+      }
+    } finally {
+      scheduleNextRun()
+    }
+  }
+
+  if (runInitially) {
+    debug('run initially')
+    return run()
+  } else {
+    return scheduleNextRun()
+  }
+}
+
+module.exports = {
+  init
+}

--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -71,15 +71,19 @@ const init = async ({
 
       debug('run started')
 
-      if (Array.isArray(runFunc)) {
-        await Promise.each(runFunc, f => f({ runDry }, context))
-      } else if (typeof runFunc === 'function') {
-        await runFunc({ runDry }, context)
+      try {
+        if (Array.isArray(runFunc)) {
+          await Promise.each(runFunc, f => f({ runDry }, context))
+        } else if (typeof runFunc === 'function') {
+          await runFunc({ runDry }, context)
+        }
+      } catch (e) {
+        console.error('scheduled run failed', e)
+      } finally {
+        // remove interval to extend lock in case runFunc takes longer than
+        // initial lock ttl.
+        clearInterval(extendLockInterval)
       }
-
-      // remove interval to extend lock in case runFunc takes longer than
-      // initial lock ttl.
-      clearInterval(extendLockInterval)
 
       // wait until other processes exceeded waiting time
       // then give up lock

--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -64,8 +64,9 @@ const init = async ({
       const extendLockInterval = setInterval(
         async () =>
           lock.extend(1000 * lockTtlSecs)
-            .then(() => { debug('extending lock') }),
-        1000 * lockTtlSecs * 0.95
+            .then(() => { debug('extending lock') })
+            .catch(e => { console.warn('extending lock failed', e) }),
+        1000 * lockTtlSecs * 0.9
       )
 
       debug('run started')

--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -66,7 +66,7 @@ const init = async ({
         .lock(`locks:${name}-scheduler`, 1000 * lockTtlSecs)
 
       const extendLockInterval = setInterval(
-        async () =>
+        () =>
           lock.extend(1000 * lockTtlSecs)
             .then(() => { debug('extending lock') })
             .catch(e => { console.warn('extending lock failed', e) }),
@@ -91,12 +91,10 @@ const init = async ({
 
       // wait until other processes exceeded waiting time
       // then give up lock
-      setTimeout(
-        async () =>
-          lock.unlock()
-            .then(() => { debug('unlocked') })
-            .catch(e => { console.warn('unlocking failed', e) }),
-        1.5 * MIN_TTL_MS
+      await Promise.delay(MIN_TTL_MS * 1.5).then(
+        () => lock.unlock()
+          .then(() => { debug('unlocked') })
+          .catch(e => { console.warn('unlocking failed', e) })
       )
 
       debug('run completed')

--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -13,7 +13,7 @@ const init = async ({
   lockTtlSecs,
   runIntervalSecs,
   runInitially = true,
-  runDry = false
+  dryRun = false
 }) => {
   if (!name || !context || !runFunc || !lockTtlSecs || !runIntervalSecs) {
     console.error(`missing input, scheduler ${name}`, { name, context, runFunc, lockTtlSecs, runIntervalSecs })
@@ -73,9 +73,9 @@ const init = async ({
 
       try {
         if (Array.isArray(runFunc)) {
-          await Promise.each(runFunc, f => f({ runDry }, context))
+          await Promise.each(runFunc, f => f({ dryRun }, context))
         } else if (typeof runFunc === 'function') {
-          await runFunc({ runDry }, context)
+          await runFunc({ dryRun }, context)
         }
       } catch (e) {
         console.error('scheduled run failed', e)

--- a/packages/schedulers/lib/timeScheduler.js
+++ b/packages/schedulers/lib/timeScheduler.js
@@ -82,10 +82,11 @@ const init = async ({
         .lock(`locks:${name}-scheduler`, 1000 * lockTtlSecs)
 
       const extendLockInterval = setInterval(
-        async () =>
+        () =>
           lock.extend(1000 * lockTtlSecs)
-            .then(() => { debug('extending lock') }),
-        1000 * lockTtlSecs * 0.95
+            .then(() => { debug('extending lock') })
+            .catch(e => { console.warn('extending lock failed', e) }),
+        1000 * lockTtlSecs * 0.9
       )
 
       debug('run started')
@@ -108,12 +109,10 @@ const init = async ({
 
       // wait until other processes exceeded waiting time
       // then give up lock
-      setTimeout(
-        async () =>
-          lock.unlock()
-            .then(() => { debug('unlocked') })
-            .catch(e => { console.warn('unlocking failed', e) }),
-        1.5 * MIN_TTL_MS
+      await Promise.delay(MIN_TTL_MS * 1.5).then(
+        () => lock.unlock()
+          .then(() => { debug('unlocked') })
+          .catch(e => { console.warn('unlocking failed', e) })
       )
 
       debug('run completed')

--- a/packages/schedulers/lib/timeScheduler.js
+++ b/packages/schedulers/lib/timeScheduler.js
@@ -22,14 +22,9 @@ const init = async ({
     console.error(`missing input, scheduler ${name}`, { name, context, runFunc, lockTtlSecs, runAtTime })
     throw new Error(`missing input, scheduler ${name}`)
   }
-  if (!Array.isArray(runFunc) && typeof runFunc !== 'function') {
-    console.error(`runFunc not executable, scheduler ${name}`, { name, runFunc })
-    throw new Error(`runFunc not executable, scheduler ${name}`)
-  }
   if (runAtDaysOfWeek.length < 1) {
     throw new Error('runAtDaysOfWeek must at least have one entry')
   }
-
   if (dryRun) {
     console.warn(`WARNING: dryRun flag enabled, scheduler "${name}"`)
   }
@@ -93,12 +88,7 @@ const init = async ({
 
       try {
         const now = moment()
-
-        if (Array.isArray(runFunc)) {
-          await Promise.each(runFunc, f => f({ now, dryRun }, context))
-        } else if (typeof runFunc === 'function') {
-          await runFunc({ now, dryRun }, context)
-        }
+        await runFunc({ now, dryRun }, context)
       } catch (e) {
         console.error('scheduled run failed', e)
       } finally {

--- a/packages/schedulers/lib/timeScheduler.js
+++ b/packages/schedulers/lib/timeScheduler.js
@@ -29,6 +29,11 @@ const init = async ({
   if (runAtDaysOfWeek.length < 1) {
     throw new Error('runAtDaysOfWeek must at least have one entry')
   }
+
+  if (dryRun) {
+    console.warn(`WARNING: dryRun flag enabled, scheduler "${name}"`)
+  }
+
   const { redis } = context
   if (!redis) {
     throw new Error('missing redis')

--- a/packages/schedulers/lib/timeScheduler.js
+++ b/packages/schedulers/lib/timeScheduler.js
@@ -16,7 +16,7 @@ const init = async ({
   runAtTime,
   runAtDaysOfWeek = [1, 2, 3, 4, 5, 6, 7],
   runInitially = false,
-  runDry = false
+  dryRun = false
 }) => {
   if (!name || !context || !runFunc || !lockTtlSecs || !runAtTime) {
     console.error(`missing input, scheduler ${name}`, { name, context, runFunc, lockTtlSecs, runAtTime })
@@ -89,9 +89,9 @@ const init = async ({
         const now = moment()
 
         if (Array.isArray(runFunc)) {
-          await Promise.each(runFunc, f => f({ now, runDry }, context))
+          await Promise.each(runFunc, f => f({ now, dryRun }, context))
         } else if (typeof runFunc === 'function') {
-          await runFunc({ now, runDry }, context)
+          await runFunc({ now, dryRun }, context)
         }
       } catch (e) {
         console.error('scheduled run failed', e)

--- a/packages/schedulers/lib/timeScheduler.js
+++ b/packages/schedulers/lib/timeScheduler.js
@@ -85,16 +85,21 @@ const init = async ({
 
       debug('run started')
 
-      const now = moment()
-      if (Array.isArray(runFunc)) {
-        await Promise.each(runFunc, f => f({ now, runDry }, context))
-      } else if (typeof runFunc === 'function') {
-        await runFunc({ now, runDry }, context)
-      }
+      try {
+        const now = moment()
 
-      // remove interval to extend lock in case runFunc takes longer than
-      // initial lock ttl.
-      clearInterval(extendLockInterval)
+        if (Array.isArray(runFunc)) {
+          await Promise.each(runFunc, f => f({ now, runDry }, context))
+        } else if (typeof runFunc === 'function') {
+          await runFunc({ now, runDry }, context)
+        }
+      } catch (e) {
+        console.error('scheduled run failed', e)
+      } finally {
+        // remove interval to extend lock in case runFunc takes longer than
+        // initial lock ttl.
+        clearInterval(extendLockInterval)
+      }
 
       // wait until other processes exceeded waiting time
       // then give up lock

--- a/servers/republik/modules/crowdfundings/graphql/schema-types.js
+++ b/servers/republik/modules/crowdfundings/graphql/schema-types.js
@@ -164,6 +164,7 @@ enum MembershipPeriodKind {
   REGULAR
   BONUS # Bonus period upon checkout
   ADMIN # A bonus period granted via admins, supporter
+  CHANGEOVER # Period upon changeover from one membership to other
 }
 
 type MembershipPeriod {

--- a/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
@@ -33,8 +33,8 @@ const changeover = async (
   const endDate = moment()
 
   const users = await pgdb.public.query(`
-    WITH users AS (${activeMembershipsQuery})
-    SELECT DISTINCT("userId") AS id FROM users
+    WITH memberships AS (${activeMembershipsQuery})
+    SELECT DISTINCT("userId") AS id FROM memberships
     WHERE
       -- Potential ending memberships to change over to dormant membership
       "endDate" < :endDate

--- a/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
@@ -8,6 +8,7 @@ const {
 } = require('../CustomPackages')
 
 const createCache = require('../cache')
+const { getLastEndDate } = require('../utils')
 
 const EXCLUDE_MEMBERSHIP_TYPES = ['MONTHLY_ABO']
 
@@ -66,6 +67,14 @@ const changeover = async (
       }
 
       const activeMembership = userMemberships.find(m => m.active)
+      if (moment(getLastEndDate(activeMembership.periods)) > endDate) {
+        console.error(
+          'changeover failed: active memberships ends later',
+          { user, endDate }
+        )
+        return
+      }
+
       const dormantMemberships = findDormantMemberships({
         memberships: userMemberships,
         user: { id: user.id }

--- a/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
@@ -27,7 +27,7 @@ GROUP BY m.id
 `
 
 const changeover = async (
-  { runDry },
+  { dryRun },
   { pgdb, mail: { enforceSubscriptions } }
 ) => {
   const endDate = moment()
@@ -105,12 +105,12 @@ const changeover = async (
           id: electedDormantMembership.id,
           type: electedDormantMembership.membershipType.name
         },
-        runDry
+        dryRun
       })
 
       stats.changeover++
 
-      if (runDry) {
+      if (dryRun) {
         return
       }
 
@@ -164,7 +164,7 @@ const changeover = async (
     }
   )
 
-  debug({ stats, runDry })
+  debug({ stats, dryRun })
 }
 
 module.exports = {

--- a/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
@@ -81,12 +81,12 @@ const changeover = async (
         user: { id: user.id }
       })
 
-      // End here if there is not dormant membership to be found
+      // End here if there is no dormant membership to be found
       if (dormantMemberships.length < 1) {
         return
       }
 
-      // Elect a dormant membership to activate. Rule is to elect dorman
+      // Elect a dormant membership to activate. Rule is to elect dormant
       // membership with lowest sequenceNumber
       const electedDormantMembership = dormantMemberships.reduce(
         (acc, curr) =>

--- a/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
@@ -130,10 +130,7 @@ const changeover = async (
           updatedAt: now
         })
 
-        await enforceSubscriptions({ userId: user.id, pgdb })
-
-        const cache = createCache({ prefix: `User:${user.id}` })
-        cache.invalidate()
+        createCache({ prefix: `User:${user.id}` }).invalidate()
 
         await transaction.transactionCommit()
       } catch (e) {
@@ -144,6 +141,8 @@ const changeover = async (
         )
         throw e
       }
+
+      await enforceSubscriptions({ userId: user.id, pgdb })
     }
   )
 

--- a/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/changeover.js
@@ -120,8 +120,7 @@ const changeover = async (
           { id: electedDormantMembership.id },
           {
             active: true,
-            renew: true,
-            sequenceNumber: activeMembership.sequenceNumber,
+            renew: activeMembership.renew,
             updatedAt: now
           }
         )

--- a/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
@@ -23,14 +23,14 @@ const deactivate = async (
     moment().startOf('day').subtract(UNCANCELLED_GRACE_PERIOD_DAYS, 'days')
 
   const memberships = await pgdb.public.query(`
-    WITH md AS (${activeMembershipsQuery})
-    SELECT * FROM md
+    WITH memberships AS (${activeMembershipsQuery})
+    SELECT * FROM memberships
     WHERE
       -- Cancelled memberships
-      ( md.renew = false AND "endDate" < :cancelledEndDate )
+      ( renew = false AND "endDate" < :cancelledEndDate )
       OR
       -- Uncancelled memberships (flagged to renew, but were not)
-      ( md.renew = true AND "endDate" < :uncancelledEndDate )
+      ( renew = true AND "endDate" < :uncancelledEndDate )
   `, { cancelledEndDate, uncancelledEndDate })
 
   debug({

--- a/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
@@ -68,7 +68,7 @@ const deactivate = async (
       try {
         await transaction.public.memberships.update(
           { id: membership.id },
-          { active: false, renew: false, updatedAt: moment() }
+          { active: false, updatedAt: moment() }
         )
 
         createCache({ prefix: `User:${membership.userId}` }).invalidate()

--- a/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
@@ -1,0 +1,64 @@
+const debug = require('debug')('crowdfundings:lib:scheduler:deactivate')
+const moment = require('moment')
+const Promise = require('bluebird')
+
+// Amount of days before a cancelled membership is deactivated after membership
+// periods end
+const CANCELLED_GRACE_PERIOD_DAYS = 0
+
+// Amount of days before an uncancelled uncancelled membership is deactivated
+// after membership periods end
+const UNCANCELLED_GRACE_PERIOD_DAYS = 14
+
+const deactivate = async (args, { pgdb, mail: { enforceSubscriptions } }) => {
+  const cancelledEndDate =
+    moment().startOf('day').subtract(CANCELLED_GRACE_PERIOD_DAYS, 'days')
+  const uncancelledEndDate =
+    moment().startOf('day').subtract(UNCANCELLED_GRACE_PERIOD_DAYS, 'days')
+
+  const memberships = await pgdb.public.query(`
+    SELECT * FROM (
+      -- Active memberships and their MAX(membershipPeriods.endDate)
+      SELECT m.*, MAX(mp."endDate") AS "endDate"
+      FROM memberships m
+      INNER JOIN "membershipPeriods" mp
+        ON m.id = mp."membershipId"
+      INNER JOIN "membershipTypes" mt
+        ON m."membershipTypeId" = mt.id
+        AND mt.name != 'MONTHLY_ABO' -- Exclude subscription via Stripe
+      WHERE
+        m.active = true
+      GROUP BY 1, 2
+    ) AS md
+    WHERE
+      -- Cancelled memberships
+      ( md.renew = false AND "endDate" < :cancelledEndDate )
+      OR
+      -- Uncancelled memberships (flagged to renew, but were not)
+      ( md.renew = true AND "endDate" < :uncancelledEndDate )
+    LIMIT 1000
+  `, { cancelledEndDate, uncancelledEndDate })
+
+  debug({
+    cancelledEndDate: cancelledEndDate.toDate(),
+    uncancelledEndDate: uncancelledEndDate.toDate(),
+    memberships: memberships.length
+  })
+
+  await Promise.map(
+    memberships,
+    async membership => {
+      await pgdb.public.memberships.update(
+        { id: membership.id },
+        { active: false, renew: false, updatedAt: moment() }
+      )
+
+      await enforceSubscriptions({ userId: membership.userId, pgdb })
+    },
+    { concurrency: 10 }
+  )
+}
+
+module.exports = {
+  deactivate
+}

--- a/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
@@ -5,12 +5,12 @@ const Promise = require('bluebird')
 const createCache = require('../cache')
 const { activeMembershipsQuery } = require('./changeover')
 
-// Amount of days before a cancelled membership is deactivated after membership
-// periods end
+// Amount of days before a cancelled membership (renew=false) is deactivated
+// after last membership periods end
 const CANCELLED_GRACE_PERIOD_DAYS = 0
 
-// Amount of days before an uncancelled uncancelled membership is deactivated
-// after membership periods end
+// Amount of days before an uncancelled membership (renew=true) is deactivated
+// after last membership periods end
 const UNCANCELLED_GRACE_PERIOD_DAYS = 14
 
 const deactivate = async (

--- a/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
@@ -2,6 +2,8 @@ const debug = require('debug')('crowdfundings:lib:scheduler:deactivate')
 const moment = require('moment')
 const Promise = require('bluebird')
 
+const createCache = require('../cache')
+
 // Amount of days before a cancelled membership is deactivated after membership
 // periods end
 const CANCELLED_GRACE_PERIOD_DAYS = 0
@@ -48,12 +50,25 @@ const deactivate = async (args, { pgdb, mail: { enforceSubscriptions } }) => {
   await Promise.map(
     memberships,
     async membership => {
-      await pgdb.public.memberships.update(
-        { id: membership.id },
-        { active: false, renew: false, updatedAt: moment() }
-      )
+      const transaction = await pgdb.transactionBegin()
 
-      await enforceSubscriptions({ userId: membership.userId, pgdb })
+      try {
+        await transaction.public.memberships.update(
+          { id: membership.id },
+          { active: false, renew: false, updatedAt: moment() }
+        )
+
+        await enforceSubscriptions({ userId: membership.userId, pgdb })
+
+        const cache = createCache({ prefix: `User:${membership.userId}` })
+        cache.invalidate()
+
+        await transaction.transactionCommit()
+      } catch (e) {
+        await transaction.transactionRollback()
+        console.log('transaction rollback', { membership, error: e })
+        throw e
+      }
     },
     { concurrency: 10 }
   )

--- a/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
@@ -71,10 +71,7 @@ const deactivate = async (
           { active: false, renew: false, updatedAt: moment() }
         )
 
-        await enforceSubscriptions({ userId: membership.userId, pgdb })
-
-        const cache = createCache({ prefix: `User:${membership.userId}` })
-        cache.invalidate()
+        createCache({ prefix: `User:${membership.userId}` }).invalidate()
 
         await transaction.transactionCommit()
       } catch (e) {
@@ -82,6 +79,8 @@ const deactivate = async (
         console.log('transaction rollback', { membership, error: e })
         throw e
       }
+
+      await enforceSubscriptions({ userId: membership.userId, pgdb })
     }
   )
 }

--- a/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
@@ -14,7 +14,7 @@ const CANCELLED_GRACE_PERIOD_DAYS = 0
 const UNCANCELLED_GRACE_PERIOD_DAYS = 14
 
 const deactivate = async (
-  { runDry },
+  { dryRun },
   { pgdb, mail: { enforceSubscriptions } }
 ) => {
   const cancelledEndDate =
@@ -37,14 +37,14 @@ const deactivate = async (
     cancelledEndDate: cancelledEndDate.toDate(),
     uncancelledEndDate: uncancelledEndDate.toDate(),
     memberships: memberships.length,
-    runDry
+    dryRun
   })
 
   await Promise.each(
     memberships,
     async membership => {
       debug({ membership: membership.id })
-      if (runDry) {
+      if (dryRun) {
         return
       }
 

--- a/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/deactivate.js
@@ -40,11 +40,6 @@ const deactivate = async (
     runDry
   })
 
-  if (runDry) {
-    debug('dry run')
-    return
-  }
-
   await Promise.each(
     memberships,
     async membership => {

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -54,25 +54,12 @@ const init = async (_context) => {
     runInitially: DEV
   })
 
-  const runIntervalSecsDeactivate = 60 * 60
-
   intervalScheduler.init({
-    name: 'memberships-deactivate',
+    name: 'changeover-deactivate',
     context,
-    runFunc: deactivate,
-    lockTtlSecs: runIntervalSecsDeactivate,
-    runIntervalSecs: runIntervalSecsDeactivate,
-    runInitially: true
-  })
-
-  const runIntervalSecsChangeover = 60 * 15
-
-  intervalScheduler.init({
-    name: 'memberships-changeover-deactivate',
-    context,
-    runFunc: changeover,
-    lockTtlSecs: runIntervalSecsChangeover,
-    runIntervalSecs: runIntervalSecsChangeover,
+    runFunc: [changeover, deactivate],
+    lockTtlSecs: 60 * 10,
+    runIntervalSecs: 60 * 10,
     runInitially: true
   })
 }

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -57,7 +57,10 @@ const init = async (_context) => {
   intervalScheduler.init({
     name: 'changeover-deactivate',
     context,
-    runFunc: [changeover, deactivate],
+    runFunc: async (args, context) => {
+      await changeover(args, context)
+      await deactivate(args, context)
+    },
     lockTtlSecs,
     runIntervalSecs: 60 * 10
   })

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -58,9 +58,8 @@ const init = async (_context) => {
     name: 'changeover-deactivate',
     context,
     runFunc: [changeover, deactivate],
-    lockTtlSecs: 60 * 10,
-    runIntervalSecs: 60 * 10,
-    runInitially: true
+    lockTtlSecs,
+    runIntervalSecs: 60 * 10
   })
 }
 

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -14,6 +14,7 @@ const { inform: informGivers } = require('./givers')
 const { inform: informCancellers } = require('./winbacks')
 const { inform: informOwners } = require('./owners')
 const { deactivate } = require('./deactivate')
+const { changeover } = require('./changeover')
 
 const init = async (_context) => {
   debug('init')
@@ -61,6 +62,17 @@ const init = async (_context) => {
     runFunc: deactivate,
     lockTtlSecs: runIntervalSecsDeactivate,
     runIntervalSecs: runIntervalSecsDeactivate,
+    runInitially: true
+  })
+
+  const runIntervalSecsChangeover = 60 * 15
+
+  intervalScheduler.init({
+    name: 'memberships-changeover-deactivate',
+    context,
+    runFunc: changeover,
+    lockTtlSecs: runIntervalSecsChangeover,
+    runIntervalSecs: runIntervalSecsChangeover,
     runInitially: true
   })
 }


### PR DESCRIPTION
This Pull Request primarily adds to membership schedulers:

* `changeover` to find expired memberships which can be replace with a dormant membership
* `deactivate` to deactivate memberships

`changeover` checks users with active memberships after their latest membership period if there are dormant memberships to activate. If so, it elects one, deactivates old membership and activates dormant membership.

`deactivate` will deactivate cancelled memberships after latest membership period ended, and, for the "grace period", it will deactivate uncancelled memberships 14 days after latest membership period ended.

To avoid user confusion it deactivates memberships after the end of a day a period ends. (Period might end on 2019-01-16 at 3pm. Scheduler won't deactivate membership before 2019-01-16 23:59:59).
