### PR TITLE
feat(access): Add email config per campaign and check for disabled emails

### DIFF
--- a/packages/access/lib/mail.js
+++ b/packages/access/lib/mail.js
@@ -112,8 +112,8 @@ const sendMail = async (
     pgdb
   }
 ) => {
-  const config = getCampaignEmailConfig(party, template, campaign)
-  if (config && config.enabled === false) {
+  const emailConfig = getConfigEmails(party, template, campaign)
+  if (emailConfig && emailConfig.enabled === false) {
     return false
   }
 
@@ -284,6 +284,12 @@ const getGlobalMergeVars = async (
   ]
 }
 
-const getCampaignEmailConfig = (party, template, campaign) => {
-  return campaign.emailConfig.find(config => config.party === party && config.template === template)
+const getConfigEmails = (party, template, campaign) => {
+  const config = campaign.config
+
+  if (!config.emails) {
+    return
+  }
+
+  return config.emails.find(email => email.party === party && email.template === template)
 }

--- a/packages/access/lib/mail.js
+++ b/packages/access/lib/mail.js
@@ -112,6 +112,11 @@ const sendMail = async (
     pgdb
   }
 ) => {
+  const config = getCampaignEmailConfig(party, template, campaign)
+  if (config && config.enabled === false) {
+    return false
+  }
+
   const mail = await sendMailTemplate({
     to,
     fromEmail: process.env.DEFAULT_MAIL_FROM_ADDRESS,
@@ -277,4 +282,8 @@ const getGlobalMergeVars = async (
       content: 'https://project-r.construction/news'
     }
   ]
+}
+
+const getCampaignEmailConfig = (party, template, campaign) => {
+  return campaign.emailConfig.find(config => config.party === party && config.template === template)
 }

--- a/packages/access/migrations/sqls/20190909040718-mail-config-down.sql
+++ b/packages/access/migrations/sqls/20190909040718-mail-config-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "accessCampaigns" DROP COLUMN "emailConfig";

--- a/packages/access/migrations/sqls/20190909040718-mail-config-down.sql
+++ b/packages/access/migrations/sqls/20190909040718-mail-config-down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "accessCampaigns" DROP COLUMN "emailConfig";
+ALTER TABLE "accessCampaigns" DROP COLUMN "config";

--- a/packages/access/migrations/sqls/20190909040718-mail-config-up.sql
+++ b/packages/access/migrations/sqls/20190909040718-mail-config-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "accessCampaigns" ADD COLUMN "emailConfig" jsonb NOT NULL DEFAULT '[]';

--- a/packages/access/migrations/sqls/20190909040718-mail-config-up.sql
+++ b/packages/access/migrations/sqls/20190909040718-mail-config-up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "accessCampaigns" ADD COLUMN "emailConfig" jsonb NOT NULL DEFAULT '[]';
+ALTER TABLE "accessCampaigns" ADD COLUMN "config" jsonb NOT NULL DEFAULT '{}';

--- a/packages/migrations/migrations/20190909040718-mail-config.js
+++ b/packages/migrations/migrations/20190909040718-mail-config.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/access/migrations/sqls'
+const file = '20190909040718-mail-config'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)


### PR DESCRIPTION
This Pull Request adds an attribute to `accessCampaigns`, named `config`. It allows to configure a campaign with props. Implemented are these props:
- `emails`
- `subscribeToEditorialNewsletters`

`emails` is an array containing objects, each dedicated to configure an email template to suit campaign needs.

```json
{
  "emails": [
    {
      "party": "recipient",
      "enabled": false,
      "template": "invitation"
    }
  ]
}
```

Above configuration would disable onboarding email to recipient.

`subscribeToEditorialNewsletters` is a boolean value, and if set to `true` users will be subscribed to editorial newsletters.

```json
{
  "subscribeToEditorialNewsletters": false
}
```

Above configuration would not "force" subscribe to editorial newsletters.