### PR TITLE
Create util to apply a PostgresInterval object and refactor

### DIFF
--- a/packages/access/lib/grants.js
+++ b/packages/access/lib/grants.js
@@ -366,7 +366,7 @@ const beginGrant = async (grant, recipient, pgdb) => {
   const campaign = await campaignsLib.findOne(grant.accessCampaignId, pgdb)
   const now = moment()
   const beginAt = now.clone()
-  const endAt = addInterval(now.clone(), campaign.grantPeriodInterval)
+  const endAt = addInterval(beginAt, campaign.grantPeriodInterval)
 
   const updateFields = {
     recipientUserId: recipient.id,

--- a/packages/access/lib/grants.js
+++ b/packages/access/lib/grants.js
@@ -3,6 +3,7 @@ const moment = require('moment')
 const validator = require('validator')
 
 const { Roles } = require('@orbiting/backend-modules-auth')
+const { applyPgInterval: { add: addInterval } } = require('@orbiting/backend-modules-utils')
 
 const campaignsLib = require('./campaigns')
 const constraints = require('./constraints')
@@ -76,21 +77,12 @@ const grant = async (granter, campaignId, email, message, t, pgdb, mail) => {
     ))
   }
 
-  const beginBefore = moment()
-
-  // '30 days 12 hours'::interval in Postgres database is retrieved as
-  // PostgresInterval object { days: 30, hours: 12 } in here. Iterating through
-  // each object key and adding count.
-  Object.keys(campaign.grantClaimableInterval).forEach(unit => {
-    beginBefore.add(campaign.grantClaimableInterval[unit], unit)
-  })
-
   const grant = await pgdb.public.accessGrants.insertAndGet({
     granterUserId: granter.id,
     email,
     message,
     accessCampaignId: campaign.id,
-    beginBefore
+    beginBefore: addInterval(moment(), campaign.grantClaimableInterval)
   })
 
   eventsLib.log(grant, 'invite', pgdb)
@@ -374,11 +366,7 @@ const beginGrant = async (grant, recipient, pgdb) => {
   const campaign = await campaignsLib.findOne(grant.accessCampaignId, pgdb)
   const now = moment()
   const beginAt = now.clone()
-  const endAt = now.clone()
-
-  Object.keys(campaign.grantPeriodInterval).forEach(key => {
-    endAt.add(campaign.grantPeriodInterval[key], key)
-  })
+  const endAt = addInterval(now.clone(), campaign.grantPeriodInterval)
 
   const updateFields = {
     recipientUserId: recipient.id,

--- a/packages/utils/__tests__/applyPgInterval.test.js
+++ b/packages/utils/__tests__/applyPgInterval.test.js
@@ -1,0 +1,59 @@
+const test = require('tape-async')
+const { add, subtract } = require('../applyPgInterval')
+
+const moment = require('moment')
+const postgresInterval = require('postgres-interval')
+
+test('applyPgInterval.add', async (t) => {
+  const a = add('2018-01-01', postgresInterval('1 mon'))
+  t.ok(a instanceof moment, 'returns moment object')
+  t.equal(a.unix(), moment('2018-02-01').unix(), 'add month')
+
+  const b = add('2018-01-01', postgresInterval('1 mon 15 days'))
+  t.ok(b instanceof moment, 'returns moment object')
+  t.equal(b.unix(), moment('2018-02-16').unix(), 'add month and 15 days')
+
+  const c = add('2018-01-01', postgresInterval('1 mon 15 days 12:00:00'))
+  t.ok(c instanceof moment, 'returns moment object')
+  t.equal(c.unix(), moment('2018-02-16 12:00').unix(), 'add month, 15 days and 12 hours')
+
+  const d = add(new Date('2018-01-01'), postgresInterval('1 mon'))
+  t.ok(d instanceof moment, 'returns moment object')
+  t.equal(d.unix(), moment('2018-02-01 01:00:00').unix(), 'accepts Date()')
+
+  const e = add(moment('2018-01-01'), postgresInterval('1 mon'))
+  t.ok(e instanceof moment, 'returns moment object')
+  t.equal(e.unix(), moment('2018-02-01').unix(), 'accepts moment()')
+
+  t.throws(() => add('2018-01-01', 'not-an-interval'), /unrecognized.*PostgresInterval/, 'interval unrecognized')
+  t.throws(() => add('2018-01-01'), /missing.*PostgresInterval/, 'interval missing')
+
+  t.end()
+})
+
+test.only('applyPgInterval.subtract', async (t) => {
+  const a = subtract('2018-01-01', postgresInterval('1 mon'))
+  t.ok(a instanceof moment, 'returns moment object')
+  t.equal(a.unix(), moment('2017-12-01').unix(), 'substract month')
+
+  const b = subtract('2018-01-01', postgresInterval('1 mon 15 days'))
+  t.ok(b instanceof moment, 'returns moment object')
+  t.equal(b.unix(), moment('2017-11-16').unix(), 'subtract month and 15 days')
+
+  const c = subtract('2018-01-01', postgresInterval('1 mon 15 days 12:00:00'))
+  t.ok(c instanceof moment, 'returns moment object')
+  t.equal(c.unix(), moment('2017-11-15 12:00').unix(), 'subtract month, 15 days and 12 hours')
+
+  const d = subtract(new Date('2018-01-01'), postgresInterval('1 mon'))
+  t.ok(d instanceof moment, 'returns moment object')
+  t.equal(d.unix(), moment('2017-12-01 01:00:00').unix(), 'accepts Date()')
+
+  const e = subtract(moment('2018-01-01'), postgresInterval('1 mon'))
+  t.ok(e instanceof moment, 'returns moment object')
+  t.equal(e.unix(), moment('2017-12-01').unix(), 'accepts moment()')
+
+  t.throws(() => subtract('2018-01-01', 'not-an-interval'), /unrecognized.*PostgresInterval/, 'interval unrecognized')
+  t.throws(() => subtract('2018-01-01'), /missing.*PostgresInterval/, 'interval missing')
+
+  t.end()
+})

--- a/packages/utils/applyPgInterval.js
+++ b/packages/utils/applyPgInterval.js
@@ -1,0 +1,42 @@
+/**
+ * Helper to apply a PostgresInterval object to a given
+ * date by either adding or substracting interval. Returns
+ * a moment object.
+ *
+ * @example add('2018-01-01', <PostgresInterval>)
+ */
+
+const moment = require('moment')
+
+const ALLOWED_MUTATIONS = ['add', 'subtract']
+
+const mutate = (date, interval, mutation) => {
+  if (!ALLOWED_MUTATIONS.includes(mutation)) {
+    throw new Error(`mutation "${mutation}" not supported`)
+  }
+
+  if (!interval) {
+    throw new Error('interval missing (should be "PostgresInterval")')
+  }
+
+  if (interval.constructor.name !== 'PostgresInterval') {
+    throw new Error('unrecognized interval (should be "PostgresInterval")')
+  }
+
+  const mutatedDate = moment(date)
+
+  // '30 days 12 hours'::interval in Postgres database is retrieved as
+  // PostgresInterval object { days: 30, hours: 12 } in here. Iterating through
+  // each object key and mutating count (add, subtract).
+  Object.keys(interval).forEach(key => {
+    // e.g. moment.add(<count>, <unit>)
+    mutatedDate[mutation](interval[key], key)
+  })
+
+  return mutatedDate
+}
+
+module.exports = {
+  add: (date, interval) => mutate(date, interval, 'add'),
+  subtract: (date, interval) => mutate(date, interval, 'subtract')
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,6 +17,10 @@
   },
   "homepage": "https://github.com/orbiting/backends#readme",
   "scripts": {
-    "link": "yarn link"
+    "link": "yarn link",
+    "test": "istanbul cover tape \"__tests__/**/*.test.js\" | tap-diff"
+  },
+  "dependencies": {
+    "moment": "^2.24.0"
   }
 }

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/Membership.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/Membership.js
@@ -1,6 +1,8 @@
-const { transformUser, Roles } = require('@orbiting/backend-modules-auth')
 const moment = require('moment')
 const _ = require('lodash')
+
+const { transformUser, Roles } = require('@orbiting/backend-modules-auth')
+const { applyPgInterval: { add: addInterval } } = require('@orbiting/backend-modules-utils')
 
 const { getLastEndDate } = require('../../lib/utils')
 const { getCustomPackages } = require('../../lib/User')
@@ -90,12 +92,10 @@ module.exports = {
           return null
         }
 
-        const graceEndDate = moment(getLastEndDate(periods))
-        Object.keys(membership.graceInterval).forEach(key => {
-          graceEndDate.add(membership.graceInterval[key], key)
-        })
-
-        return graceEndDate
+        return addInterval(
+          getLastEndDate(periods),
+          membership.graceInterval
+        )
       })
   },
   async pledge (membership, args, { pgdb, user: me }) {

--- a/servers/republik/modules/crowdfundings/lib/CustomPackages/index.js
+++ b/servers/republik/modules/crowdfundings/lib/CustomPackages/index.js
@@ -3,6 +3,8 @@ const moment = require('moment')
 const uuid = require('uuid/v4')
 const Promise = require('bluebird')
 
+const { applyPgInterval: { add: addInterval } } = require('@orbiting/backend-modules-utils')
+
 const { getPeriodEndingLast, getLastEndDate } = require('../utils')
 const rules = require('./rules')
 
@@ -148,10 +150,10 @@ const evaluate = async ({
     return false
   }
 
-  const lastEndDateWithGracePeriod = moment(lastEndDate)
-  Object.keys(membership.graceInterval).forEach(key => {
-    lastEndDateWithGracePeriod.add(membership.graceInterval[key], key)
-  })
+  const lastEndDateWithGracePeriod = addInterval(
+    lastEndDate,
+    membership.graceInterval
+  )
 
   /**
    * Usually, we want to extend an existing series of periods. We therefor

--- a/yarn.lock
+++ b/yarn.lock
@@ -6528,6 +6528,11 @@ moment@^2.22.2:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
   integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 "mongodb-uri@>= 0.9.7":
   version "0.9.7"
   resolved "https://registry.yarnpkg.com/mongodb-uri/-/mongodb-uri-0.9.7.tgz#0f771ad16f483ae65f4287969428e9fbc4aa6181"


### PR DESCRIPTION
pogi uses [postgres-interval](https://www.npmjs.com/package/postgres-interval) to represent intervals stored in Postgres database (via pg-core).

New util `applyPgInterval` in utils package is either adding or subtracting such an interval on a given date.

This Pull Request refactors code parts which did already added a Postgres interval to dates.