### PR TITLE
 feat(crowdfundings): Improve adminUsers search results 

### DIFF
--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_queries/adminUsers.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_queries/adminUsers.js
@@ -21,8 +21,6 @@ module.exports = async (
   const filterActive = (dateRangeFilter || stringArrayFilter || booleanFilter)
   let items = !(search || filterActive)
     ? await pgdb.public.users.findAll({
-      limit,
-      offset,
       orderBy: orderBy
         ? `"${orderBy.field}" ${orderBy.direction}`
         : '"createdAt" ASC'
@@ -95,8 +93,6 @@ module.exports = async (
     ? `u."${orderBy.field}" ${orderBy.direction}`
     : 'u."createdAt" ASC'
 }
-        OFFSET :offset
-        LIMIT :limit
       )
         SELECT * FROM raw
         WHERE
@@ -108,12 +104,10 @@ module.exports = async (
       toDate: dateRangeFilter ? dateRangeFilter.to : null,
       stringArray: stringArrayFilter ? stringArrayFilter.values : null,
       booleanValue: booleanFilter ? booleanFilter.value : null,
-      limit,
-      offset,
       WORD_SIMILARITY_THRESHOLD,
       WORD_DISTANCE_THRESHOLD
     })
-  items = items.map(transformUser)
-  const count = await pgdb.public.users.count()
+  const count = items.length
+  items = items.slice(offset, offset + limit).map(transformUser)
   return { items, count }
 }


### PR DESCRIPTION
This Pull Request attempts to improve search results on `adminUsers` GraphQL query.

It only changes how database is queried, and what results are returned in which order. It does not improve speed (neither does it decrease it).

**More relevant results**

Query changes relay even more on word similarity and distance calculated by Postgres ("relevance"). The more relevant a term is in on-the-fly generated searchable text (`concat_ws(...)` parts), the further up result should appear.

Results are not shown if their relevance is deemed too low.

There are two thresholds we can adjust: `WORD_SIMILARITY_THRESHOLD` ("similiarity") and `WORD_DISTANCE_THRESHOLD` ("distance"). Results with a similarity ratio below 0.6 are omitted, as well as results whith a distance ratio above 0.5.

Thresholds were set after manual testing with different types of data (membership #, HR-ID) which did deliver relevant results without omitting potential relevant records.

**Prefixes pattern**

Search terms may match multiple data props. Using prefixes helps to precise information one is looking for.

As an example: Searching for membership #1, using "1" as search term would result many results. Searching for "nr:1" however would likely find membership #1 and sort it to top results.

Available prefixes which can precise a search:
* `nr:` to look for a user with a specific membership sequence number (membership #)
* `voucher:` to look for a user with a membership which hold as specific voucher code
* `hrid:` to look for a user with specific payment HR-ID 
* `pspid:` to look for a user with a specific payment service provider ID
* `access:` to look for a user with a specific access grant voucher code 
* `plz:` to look for a user with a specific postal code in addresses

**Other changes**
* Removes query in `paymentSources`. Table is no longer populated.
* Data is paginated in code. This helps to return an precise number of total results without having to run an expensive search query twice. Memory footprint ok.
* Moved filters outside query. Auto-format made a mess.

Fixes https://github.com/orbiting/republik-admin-frontend/issues/33