### PR TITLE
WIP: fix(crowdfundings): Pledger can claim own voucher codes

### DIFF
--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/claimMembership.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/claimMembership.js
@@ -25,11 +25,6 @@ module.exports = async (_, args, {pgdb, req, t, mail, mail: {enforceSubscription
       throw new Error(t('api/membership/claim/invalidToken'))
     }
 
-    // A user can not claim a membership he owns.
-    if (membership.userId === req.user.id) {
-      throw new Error(t('api/membership/claim/ownerIsClaimer'))
-    }
-
     const now = new Date()
 
     pledgerId = membership.userId


### PR DESCRIPTION
Remove check which refuses to let pledgers claim their own membership on `claimMembership` mutation.

Check impact on these part of code:
- [ ] servers/republik/graphql/resolvers/MembershipStats/periods.js
- [ ] servers/republik/modules/crowdfundings/graphql/resolvers/User.js `prolongBeforeDate`
- [ ] servers/republik/modules/crowdfundings/lib/scheduler/givers.js