### PR TITLE
fix(crowdfundings): Prevent single day bonus

### DIFF
--- a/servers/republik/modules/crowdfundings/lib/CustomPackages/rules/earlyAdopterBonus.js
+++ b/servers/republik/modules/crowdfundings/lib/CustomPackages/rules/earlyAdopterBonus.js
@@ -50,7 +50,6 @@ module.exports = ({ package_, packageOption, membership, payload, now }) => {
 
   const bonus = moment
     .duration(moment(beginDate).diff(now))
-    .add(1, 'day')
 
   if (bonus.asDays() < 1) {
     debug(
@@ -59,6 +58,8 @@ module.exports = ({ package_, packageOption, membership, payload, now }) => {
     )
     return
   }
+
+  bonus.add(1, 'day')
 
   debug('%d days granted. role applied.', Math.floor(bonus.asDays()))
 


### PR DESCRIPTION
Mutate `bonus` later to prevent single-day-bonus.