### PR TITLE
feat(employees): shuffle and boost

### DIFF
--- a/servers/republik/graphql/resolvers/_queries/employees.js
+++ b/servers/republik/graphql/resolvers/_queries/employees.js
@@ -1,14 +1,32 @@
+const { shuffle } = require('d3-array')
 const { transformUser } = require('@orbiting/backend-modules-auth')
 
-module.exports = async (_, args, {pgdb}) => {
-  const data = await pgdb.public.gsheets.findOneFieldOnly({name: 'employees'}, 'data')
+module.exports = async (_, args, { pgdb }) => {
+  const data = await pgdb.public.gsheets.findOneFieldOnly({ name: 'employees' }, 'data')
   if (!data) {
     return []
   }
-  const publishedData = data
-    .filter(d => d.published)
+  let result = data.filter(d => d.published)
 
-  const userIds = publishedData
+  if (args.shuffle) {
+    const randomOrder = shuffle(result)
+    const boosted = shuffle([
+      randomOrder.find(d => d.famous && d.gender === 'f'),
+      randomOrder.find(d => d.famous && d.gender === 'm')
+    ])
+    const rest = randomOrder.filter(d => !boosted.includes(d))
+
+    result = [
+      boosted[0],
+      rest[0],
+      boosted[1]
+    ].concat(rest.slice(1))
+      .filter(Boolean)
+      .filter((a, i, all) => all.findIndex(b => b.userId === a.userId) === i)
+      .slice(0, args.shuffle)
+  }
+
+  const userIds = result
     .map(e => e.userId)
     .filter(Boolean)
 
@@ -19,7 +37,7 @@ module.exports = async (_, args, {pgdb}) => {
       .map(transformUser)
     )
 
-  return publishedData.map(d => ({
+  return result.map(d => ({
     ...d,
     user: users.find(u => u.id === d.userId)
   }))

--- a/servers/republik/graphql/schema.js
+++ b/servers/republik/graphql/schema.js
@@ -24,7 +24,14 @@ type queries {
   faqs: [Faq!]!
   events: [Event!]!
   updates: [Update!]!
-  employees: [Employee!]!
+  employees(
+    """
+    shuffle and limit the result to the specified count
+    - one famous female and one famous male is boosted
+    - ensures unique users
+    """
+    shuffle: Int
+  ): [Employee!]!
   mediaResponses: [MediaResponse!]!
   membershipStats: MembershipStats!
   memberStats: MemberStats!


### PR DESCRIPTION
New argument for `employees` to shuffle and limit the result to the specified count
 - one famous female and one famous male is boosted
 - ensures unique users