### PR TITLE
fix(crowdfundings): Return Pledge.payments by Payment.createdAt desc

### DIFF
--- a/servers/republik/modules/crowdfundings/graphql/resolvers/Pledge.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/Pledge.js
@@ -74,7 +74,10 @@ module.exports = {
 
     const pledgePayments = await pgdb.public.pledgePayments.find({pledgeId: pledge.id})
     return pledgePayments.length
-      ? pgdb.public.payments.find({id: pledgePayments.map((pp) => { return pp.paymentId })})
+      ? pgdb.public.payments.find(
+        { id: pledgePayments.map(pp => pp.paymentId) },
+        { orderBy: { createdAt: 'desc' } }
+      )
       : []
   },
   async memberships (pledge, args, { pgdb, user: me }) {


### PR DESCRIPTION
Querying for `User.pleges.payments` returns payments sorted by `Payment.createdAt` in a descending manner.

```
{
  me {
    pledges {
      payments {
        createdAt
      }
    }
  }
}
```

Fixes https://github.com/orbiting/republik-admin-frontend/issues/25