### PR TITLE
feat(documents): Evaluate SUPRESS_READING_MINUTES config

### DIFF
--- a/servers/republik/.env.example
+++ b/servers/republik/.env.example
@@ -103,3 +103,6 @@ TWILIO_DEFAULT_SENDER_NUMBER=
 
 # Listener processing changes in Postgres tables and posting to ElasticSearch
 SEARCH_PG_LISTENER=true
+
+# Suppress Document.estimatedReadingMinutes
+#SUPPRESS_READING_MINUTES='{"series":["A Series Title"],"format":["repo/id"]}'


### PR DESCRIPTION
This Pull Request allows suppressing evaluation of `Document.meta.estimatedReadingMinutes` with environment variable `SUPPRESS_READING_MINUTES`, which is parsed on startup. Requires a JSON object.

Example:

```
SUPPRESS_READING_MINUTES='{"series":["An der Bar"]}'
```