### PR TITLE
fix(newsletters): remove feuilleton newsletter

### DIFF
--- a/app.json
+++ b/app.json
@@ -94,9 +94,6 @@
     "MAILCHIMP_INTEREST_NEWSLETTER_WEEKLY": {
       "required": true
     },
-    "MAILCHIMP_INTEREST_NEWSLETTER_FEUILLETON": {
-      "required": true
-    },
     "MAILCHIMP_INTEREST_PLEDGE": {
       "required": true
     },

--- a/servers/republik/graphql/schema-types.js
+++ b/servers/republik/graphql/schema-types.js
@@ -133,7 +133,6 @@ enum Badge {
 enum NewsletterName {
   DAILY
   WEEKLY
-  FEUILLETON
   PROJECTR
 }
 

--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -21,7 +21,6 @@ const {
   MAILCHIMP_INTEREST_GRANTED_ACCESS,
   MAILCHIMP_INTEREST_NEWSLETTER_DAILY,
   MAILCHIMP_INTEREST_NEWSLETTER_WEEKLY,
-  MAILCHIMP_INTEREST_NEWSLETTER_FEUILLETON,
   MAILCHIMP_INTEREST_NEWSLETTER_PROJECTR,
   FRONTEND_BASE_URL
 } = process.env
@@ -30,11 +29,6 @@ const mail = createMail([
   {
     name: 'DAILY',
     interestId: MAILCHIMP_INTEREST_NEWSLETTER_DAILY,
-    roles: ['member']
-  },
-  {
-    name: 'FEUILLETON',
-    interestId: MAILCHIMP_INTEREST_NEWSLETTER_FEUILLETON,
     roles: ['member']
   },
   {
@@ -99,7 +93,6 @@ const getInterestsForUser = async ({
     // Autosubscribe all newsletters when new user just paid the membersh.
     interests[MAILCHIMP_INTEREST_NEWSLETTER_DAILY] = true
     interests[MAILCHIMP_INTEREST_NEWSLETTER_WEEKLY] = true
-    interests[MAILCHIMP_INTEREST_NEWSLETTER_FEUILLETON] = true
     interests[MAILCHIMP_INTEREST_NEWSLETTER_PROJECTR] = true
   }
 


### PR DESCRIPTION
It looks like removing `FEUILLETON` from the `NewsletterName` enum shouldn't hurt us for existing subscriptions, because it's only used on `updateNewsletterSubscription` and not on getting a `NewsletterSubscription`. (Will test on staging of course.)