### PR TITLE
feat(access): Add script to generate voucher codes in bulk 

### DIFF
--- a/packages/access/graphql/schema-types.js
+++ b/packages/access/graphql/schema-types.js
@@ -25,7 +25,7 @@ type AccessCampaign {
     "Include grants with were invalidated (admin only)"
     withInvalidated: Boolean
   ): [AccessGrant!]!
-  slots: AccessCampaignSlots
+  slots: AccessCampaignSlots!
   "Begin of campaign"
   beginAt: DateTime!
   "End of campaign"

--- a/packages/access/lib/campaigns.js
+++ b/packages/access/lib/campaigns.js
@@ -89,7 +89,13 @@ const filterInvisibleCampaigns = campaigns =>
 
 const mergeConstraintPayloads = campaigns =>
   campaigns.map(campaign => {
-    const payload = {}
+    const payload = {
+      slots: {
+        total: 0,
+        used: 0,
+        free: 0
+      }
+    }
 
     campaign.constraintMeta.forEach(meta => {
       Object.assign(payload, meta.payload)

--- a/packages/access/lib/constraints/requireExistingGrants.js
+++ b/packages/access/lib/constraints/requireExistingGrants.js
@@ -1,0 +1,51 @@
+const debug = require('debug')('access:lib:constraints:requireExistingGrants')
+
+/**
+ * Contraint checks if a granter has grants in campaign. If false, constraint
+ * will hinder display of campaign.
+ *
+ * Story: User should only see campaign if grants are in campaign. Grants may
+ * be pre-generated e.g. a series of voucher codes which may be printed on
+ * business cards.
+ *
+ * @example: {"requireExistingGrants": {}}
+ */
+
+const getMeta = async (args, context) => {
+  const { granter, campaign } = args
+  const { pgdb } = context
+
+  const hasGrants = await pgdb.query(`
+    SELECT "accessGrants".id
+
+    FROM "accessGrants"
+
+    WHERE
+      "accessGrants"."accessCampaignId" = '${campaign.id}'
+      AND "accessGrants"."granterUserId" = '${granter.id}'
+      AND "accessGrants"."revokedAt" IS NULL
+      AND "accessGrants"."invalidatedAt" IS NULL
+  `)
+
+  const meta = {
+    visible: hasGrants.length > 0,
+    grantable: null,
+    payload: {}
+  }
+
+  debug(
+    'getMeta',
+    {
+      granter: granter.id,
+      campaign,
+      meta
+    }
+  )
+
+  return meta
+}
+
+module.exports = {
+  isGrantable: () => true,
+  getMeta
+}

--- a/packages/access/lib/grants.js
+++ b/packages/access/lib/grants.js
@@ -53,7 +53,7 @@ const evaluateConstraints = async (granter, campaign, email, t, pgdb) => {
 const generate = async (granter, campaignId, grants = [], pgdb) => {
   const campaign = await campaignsLib.findOne(campaignId, pgdb)
 
-  if (campaign === undefined) {
+  if (!campaign) {
     throw new Error('Campaign not found.')
   }
 

--- a/packages/access/script/generateVoucherCodes.js
+++ b/packages/access/script/generateVoucherCodes.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * This script can generated a desired amount of access grant voucher
+ * codes for a single user.
+ *
+ * Usage:
+ * packages/access/script/generateVoucherCodes.js --campaign <A Campaign ID> --granter <A User ID> --prefix ABC --amount 10
+ */
+
+require('@orbiting/backend-modules-env').config()
+const yargs = require('yargs')
+
+const PgDb = require('@orbiting/backend-modules-base/lib/pgdb')
+
+const grantsLib = require('../lib/grants')
+
+const argv = yargs
+  .option('campaign', { alias: ['c', 'ac', 'accessCampaignId'] })
+  .option('granter', { alias: ['g', 'u', 'user'] })
+  .option('amount', {
+    alias: ['n'],
+    type: 'number',
+    default: 1
+  })
+  .option('prefix', { alias: ['p'] })
+  .default(['campaign', 'granter', 'label'])
+  .check(argv => {
+    if (argv.prefix && argv.prefix.length >= grantsLib.VOUCHER_CODE_LENGTH) {
+      return `Check --prefix. "${argv.prefix}" too long to generate voucher codes.`
+    }
+
+    if (argv.prefix.match(/[^123456789ABCDEFGHKLMRSTUWXYZ]+/)) {
+      return `Check --prefix. "${argv.prefix}" contains invalid chars.`
+    }
+
+    if (argv.amount < 1) {
+      return `Check --amount. Should be higher than 1.`
+    }
+
+    return true
+  })
+  .help()
+  .version()
+  .argv
+
+PgDb.connect().then(async pgdb => {
+  const transaction = await pgdb.transactionBegin()
+
+  try {
+    const granter = await pgdb.public.users.findOne({ id: argv.granter })
+
+    if (granter === undefined) {
+      throw new Error('User not found.')
+    }
+
+    const grants = []
+
+    let iteration = 0
+    while (grants.length < argv.amount && iteration < 5 * argv.amount) {
+      iteration++
+
+      const grant = {
+        voucherCode: await pgdb.queryOneField('SELECT make_hrid(\'"accessGrants"\'::regclass, \'voucherCode\'::text, 5::bigint)')
+      }
+
+      if (argv.prefix) {
+        grant.voucherCode = argv.prefix + grant.voucherCode.slice(argv.prefix.length, grantsLib.VOUCHER_CODE_LENGTH)
+      }
+
+      if (
+        await pgdb.public.accessGrants.count({ voucherCode: grant.voucherCode }) < 1 &&
+        !grants.find(({ voucherCode }) => voucherCode === grant.voucherCode)
+      ) {
+        grants.push(grant)
+      }
+    }
+
+    if (grants.length < argv.amount) {
+      throw new Error(`Unable to generate ${argv.amount} unqiue voucher codes. Change parameters.`)
+    }
+
+    console.log(`generating ${grants.length} grant(s)...`)
+
+    await grantsLib.generate(granter, argv.campaign, grants, transaction)
+    await transaction.transactionCommit()
+
+    console.log(`${grants.length} grant(s) generated.`)
+  } catch (e) {
+    await transaction.transactionRollback()
+    console.error(e)
+  } finally {
+    await pgdb.close()
+  }
+}).then(() => console.log('Done.'))

--- a/packages/access/script/generateVoucherCodes.js
+++ b/packages/access/script/generateVoucherCodes.js
@@ -60,7 +60,7 @@ PgDb.connect().then(async pgdb => {
       iteration++
 
       const grant = {
-        voucherCode: await pgdb.queryOneField(`SELECT make_hrid(\'"accessGrants"\'::regclass, \'voucherCode\'::text, ${grantsLib.VOUCHER_CODE_LENGTH}::bigint)`)
+        voucherCode: await pgdb.queryOneField(`SELECT make_hrid('"accessGrants"'::regclass, 'voucherCode'::text, ${grantsLib.VOUCHER_CODE_LENGTH}::bigint)`)
       }
 
       if (argv.prefix) {
@@ -79,12 +79,12 @@ PgDb.connect().then(async pgdb => {
       throw new Error(`Unable to generate ${argv.amount} unqiue voucher codes. Change parameters.`)
     }
 
-    console.log(`generating ${grants.length} grant(s)...`)
+    console.log(`inserting ${grants.length} grant(s)...`)
 
-    await grantsLib.generate(granter, argv.campaign, grants, transaction)
+    await grantsLib.insert(granter, argv.campaign, grants, transaction)
     await transaction.transactionCommit()
 
-    console.log(`${grants.length} grant(s) generated.`)
+    console.log(`${grants.length} grant(s) inserted.`)
   } catch (e) {
     await transaction.transactionRollback()
     console.error(e)


### PR DESCRIPTION
Can generate a series of grants for a user with only voucher codes in campaign. Prefix and amount can be specified, too.

This Pull Request also adds a constraint which requires existing grants to display a campaign. User should only see campaign if grants are in campaign. Grants may be pre-generated e.g. a series
of voucher codes which may be printed on business cards.

Fixes constraint's default `payload`: Allows to create campaigns without any constraints having to generate `payload.slots = {...}`. Previously, schema allowed `Campaign.slots` to be null.

**How to test**

Create a dedicated campaign, using new constraint:

```sql
INSERT INTO "public"."accessCampaigns"("id","title","description","grantPeriodInterval","emailFollowup","beginAt","endAt","constraints","createdAt","updatedAt","grantClaimableInterval")
VALUES
(E'9a7f13da-4e01-4de9-87de-ce4cee00c838',E'Probezugriff über Visitenkarte 🎟',NULL,E'14 days',E'7 days',E'2019-03-30 00:00:00+00',E'2020-01-01 00:00:00+00',E'[{"requireExistingGrants": {}}, {"notGrantable": {}}]',E'2019-03-31 12:54:57.208611+00',E'2019-03-31 12:54:57.208611+00',E'1 year');
```

You should then see in /konto no new campaign. Campaign will show up once your generate grants for logged in user.

Generate voucher code for a user ID, like so:

```sh
packages/access/script/generateVoucherCodes.js --campaign 9a7f13da-4e01-4de9-87de-ce4cee00c838 --granter <Your User ID> --prefix AB --amount 10
```

You should then see in /konto a section showing voucher codes.