### PR TITLE
fix(collections): Determines accessor properly

### DIFF
--- a/packages/collections/lib/Collection.js
+++ b/packages/collections/lib/Collection.js
@@ -87,11 +87,11 @@ const upsertItem = async (tableName, query, data, { pgdb, t }) => {
   let newData = { ...data }
   let accessor
 
-  if (newData.percentage) {
+  if (newData.percentage !== undefined && newData.percentage !== null) {
     accessor = 'percentage'
     newData.percentage = Math.max(newData.percentage, 0)
     newData.percentage = Math.min(newData.percentage, 1)
-  } else if (newData.secs) {
+  } else if (newData.secs !== undefined && newData.secs !== null) {
     accessor = 'secs'
   }
 

--- a/packages/collections/lib/Collection.js
+++ b/packages/collections/lib/Collection.js
@@ -84,11 +84,11 @@ const upsertItem = async (tableName, query, data, { pgdb, t }) => {
   } else {
     let newData = { ...data }
     let accessor
-    if (data.percentage !== null) {
+    if (data.percentage) {
       accessor = 'percentage'
       newData.percentage = Math.max(newData.percentage, 0)
       newData.percentage = Math.min(newData.percentage, 1)
-    } else if (data.secs !== null) {
+    } else if (data.secs) {
       accessor = 'secs'
     }
     if (accessor) {


### PR DESCRIPTION
[If `data.percentage` was `undefined` it still determined `accessor` to be "percentage"](0e63502). This hindered `data.max` evaluation for media items w/ `data.secs` but no percentage.

This Pull Request includes also some refactoring:
- Uses `newData` variable in condition instead of `data`
- Removes unnecessary `else` branch