### PR TITLE
prolongBeforeDate on pending pledges and fixes

### DIFF
--- a/servers/republik/modules/crowdfundings/lib/CustomPackages/rules/earlyAdopterBonus.js
+++ b/servers/republik/modules/crowdfundings/lib/CustomPackages/rules/earlyAdopterBonus.js
@@ -52,6 +52,14 @@ module.exports = ({ package_, packageOption, membership, payload, now }) => {
     .duration(moment(beginDate).diff(now))
     .add(1, 'day')
 
+  if (bonus.asDays() < 1) {
+    debug(
+      'bonus not positive (%d). rule does not apply.',
+      Math.floor(bonus.asDays())
+    )
+    return
+  }
+
   debug('%d days granted. role applied.', Math.floor(bonus.asDays()))
 
   payload.additionalPeriods.push({

--- a/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
@@ -49,7 +49,7 @@ const createBuckets = (now) => [
   },
   {
     templateName: 'membership_owner_prolong_notice_0',
-    minEndDate: getMinEndDate(now, -5),
+    minEndDate: getMinEndDate(now, -3),
     maxEndDate: getMaxEndDate(now, 0),
     onlyMembershipTypes: ['ABO'],
     users: []


### PR DESCRIPTION
This Pull Request introduces multiple changes:

* Feature: Return `prolongBeforeDate` on **pending pledges too** if `periods.max(endDate)` is smaller than `now`
* Fix: Check if earlyAdopterBonus days is **a positive value**
* Fix: Lower minEndDate for T-0 email