### PR TITLE
feat(voting): groupTurnout

### DIFF
--- a/packages/migrations/migrations/20190701024155-group-votings.js
+++ b/packages/migrations/migrations/20190701024155-group-votings.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/voting/migrations/sqls'
+const file = '20190701024155-group-votings'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)

--- a/packages/voting/graphql/resolvers/Voting.js
+++ b/packages/voting/graphql/resolvers/Voting.js
@@ -35,6 +35,12 @@ module.exports = {
     }
     return { entity: voting }
   },
+  async groupTurnout (voting, args, { pgdb }) {
+    if (voting.result && voting.result.groupTurnout) { // after counting
+      return voting.result.groupTurnout
+    }
+    return { entity: voting, groupSlug: true }
+  },
   async result (entity, args, { pgdb }) {
     if (entity.result) {
       return entity.result

--- a/packages/voting/graphql/resolvers/Voting.js
+++ b/packages/voting/graphql/resolvers/Voting.js
@@ -39,7 +39,10 @@ module.exports = {
     if (voting.result && voting.result.groupTurnout) { // after counting
       return voting.result.groupTurnout
     }
-    return { entity: voting, groupSlug: true }
+    if (voting.groupSlug) {
+      return { entity: voting, groupSlug: true }
+    }
+    return null
   },
   async result (entity, args, { pgdb }) {
     if (entity.result) {

--- a/packages/voting/graphql/resolvers/VotingTurnout.js
+++ b/packages/voting/graphql/resolvers/VotingTurnout.js
@@ -1,6 +1,7 @@
 const {
   numEligible,
-  numSubmitted
+  numSubmitted,
+  numSubmittedByGroup
 } = require('../../lib/Voting')
 
 module.exports = {
@@ -16,6 +17,8 @@ module.exports = {
   async submitted (obj, args, { pgdb }) {
     if (obj.submitted) {
       return obj.submitted
+    } else if (obj.groupSlug) {
+      return numSubmittedByGroup(obj.entity.groupSlug, pgdb)
     } else if (obj.entity) {
       return numSubmitted(obj.entity.id, pgdb)
     } else {

--- a/packages/voting/graphql/schema-types.js
+++ b/packages/voting/graphql/schema-types.js
@@ -30,11 +30,13 @@ type Voting implements VotingInterface {
   allowEmptyBallots: Boolean!
   allowedMemberships: [VotingMembershipRequirement!]
   allowedRoles: [String!]
+  groupSlug: String
 
   name: String!
   discussion: Discussion
 
   turnout: VotingTurnout!
+  groupTurnout: VotingTurnout
 
   liveResult: Boolean!
   result: VotingResult
@@ -62,6 +64,7 @@ type VotingOptionResult {
 type VotingResult {
   options: [VotingOptionResult!]!
   turnout: VotingTurnout!
+  groupTurnout: VotingTurnout
   message: String
   video: Video
   createdAt: DateTime!
@@ -88,6 +91,8 @@ input VotingInput {
   allowEmptyBallots: Boolean
   allowedMemberships: [VotingMembershipRequirementInput!]
   allowedRoles: [String!]
+  # only group votings with identical restrictions (allow*)
+  groupSlug: String
 }
 
 input VotingOptionInput {

--- a/packages/voting/lib/Voting.js
+++ b/packages/voting/lib/Voting.js
@@ -104,6 +104,15 @@ const finalize = async (voting, args, pgdb, t) => {
     options: await getOptionsResult(voting, args, pgdb, t),
     turnout: await queries.turnout(voting, pgdb)
   }
+  if (voting.groupSlug) {
+    Object.assign(result, {
+      groupSlug: voting.groupSlug,
+      groupTurnout: {
+        eligible: result.turnout.eligible,
+        submitted: await queries.numSubmittedByGroup(voting.groupSlug, pgdb)
+      }
+    })
+  }
   return finalizeLib('votings', voting, result, args, pgdb)
 }
 

--- a/packages/voting/migrations/sqls/20190701024155-group-votings-down.sql
+++ b/packages/voting/migrations/sqls/20190701024155-group-votings-down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE votings
+  DROP COLUMN "groupSlug"
+;

--- a/packages/voting/migrations/sqls/20190701024155-group-votings-up.sql
+++ b/packages/voting/migrations/sqls/20190701024155-group-votings-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE votings
+  ADD COLUMN "groupSlug" text
+;


### PR DESCRIPTION
group votings by setting `groupSlug: 'aslug'` when creating votings and retrieve the same `groupTurnout` on each member.
`groupTurnout.submitted` num unique users which have submitted in at least one of the groups votings.
`groupTurnout.eligible` is the same as turnout.eligible

For query examples check the [PR for july 2019 votings](https://github.com/orbiting/republik-frontend/pull/312)