### PR TITLE
feat(publikator): Add mutation to archive repo

### DIFF
--- a/packages/search/script/inserts/repo.js
+++ b/packages/search/script/inserts/repo.js
@@ -69,7 +69,8 @@ module.exports = {
         name: repo.id.split('/')[1],
         publications,
         tags: repo.tags,
-        updatedAt: repo.updatedAt
+        updatedAt: repo.updatedAt,
+        refresh: false
       })
     })
 

--- a/servers/publikator/graphql/resolvers/Repo.js
+++ b/servers/publikator/graphql/resolvers/Repo.js
@@ -141,7 +141,6 @@ module.exports = {
   },
   isArchived: async (repo, args, context) => {
     if (repo.isArchived !== undefined) {
-      console.log('isArchived via repo.isArchived')
       return repo.isArchived
     }
 

--- a/servers/publikator/graphql/resolvers/Repo.js
+++ b/servers/publikator/graphql/resolvers/Repo.js
@@ -3,6 +3,7 @@ const yaml = require('../../lib/yaml')
 const { descending } = require('d3-array')
 const zipArray = require('../../lib/zipArray')
 const {
+  getRepo,
   getCommits,
   getCommit,
   getHeads,
@@ -137,5 +138,14 @@ module.exports = {
       return {}
     }
     return yaml.parse(message)
+  },
+  isArchived: async (repo, args, context) => {
+    if (repo.isArchived !== undefined) {
+      console.log('isArchived via repo.isArchived')
+      return repo.isArchived
+    }
+
+    const { isArchived } = await getRepo(repo.id)
+    return isArchived
   }
 }

--- a/servers/publikator/graphql/resolvers/_mutations/archive.js
+++ b/servers/publikator/graphql/resolvers/_mutations/archive.js
@@ -12,7 +12,7 @@ module.exports = async (
   { repoIds, unpublish = false },
   context
 ) => {
-  const { user, pubsub } = context
+  const { user, pubsub, t } = context
   ensureUserHasRole(user, 'editor')
 
   await Promise.each(repoIds, async repoId => {
@@ -20,7 +20,8 @@ module.exports = async (
 
     if (publications.length > 0) {
       if (!unpublish) {
-        throw new Error('Unable to archive published repository. Unpublish first.')
+        // Unable to archive published repository. Unpublish first.
+        throw new Error(t('api/archive/error/published', { repoId }))
       }
 
       await unpublishMutation(_, { repoId }, context)
@@ -41,7 +42,7 @@ module.exports = async (
   })
 
   return {
-    nodes: repoIds,
+    nodes: repoIds.map(id => ({ id })),
     totalCount: repoIds.length,
     pageInfo: {
       hasNextPage: false,

--- a/servers/publikator/graphql/resolvers/_mutations/archive.js
+++ b/servers/publikator/graphql/resolvers/_mutations/archive.js
@@ -1,0 +1,51 @@
+const Promise = require('bluebird')
+const { Roles: { ensureUserHasRole } } = require('@orbiting/backend-modules-auth')
+
+const { latestPublications: getLatestPublications } = require('../Repo')
+const { archiveRepo } = require('../../../lib/github')
+const { upsert: repoCacheUpsert } = require('../../../lib/cache/upsert')
+
+const unpublishMutation = require('./unpublish')
+
+module.exports = async (
+  _,
+  { repoIds, unpublish = false },
+  context
+) => {
+  const { user, pubsub } = context
+  ensureUserHasRole(user, 'editor')
+
+  await Promise.each(repoIds, async repoId => {
+    const publications = await getLatestPublications({ id: repoId })
+
+    if (publications.length > 0) {
+      if (!unpublish) {
+        throw new Error('Unable to archive published repository. Unpublish first.')
+      }
+
+      await unpublishMutation(_, { repoId }, context)
+    }
+
+    await archiveRepo(repoId)
+
+    await repoCacheUpsert({
+      id: repoId,
+      isArchived: true
+    })
+
+    await pubsub.publish('repoUpdate', {
+      repoUpdate: {
+        id: repoId
+      }
+    })
+  })
+
+  return {
+    nodes: repoIds,
+    totalCount: repoIds.length,
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false
+    }
+  }
+}

--- a/servers/publikator/graphql/schema-types.js
+++ b/servers/publikator/graphql/schema-types.js
@@ -17,6 +17,8 @@ type Repo {
   unpublished: Boolean!
 
   meta: RepoMeta!
+
+  isArchived: Boolean!
 }
 
 type RepoConnection {

--- a/servers/publikator/graphql/schema.js
+++ b/servers/publikator/graphql/schema.js
@@ -88,6 +88,11 @@ type mutations {
     publishDate: DateTime
     briefingUrl: String
   ): Repo!
+
+  archive(
+    repoIds: [ID!]!
+    unpublish: Boolean
+  ): RepoConnection!
 }
 
 type subscriptions {

--- a/servers/publikator/lib/cache/upsert.js
+++ b/servers/publikator/lib/cache/upsert.js
@@ -131,11 +131,11 @@ const upsert = async ({
   id,
   meta,
   name,
-  publication,
   publications,
   tag,
   tags,
-  updatedAt
+  updatedAt,
+  refresh = true
 }) => {
   let doc = {}
 
@@ -172,6 +172,7 @@ const upsert = async ({
 
   await client.update({
     ...getPath(id),
+    refresh,
     version: doc._version,
     body: {
       doc_as_upsert: true,

--- a/servers/publikator/lib/github/index.js
+++ b/servers/publikator/lib/github/index.js
@@ -77,6 +77,7 @@ module.exports = {
             name: $repoName
           ) {
             name
+            isArchived
           }
         }
       `,

--- a/servers/publikator/lib/github/index.js
+++ b/servers/publikator/lib/github/index.js
@@ -455,5 +455,15 @@ module.exports = {
           console.log(errors)
         }
       })
+  },
+  archiveRepo: async (repoId) => {
+    const [login, repoName] = repoId.split('/')
+    const { githubRest } = await createGithubClients()
+    return githubRest.repos.edit({
+      owner: login,
+      repo: repoName,
+      name: repoName,
+      archived: true
+    })
   }
 }

--- a/servers/publikator/lib/translations.json
+++ b/servers/publikator/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-04-15T11:20:46.372Z",
+  "updated": "2019-04-15T15:25:34.384Z",
   "title": "live",
   "data": [
     {
@@ -68,7 +68,7 @@
     },
     {
       "key": "api/archive/error/published",
-      "value": "\"{repoId}\" ist veröffentlicht und kann nicht archiviert werden. Heben Sie erst alle Veröffentlichungen auf."
+      "value": "«{repoId}» ist veröffentlicht und kann nicht archiviert werden. Heben Sie erst alle Veröffentlichungen auf."
     }
   ]
 }

--- a/servers/publikator/lib/translations.json
+++ b/servers/publikator/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-04-15T07:26:36.601Z",
+  "updated": "2019-04-15T11:20:46.372Z",
   "title": "live",
   "data": [
     {
@@ -68,7 +68,7 @@
     },
     {
       "key": "api/archive/error/published",
-      "value": "\"{repoId}\" ist veröffentlicht und kann nicht archiviert werden. Ziehen Sie erst alle Veröffentlichungen zurück."
+      "value": "\"{repoId}\" ist veröffentlicht und kann nicht archiviert werden. Heben Sie erst alle Veröffentlichungen auf."
     }
   ]
 }

--- a/servers/publikator/lib/translations.json
+++ b/servers/publikator/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-11-16T14:13:12.135Z",
+  "updated": "2019-04-15T07:26:36.601Z",
   "title": "live",
   "data": [
     {
@@ -65,6 +65,10 @@
     {
       "key": "api/publish/disabled",
       "value": "Artikel können im Moment weder veröffentlicht noch zurückgezogen werden. Bitte versuche es in ein paar Minuten noch einmal, ansonsten kontaktiere bitte die IT."
+    },
+    {
+      "key": "api/archive/error/published",
+      "value": "\"{repoId}\" ist veröffentlicht und kann nicht archiviert werden. Ziehen Sie erst alle Veröffentlichungen zurück."
     }
   ]
 }


### PR DESCRIPTION
Sets `archived` flag on repositories provided and updates `repo` cache in ElasticSearch.

If a repository has tags indicated an article is published, it fails. An additional flag (`unpublish`) will unpublish such articles first.