### PR TITLE
feat(documents): optimise linked/related docs loading

### DIFF
--- a/packages/assets/lib/webp.js
+++ b/packages/assets/lib/webp.js
@@ -3,6 +3,11 @@ const addSuffix = (url) => {
   if (!query) {
     return base
   }
+  // prevent double suffix
+  // - e.g. when resolving twice (content & children)
+  if (base.endsWith('.webp')) {
+    return url
+  }
   return `${base}.webp?${query}`
 }
 

--- a/packages/documents/graphql/resolvers/_queries/document.js
+++ b/packages/documents/graphql/resolvers/_queries/document.js
@@ -1,12 +1,12 @@
 const getDocuments = require('./documents')
 
-module.exports = async (_, args, context) => {
+module.exports = async (_, args, context, info) => {
   const {
     id,
     path,
     repoId
   } = args
 
-  return getDocuments(_, { id, path, repoId }, context)
+  return getDocuments(_, { id, path, repoId }, context, info)
     .then(docCon => docCon.nodes[0])
 }

--- a/packages/documents/graphql/resolvers/_queries/documents.js
+++ b/packages/documents/graphql/resolvers/_queries/documents.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 const search = require('@orbiting/backend-modules-search/graphql/resolvers/_queries/search')
 
-module.exports = async (__, args, context) => {
+module.exports = async (__, args, context, info) => {
   const docsConnection = await search(null, {
     first: args.first,
     after: args.after,
@@ -14,7 +14,7 @@ module.exports = async (__, args, context) => {
       key: 'publishedAt',
       direction: 'DESC'
     }
-  }, context)
+  }, context, info)
 
   // transform SearchConnection to DocumentConnection
   return {

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -49,7 +49,7 @@ const indexRef = {
   type: indexType
 }
 
-const getDocumentId = ({repoId, commitId, versionName}) =>
+const getDocumentId = ({ repoId, commitId, versionName }) =>
   Buffer.from(`${repoId}/${commitId}/${versionName}`).toString('base64')
 
 const documentIdParser = value => {
@@ -178,7 +178,7 @@ const getElasticDoc = (
   { doc, commitId, versionName, milestoneCommitId, resolved }
 ) => {
   const meta = doc.content.meta
-  const id = getDocumentId({repoId: meta.repoId, commitId, versionName})
+  const id = getDocumentId({ repoId: meta.repoId, commitId, versionName })
   return {
     __type: indexType,
     __sort: {
@@ -200,77 +200,51 @@ const getElasticDoc = (
   }
 }
 
-const addRelatedDocs = async ({
-  connection,
-  scheduledAt,
-  ignorePrepublished,
-  context
-}) => {
-  const search = require('../graphql/resolvers/_queries/search')
-  const { pgdb } = context
-
-  const getDocsForConnection = (connection) =>
-    [
-      ...connection.nodes
-        .filter(node => node.type === 'Document')
-        .map(node => node.entity)
-    ]
-
-  const docs = getDocsForConnection(connection)
-
-  // extract users and related repoIds (from content and meta)
-  const userIds = []
-  const repoIds = []
-  const seriesRepoIds = []
-  docs.forEach(doc => {
-    // from content
-    visit(doc.content, 'zone', node => {
-      if (node.data) {
-        repoIds.push(getRepoId(node.data.url))
-        repoIds.push(getRepoId(node.data.formatUrl))
-      }
-    })
-    visit(doc.content, 'link', node => {
-      const info = extractUserUrl(node.url)
-      if (info) {
-        node.url = info.path
-        if (isUUID.v4(info.id)) {
-          userIds.push(info.id)
-        } else {
-          debug(
-            'addRelatedDocs found nonUUID %s in repo %s',
-            info.id,
-            doc.repoId
-          )
-        }
-      }
-      const repoId = getRepoId(node.url, 'autoSlug')
-      if (repoId) {
-        repoIds.push(repoId)
-      }
-    })
-    // from meta
-    const meta = doc.content.meta
-    // TODO get keys from packages/documents/lib/resolve.js
-    repoIds.push(getRepoId(meta.dossier))
-    repoIds.push(getRepoId(meta.format))
-    repoIds.push(getRepoId(meta.discussion))
-    if (meta.series) {
-      // If a string, probably a series master (tbc.)
-      if (typeof meta.series === 'string') {
-        seriesRepoIds.push(getRepoId(meta.series))
-        repoIds.push(getRepoId(meta.series))
-      } else {
-        meta.series.episodes && meta.series.episodes.forEach(episode => {
-          repoIds.push(getRepoId(episode.document))
-        })
-      }
+const extractIdsFromNode = (haystack, contextRepoId) => {
+  const repos = []
+  const users = []
+  visit(haystack, 'zone', node => {
+    if (node.data) {
+      repos.push(getRepoId(node.data.url))
+      repos.push(getRepoId(node.data.formatUrl))
     }
   })
+  visit(haystack, 'link', node => {
+    const info = extractUserUrl(node.url)
+    if (info) {
+      node.url = info.path
+      if (isUUID.v4(info.id)) {
+        users.push(info.id)
+      } else {
+        debug(
+          'addRelatedDocs found nonUUID %s in repo %s',
+          info.id,
+          contextRepoId
+        )
+      }
+    }
+    const repoId = getRepoId(node.url, 'autoSlug')
+    if (repoId) {
+      repos.push(repoId)
+    }
+  })
+  return { repos, users }
+}
 
-  // load users
-  const usernames = userIds.length
-    ? await pgdb.public.users.find(
+const getDocsForConnection = (connection) => connection.nodes
+  .filter(node => node.type === 'Document')
+  .map(node => node.entity)
+
+const loadLinkedMetaData = async ({
+  repoIds = [],
+  userIds = [],
+  context,
+  scheduledAt,
+  ignorePrepublished
+}) => {
+  const usernames = !userIds.length
+    ? []
+    : await context.pgdb.public.users.find(
       {
         id: userIds,
         hasPublicProfile: true,
@@ -280,24 +254,83 @@ const addRelatedDocs = async ({
         fields: ['id', 'username']
       }
     )
-    : []
 
-  // If there are any series master repositories, fetch these series master
-  // documents and push series episodes onto the related docs stack
-  const sanitizedSeriesRepoIds = [...new Set(seriesRepoIds.filter(Boolean))]
-  if (sanitizedSeriesRepoIds.length > 0) {
-    const seriesRelatedDocs = await search(null, {
+  const search = require('../graphql/resolvers/_queries/search')
+  const sanitizedRepoIds = [...new Set(repoIds.filter(Boolean))]
+  const docs = !sanitizedRepoIds.length
+    ? []
+    : await search(null, {
       recursive: true,
       withoutContent: true,
       scheduledAt,
       ignorePrepublished,
-      first: sanitizedSeriesRepoIds.length * 2,
+      first: sanitizedRepoIds.length * 2,
       filter: {
-        repoId: sanitizedSeriesRepoIds,
+        repoId: sanitizedRepoIds,
         type: 'Document'
       }
-    }, context)
-      .then(getDocsForConnection)
+    }, context).then(getDocsForConnection)
+
+  return {
+    usernames,
+    docs
+  }
+}
+
+const addRelatedDocs = async ({
+  connection,
+  scheduledAt,
+  ignorePrepublished,
+  context,
+  withoutContent
+}) => {
+  const docs = getDocsForConnection(connection)
+
+  // extract users and related repoIds (from content and meta)
+  let userIds = []
+  let repoIds = []
+  const seriesRepoIds = []
+  docs.forEach(doc => {
+    // from content
+    if (!withoutContent) {
+      const extractedIds = extractIdsFromNode(doc.content, doc.repoId)
+      userIds = userIds.concat(extractedIds.users)
+      repoIds = repoIds.concat(extractedIds.repos)
+    }
+    // from meta
+    const meta = doc.content.meta
+    // TODO get keys from packages/documents/lib/resolve.js
+    repoIds.push(getRepoId(meta.dossier))
+    repoIds.push(getRepoId(meta.format))
+    repoIds.push(getRepoId(meta.discussion))
+    if (meta.series) {
+      // If a string, probably a series master (tbc.)
+      if (typeof meta.series === 'string') {
+        const seriesRepoId = getRepoId(meta.series)
+        if (seriesRepoId) {
+          seriesRepoIds.push(seriesRepoId)
+        }
+      } else {
+        meta.series.episodes && meta.series.episodes.forEach(episode => {
+          repoIds.push(getRepoId(episode.document))
+        })
+      }
+    }
+  })
+
+  let relatedDocs = []
+
+  // If there are any series master repositories, fetch these series master
+  // documents and push series episodes onto the related docs stack
+  if (seriesRepoIds.length) {
+    const { docs: seriesRelatedDocs } = await loadLinkedMetaData({
+      context,
+      repoIds: seriesRepoIds,
+      scheduledAt,
+      ignorePrepublished
+    })
+
+    relatedDocs = relatedDocs.concat(seriesRelatedDocs)
 
     seriesRelatedDocs.forEach(doc => {
       const meta = doc.content.meta
@@ -308,24 +341,18 @@ const addRelatedDocs = async ({
     })
   }
 
-  const sanitizedRepoIds = [...new Set(repoIds.filter(Boolean))]
+  const {
+    docs: variousRelatedDocs,
+    usernames
+  } = await loadLinkedMetaData({
+    context,
+    repoIds,
+    userIds,
+    scheduledAt,
+    ignorePrepublished
+  })
 
-  let relatedDocs = []
-
-  if (sanitizedRepoIds.length > 0) {
-    relatedDocs = await search(null, {
-      recursive: true,
-      withoutContent: true,
-      scheduledAt,
-      ignorePrepublished,
-      first: sanitizedRepoIds.length * 2,
-      filter: {
-        repoId: sanitizedRepoIds,
-        type: 'Document'
-      }
-    }, context)
-      .then(getDocsForConnection)
-  }
+  relatedDocs = relatedDocs.concat(variousRelatedDocs)
 
   debug({
     numDocs: docs.length,
@@ -725,6 +752,8 @@ const findTemplates = async function (elastic, template, repoId) {
 module.exports = {
   schema,
   getElasticDoc,
+  extractIdsFromNode,
+  loadLinkedMetaData,
   addRelatedDocs,
   unpublish,
   publish,

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -228,7 +228,10 @@ const extractIdsFromNode = (haystack, contextRepoId) => {
       repos.push(repoId)
     }
   })
-  return { repos, users }
+  return {
+    repos: repos.filter(Boolean),
+    users: users.filter(Boolean)
+  }
 }
 
 const getDocsForConnection = (connection) => connection.nodes


### PR DESCRIPTION
only load linked docs in returned content or children

This speeds up getting the front document a lot. Locally the response time goes from ~140ms to ~70ms (both with hot caches) with the smaller dev documents collection. In prd the gains may reach 5x to 10x. I expect the current prd ~700ms to go down to ~200ms.

~ToDo~:
- ~new `afterDate` & `beforeDate` query for `Document.children` for overview page~

Decided not to implement advanced children filtering in backend (credit line based) and instead hard code some teaser ids in the frontend: https://github.com/orbiting/republik-frontend/commit/7bdab34cc56717c146003fdc5f75e16c3285dd58#diff-048df1fa60145e7b472e7ed8cafbcf72R37

This will allow for the same optimisations.