### PR TITLE
fix(auth): Split challenge payload into chunks

### DIFF
--- a/packages/auth/lib/challenges/EmailCodeChallenge.js
+++ b/packages/auth/lib/challenges/EmailCodeChallenge.js
@@ -48,15 +48,19 @@ module.exports = {
     return { payload, expiresAt }
   },
   startChallenge: async ({ email, token, pgdb }) => {
+    // Split payload into chunks glued w/ a space
+    // e.g. 12345678 -> "123 456 78"
+    const chunkedCode = token.payload.match(/\d{1,3}/g).join(' ')
+
     return sendMailTemplate({
       to: email,
       fromEmail: DEFAULT_MAIL_FROM_ADDRESS,
-      subject: t('api/signin/EMAIL_CODE/mail/subject', { code: token.payload }),
+      subject: t('api/signin/EMAIL_CODE/mail/subject', { code: chunkedCode }),
       templateName: 'signin_code',
       mergeLanguage: 'handlebars',
       globalMergeVars: [
         { name: 'code',
-          content: token.payload
+          content: chunkedCode
         }
       ]
     }, { pgdb })


### PR DESCRIPTION
This Pull Request splits an email code onto chunks of 3 chars and glues those chunks with a space. A chunked code helps a user to remember it.

Excerpt from transactional email hereafter:

<img width="465" alt="Bildschirmfoto 2019-08-05 um 07 24 51" src="https://user-images.githubusercontent.com/331800/62441396-37a1d780-b754-11e9-9828-c76de8f682e6.png">