### PR TITLE
Extend Membership type

### DIFF
--- a/servers/republik/modules/crowdfundings/graphql/schema-types.js
+++ b/servers/republik/modules/crowdfundings/graphql/schema-types.js
@@ -155,7 +155,7 @@ type Membership {
   initialInterval: MembershipTypeInterval!
   initialPeriods: Int!
   periods: [MembershipPeriod]!
-  prolongBeforeDate: DateTime
+  needsProlong: Boolean!
   endDate: DateTime
   graceEndDate: DateTime
   overdue: Boolean!

--- a/servers/republik/modules/crowdfundings/graphql/schema-types.js
+++ b/servers/republik/modules/crowdfundings/graphql/schema-types.js
@@ -6,6 +6,7 @@ scalar JSON
 extend type User {
   pledges: [Pledge!]!
   memberships: [Membership!]!
+  activeMembership: Membership
 
   paymentSources: [PaymentSource!]!
   hasChargableSource: Boolean
@@ -154,6 +155,7 @@ type Membership {
   initialInterval: MembershipTypeInterval!
   initialPeriods: Int!
   periods: [MembershipPeriod]!
+  prolongBeforeDate: DateTime
   overdue: Boolean!
   cancellations: [Cancellation!]!
   createdAt: DateTime!

--- a/servers/republik/modules/crowdfundings/graphql/schema-types.js
+++ b/servers/republik/modules/crowdfundings/graphql/schema-types.js
@@ -156,6 +156,8 @@ type Membership {
   initialPeriods: Int!
   periods: [MembershipPeriod]!
   prolongBeforeDate: DateTime
+  endDate: DateTime
+  graceEndDate: DateTime
   overdue: Boolean!
   cancellations: [Cancellation!]!
   createdAt: DateTime!

--- a/servers/republik/modules/crowdfundings/lib/User.js
+++ b/servers/republik/modules/crowdfundings/lib/User.js
@@ -1,0 +1,53 @@
+const Promise = require('bluebird')
+
+const {
+  resolvePackages,
+  getCustomOptions
+} = require('./CustomPackages')
+
+const getCustomPackages = async ({ user, crowdfundingName, pgdb }) => {
+  const now = new Date()
+
+  const crowdfundings = crowdfundingName
+    ? await pgdb.public.crowdfundings.find({
+      name: crowdfundingName,
+      'beginDate <=': now,
+      'endDate >': now
+    })
+    : await pgdb.public.crowdfundings.find({
+      'beginDate <=': now,
+      'endDate >': now
+    })
+
+  const packages = await pgdb.public.packages.find({
+    crowdfundingId: crowdfundings.map(crowdfunding => crowdfunding.id),
+    custom: true
+  })
+
+  if (packages.length === 0) {
+    return []
+  }
+
+  return Promise
+    .map(
+      await resolvePackages({ packages, pledger: user, pgdb }),
+      async package_ => {
+        if (package_.custom === true) {
+          const options = await getCustomOptions(package_)
+
+          if (options.length === 0) {
+            return
+          }
+
+          return { ...package_, options }
+        }
+
+        return package_
+      }
+    )
+    .filter(Boolean)
+}
+
+module.exports = {
+  getCustomPackages
+}

--- a/servers/republik/modules/crowdfundings/lib/cache.js
+++ b/servers/republik/modules/crowdfundings/lib/cache.js
@@ -8,10 +8,11 @@ const getRedisKey = ({ prefix, key }) =>
   `${namespace}:${prefix}:${key}`
 
 const createGet = ({ options, redis }) => async function () {
-  const payload = await redis.getAsync(getRedisKey(options))
+  const key = getRedisKey(options)
+  const payload = await redis.getAsync(key)
   debug('crowdfundings:cache:get')(
-    `${payload ? 'HIT' : 'MISS'} %O`,
-    options.key
+    `${payload ? 'HIT' : 'MISS'} %s`,
+    key
   )
 
   return payload
@@ -29,9 +30,10 @@ const createSet = ({ options, redis }) => async function (payload) {
   }
 
   if (payloadString) {
-    debug('crowdfundings:cache:set')('PUT %O', options.key)
+    const key = getRedisKey(options)
+    debug('crowdfundings:cache:set')('PUT %s', key)
     return redis.setAsync(
-      getRedisKey(options),
+      key,
       payloadString,
       'EX', options.ttl || 60
     )


### PR DESCRIPTION
This Pull Requests adds props to `Membership` types:

* `needsProlong: Boolean!`, flag whether membership can be prolonged
* `endDate: DateTime`, date time describing when a membership ends
* `graceEndDate: DateTime`, date time describing when a membership is deactivated

It further returns an active membership on `User.activeMembership`.

Some resolver results are cached up to 24h and invalidate upon some membership mutations.
- `User.activeMembership`, membership query
- `Membership.type`, type query
- `Membership.needsProlong`
- `Membership.endDate`
- `Membership.graceEndDate`

Sample GraphQL Query:

```gql
{
  me {
    activeMembership {
      needsProlong
      endDate
      graceEndDate
      type {
        name
      }
    }
  }
}
```