### PR TITLE
Fix some cancelMembership calls

### DIFF
--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/cancelPledge.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/cancelPledge.js
@@ -18,6 +18,7 @@ module.exports = async (_, args, {
   pgdb,
   req,
   t,
+  mail,
   mail: { enforceSubscriptions }
 }) => {
   if (!PARKING_PLEDGE_ID || !PARKING_USER_ID) {
@@ -119,7 +120,7 @@ module.exports = async (_, args, {
             id: memberships[0].id,
             immediately: true
           },
-          { pgdb: transaction, req, t }
+          { pgdb: transaction, req, t, mail }
         )
       }
     }

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/claimMembership.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/claimMembership.js
@@ -7,7 +7,7 @@ const { ensureSignedIn } = require('@orbiting/backend-modules-auth')
 const cancelMembership = require('./cancelMembership')
 const createCache = require('../../../lib/cache')
 
-module.exports = async (_, args, {pgdb, req, t, mail: {enforceSubscriptions}}) => {
+module.exports = async (_, args, {pgdb, req, t, mail, mail: {enforceSubscriptions}}) => {
   ensureSignedIn(req)
 
   let pledgerId
@@ -84,12 +84,12 @@ module.exports = async (_, args, {pgdb, req, t, mail: {enforceSubscriptions}}) =
             id: m.id,
             details: {
               type: 'SYSTEM',
-              reason: 'Auto Cancellation (claimMembership)'
-            },
-            suppressConfirmation: true,
-            suppressWinback: true
+              reason: 'Auto Cancellation (claimMembership)',
+              suppressConfirmation: true,
+              suppressWinback: true
+            }
           },
-          { req, t, pgdb: transaction }
+          { req, t, pgdb: transaction, mail }
         )
       )
     }

--- a/servers/republik/modules/crowdfundings/lib/generateMemberships.js
+++ b/servers/republik/modules/crowdfundings/lib/generateMemberships.js
@@ -4,7 +4,11 @@ const { evaluate, resolvePackages } = require('./CustomPackages')
 const createCache = require('./cache')
 const cancelMembership = require('../graphql/resolvers/_mutations/cancelMembership')
 const debug = require('debug')('crowdfundings:memberships')
-const { enforceSubscriptions, sendMembershipProlongConfirmation } = require('./Mail')
+const {
+  enforceSubscriptions,
+  sendMembershipProlongConfirmation,
+  sendMembershipCancellation
+} = require('./Mail')
 const Promise = require('bluebird')
 const omit = require('lodash/omit')
 
@@ -208,12 +212,12 @@ module.exports = async (pledgeId, pgdb, t, req, logger = console) => {
         id: m.id,
         details: {
           type: 'SYSTEM',
-          reason: 'Auto Cancellation (generateMemberships)'
-        },
-        suppressConfirmation: true,
-        suppressWinback: true
+          reason: 'Auto Cancellation (generateMemberships)',
+          suppressConfirmation: true,
+          suppressWinback: true
+        }
       },
-      { req, t, pgdb }
+      { req, t, pgdb, mail: { sendMembershipCancellation } }
     ))
   }
 

--- a/servers/republik/modules/crowdfundings/lib/generateMemberships.js
+++ b/servers/republik/modules/crowdfundings/lib/generateMemberships.js
@@ -4,11 +4,7 @@ const { evaluate, resolvePackages } = require('./CustomPackages')
 const createCache = require('./cache')
 const cancelMembership = require('../graphql/resolvers/_mutations/cancelMembership')
 const debug = require('debug')('crowdfundings:memberships')
-const {
-  enforceSubscriptions,
-  sendMembershipProlongConfirmation,
-  sendMembershipCancellation
-} = require('./Mail')
+const mail = require('./Mail')
 const Promise = require('bluebird')
 const omit = require('lodash/omit')
 
@@ -141,7 +137,7 @@ module.exports = async (pledgeId, pgdb, t, req, logger = console) => {
         debug('additionalPeriods %o', additionalPeriods)
 
         if (membership.userId !== pledge.userId) {
-          await sendMembershipProlongConfirmation({
+          await mail.sendMembershipProlongConfirmation({
             pledger: user, membership, additionalPeriods, t, pgdb
           })
         }
@@ -217,7 +213,7 @@ module.exports = async (pledgeId, pgdb, t, req, logger = console) => {
           suppressWinback: true
         }
       },
-      { req, t, pgdb, mail: { sendMembershipCancellation } }
+      { req, t, pgdb, mail }
     ))
   }
 
@@ -241,7 +237,7 @@ module.exports = async (pledgeId, pgdb, t, req, logger = console) => {
   }
 
   try {
-    await enforceSubscriptions({
+    await mail.enforceSubscriptions({
       pgdb,
       userId: user.id,
       isNew: !user.verified,


### PR DESCRIPTION
Provide context `mail` in `cancelMembership` calls and move suppress-flags to `details` in function argument call.