### PR TITLE
fix(crowdfundings): Exclude cancelled pledges

### DIFF
--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -152,6 +152,7 @@ mail.sendPledgeConfirmations = async ({ userId, pgdb, t }) => {
   const user = await pgdb.public.users.findOne({ id: userId })
   const pledges = await pgdb.public.pledges.find({
     userId: user.id,
+    'status !=': 'CANCELLED',
     sendConfirmMail: true
   })
 


### PR DESCRIPTION
This prevents sending confirmation email when a pledge was cancelled.

A previously unverified user account containing a meanwhile cancelled pledge received a pledge conformation email 8 months later upon claiming an access grant, effectively verifying the account and triggering sending of pending pledge confirmation emails.