### PR TITLE
fix auto login, AUTO_LOGIN -> AUTO_LOGIN_REGEX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,10 @@ AUTH_MAIL_TEMPLATE_NAME=cf_signin
 # comma separated list of values
 #ENFORCE_CONSENTS=PRIVACY
 
+# NEVER DO THIS IN PROD
+# signs in matching emails automatically
+#AUTO_LOGIN_REGEX=^([a-zA-Z0-9._%+-]+)@test\.project-r\.construction$
+
 #############
 # mail
 #############

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ env:
     - PUBLIC_WS_URL_PATH=/graphql
     - SEND_MAILS=false
     - FORCE_TEST_END=true
-    - AUTO_LOGIN=true
     - SESSION_SECRET=testtest
     - DEFAULT_MAIL_FROM_NAME='travis'
     - DEFAULT_MAIL_FROM_ADDRESS='travis@test.project-r.construction'

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ env:
     - PARKING_PLEDGE_ID=00000000-1234-0000-0000-000000000001
     - PARKING_USER_ID=00000000-4321-0000-0000-000000000001
     - DISPLAY_AUTHOR_SECRET=testtest
+    - AUTO_LOGIN_REGEX=^([a-zA-Z0-9._%+-]+)@test\.project-r\.construction$
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
   - export PATH=$HOME/.yarn/bin:$PATH

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -62,9 +62,9 @@ AUTH_MAIL_SUBJECT=sign in link
 # what to prefix the sign-in link with
 PUBLIC_URL=http://localhost:3020
 
-# if truthy, @test.project-r.construction mail addresses get automatically
-# signedin and no mail is sent (used for automated testing)
-AUTO_LOGIN=1
+# NEVER DO THIS IN PROD
+# signs in matching emails automatically
+#AUTO_LOGIN_REGEX=^([a-zA-Z0-9._%+-]+)@test\.project-r\.construction$
 ```
 
 ## static-texts

--- a/packages/auth/lib/Users.js
+++ b/packages/auth/lib/Users.js
@@ -208,13 +208,12 @@ const signIn = async (_email, context, pgdb, req, consents, _tokenType) => {
 
 const shouldAutoLogin = ({ email }) => {
   if (AUTO_LOGIN_REGEX) {
-    let testMatch = false
     try {
-      testMatch = new RegExp(AUTO_LOGIN_REGEX).test(email)
+      return new RegExp(AUTO_LOGIN_REGEX).test(email)
     } catch (e) {
-      testMatch = false
+      console.warn(e)
+      return false
     }
-    return testMatch
   }
   return false
 }

--- a/packages/auth/lib/Users.js
+++ b/packages/auth/lib/Users.js
@@ -173,7 +173,7 @@ const signIn = async (_email, context, pgdb, req, consents, _tokenType) => {
     })
     if (shouldAutoLogin({ email })) {
       setTimeout(async () => {
-        console.warn(`🔓💥 auto login for ${email}!!! AUTO_LOGIN_REGEX`)
+        console.warn(`🔓💥 Auto Login for ${email} due to AUTO_LOGIN_REGEX`)
         await authorizeSession({
           pgdb,
           tokens: [token],

--- a/packages/auth/lib/Users.js
+++ b/packages/auth/lib/Users.js
@@ -40,7 +40,7 @@ const SecondFactorHasToBeDisabledError = newAuthError('second-factor-has-to-be-d
 const SessionTokenValidationFailed = newAuthError('token-validation-failed', 'api/token/invalid')
 
 const {
-  AUTO_LOGIN,
+  AUTO_LOGIN_REGEX,
   FRONTEND_BASE_URL
 } = process.env
 
@@ -173,11 +173,13 @@ const signIn = async (_email, context, pgdb, req, consents, _tokenType) => {
     })
     if (shouldAutoLogin({ email })) {
       setTimeout(async () => {
-        console.log('AUTO_LOGIN!')
+        console.warn(`🔓💥 auto login for ${email}!!! AUTO_LOGIN_REGEX`)
         await authorizeSession({
           pgdb,
           tokens: [token],
-          email
+          email,
+          req,
+          me: user
         })
       }, 2000)
     } else {
@@ -205,15 +207,14 @@ const signIn = async (_email, context, pgdb, req, consents, _tokenType) => {
 }
 
 const shouldAutoLogin = ({ email }) => {
-  if (AUTO_LOGIN) {
-    // email addresses @test.project-r.construction will be auto logged in
-    // - email addresses containing «not» will neither be logged in nor send an sign request
-    const testMatch = email.match(/^([a-zA-Z0-9._%+-]+)@test\.project-r\.construction$/)
-    if (testMatch) {
-      if (testMatch[1].indexOf('not') === -1) {
-        return true
-      }
+  if (AUTO_LOGIN_REGEX) {
+    let testMatch = false
+    try {
+      testMatch = new RegExp(AUTO_LOGIN_REGEX).test(email)
+    } catch (e) {
+      testMatch = false
     }
+    return testMatch
   }
   return false
 }


### PR DESCRIPTION
AUTO_LOGIN_REGEX signs in matching emails automatically after 2 seconds.
Set `AUTO_LOGIN_REGEX=^([a-zA-Z0-9._%+-]+)@republik\.ch$` for a more open life in development.

- fix auto `authorizeSession`
- rename AUTO_LOGIN -> AUTO_LOGIN_REGEX

![screenshot from 2019-02-12 01-25-44](https://user-images.githubusercontent.com/3500621/52603011-2642d700-2e65-11e9-8fa0-55eb3dc46c54.png)
