### PR TITLE
fix(crowdfundings): Sending prolong notices

### DIFF
--- a/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
@@ -15,10 +15,6 @@ const {
 } = process.env
 
 const STATS_INTERVAL_SECS = 3
-const me = {
-  roles: ['admin']
-}
-
 const DAYS_BEFORE_END_DATE = 29
 
 const formatDate = (date) =>
@@ -58,7 +54,9 @@ const createBuckets = (now) => [
   }
 ]
 
-const getBuckets = async ({ now }, { pgdb }) => {
+const getBuckets = async ({ now }, context) => {
+  const { pgdb } = context
+
   /**
    * Load users with a membership.
    *
@@ -115,7 +113,7 @@ const getBuckets = async ({ now }, { pgdb }) => {
       const prolongBeforeDate = await getProlongBeforeDate(
         user,
         { ignoreClaimedMemberships: false },
-        { pgdb, user: me }
+        { ...context, user }
       )
         .then(date => date && moment(date))
 
@@ -162,7 +160,7 @@ const getBuckets = async ({ now }, { pgdb }) => {
 
 const inform = async (args, context) => {
   const buckets = await getBuckets(args, context)
-  debug('buckets: %o', buckets.map(b => ({...b, users: b.users.length})))
+  debug('buckets: %o', buckets.map(b => ({ ...b, users: b.users.length })))
 
   return Promise.each(
     buckets,

--- a/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
@@ -33,25 +33,25 @@ const getMaxEndDate = (now, daysBeforeEndDate) =>
 const createBuckets = (now) => [
   {
     templateName: 'membership_owner_prolong_notice',
-    minEndDate: getMinEndDate(now, 22),
+    minEndDate: getMinEndDate(now, 15),
     maxEndDate: getMaxEndDate(now, DAYS_BEFORE_END_DATE),
     onlyMembershipTypes: ['ABO'],
     users: []
   },
   {
     templateName: 'membership_owner_prolong_notice_7',
-    minEndDate: getMinEndDate(now, 5),
+    minEndDate: getMinEndDate(now, 3),
     maxEndDate: getMaxEndDate(now, 7),
     onlyMembershipTypes: ['ABO'],
     users: []
-  },
+  }/*,
   {
     templateName: 'membership_owner_prolong_notice_0',
     minEndDate: getMinEndDate(now, -3),
     maxEndDate: getMaxEndDate(now, 0),
     onlyMembershipTypes: ['ABO'],
     users: []
-  }
+  } */
 ]
 
 const getBuckets = async ({ now }, context) => {


### PR DESCRIPTION
This Pull Request fixes bug when sending membership owner prolong notices. It prevent sending those notices.

Bug was introduced while [refactoring database connections](https://github.com/orbiting/backends/pull/224): [User.getProlongBeforeDate](https://github.com/orbiting/backends/blob/0d936dbcb3a5e9239cde85359e96175856bfdf13/servers/republik/modules/crowdfundings/graphql/resolvers/User.js#L80) now requires a context including a redis instance to [create a cache instance](https://github.com/orbiting/backends/blob/0d936dbcb3a5e9239cde85359e96175856bfdf13/servers/republik/modules/crowdfundings/graphql/resolvers/User.js#L86-L90).

It temporary prevents T-0 mails to be send.