### PR TITLE
Hide discussions and return accurate Comment.comments counts

### DIFF
--- a/packages/cards/migrations/sqls/20190911012939-improvements-down.sql
+++ b/packages/cards/migrations/sqls/20190911012939-improvements-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "cardGroups" RENAME COLUMN "discussionId" TO "disucussionId" ;

--- a/packages/cards/migrations/sqls/20190911012939-improvements-up.sql
+++ b/packages/cards/migrations/sqls/20190911012939-improvements-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "cardGroups" RENAME COLUMN "disucussionId" TO "discussionId" ;

--- a/packages/cards/script/insert-discussions.js
+++ b/packages/cards/script/insert-discussions.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+require('@orbiting/backend-modules-env').config()
+
+const Promise = require('bluebird')
+
+const PgDb = require('@orbiting/backend-modules-base/lib/PgDb')
+
+PgDb.connect().then(async pgdb => {
+  const transaction = await pgdb.transactionBegin()
+  const now = new Date()
+
+  try {
+    const groups = await transaction.public.cardGroups.findAll()
+
+    await Promise.map(groups, async group => {
+      if (group.discussionId) {
+        console.log(`CardGroup "${group.name}" has a discussion linked already`)
+        return
+      }
+
+      console.log(`Creating discussion and linking to CardGroup "${group.name}"...`)
+
+      const discussion = await transaction.public.discussions.insertAndGet({
+        title: `Wahltindär: ${group.name}`,
+        path: `/wahltindaer/${group.slug}/diskussion`,
+
+        hidden: true,
+        closed: true,
+        collapsable: true,
+        disableTopLevelComments: true,
+        maxLength: null,
+        minInterval: null,
+        anonymity: 'FORBIDDEN',
+
+        repoId: null,
+        tags: null,
+        tagRequired: false,
+
+        createdAt: now,
+        updatedAt: now
+      })
+
+      await transaction.public.cardGroups.updateOne(
+        { id: group.id },
+        { discussionId: discussion.id, updatedAt: now }
+      )
+    })
+
+    await transaction.transactionCommit()
+  } catch (e) {
+    await transaction.transactionRollback()
+    throw e
+  }
+
+  await pgdb.close()
+})

--- a/packages/discussions/graphql/resolvers/Comment.js
+++ b/packages/discussions/graphql/resolvers/Comment.js
@@ -211,24 +211,13 @@ module.exports = {
     }
 
     const children = await loaders.Comment.byParentId.load(comment.id)
-    const nodes = children
-      .map(child => {
-        if (
-          (!comment.parentIds && child.parentIds.length === 1) ||
-          (comment.parentIds && child.parentIds.length === comment.depth + 1)
-        ) {
-          return child
-        }
-
-        return false
-      })
-      .filter(Boolean)
+    const nodes = children.filter(child => child.parentIds.length === comment.depth + 1)
 
     if (children) {
       return {
         totalCount: children.length,
         directTotalCount: nodes.length,
-        nodes: nodes
+        nodes
       }
     }
 

--- a/packages/discussions/graphql/resolvers/Comment.js
+++ b/packages/discussions/graphql/resolvers/Comment.js
@@ -213,13 +213,14 @@ module.exports = {
     const children = await loaders.Comment.byParentId.load(comment.id)
     const nodes = children
       .map(child => {
-        const parentsLeft = child.parentIds.filter(p => p !== comment.id)
         if (
-          (!comment.parentIds && parentsLeft.length === 0) ||
-          (comment.parentIds && parentsLeft.length === 1)
+          (!comment.parentIds && child.parentIds.length === 1) ||
+          (comment.parentIds && child.parentIds.length === comment.depth + 1)
         ) {
           return child
         }
+
+        return false
       })
       .filter(Boolean)
 

--- a/packages/discussions/loaders/Comment.js
+++ b/packages/discussions/loaders/Comment.js
@@ -1,7 +1,15 @@
 const createDataLoader = require('@orbiting/backend-modules-dataloader')
 
 module.exports = (context) => ({
-  byId: createDataLoader(ids =>
-    context.pgdb.public.comments.find({ id: ids })
+  byId: createDataLoader(
+    ids => context.pgdb.public.comments.find({ id: ids })
+  ),
+  byParentId: createDataLoader(
+    async parentIds => {
+      const or = parentIds.map(p => ({ 'parentIds @>': [ p ] }))
+      return context.pgdb.public.comments.find({ or })
+    },
+    null,
+    (key, rows) => rows.filter(row => row.parentIds.includes(key))
   )
 })

--- a/packages/discussions/loaders/Discussion.js
+++ b/packages/discussions/loaders/Discussion.js
@@ -18,18 +18,11 @@ module.exports = (context) => ({
     context.loaders.Discussion.byId.clear(id)
     context.loaders.Discussion.byRepoId.clear(id)
   },
-  byId: createDataLoader(ids =>
-    context.pgdb.public.discussions.find({
-      id: ids,
-      hidden: false
-    })
+  byId: createDataLoader(
+    ids => context.pgdb.public.discussions.find({ id: ids })
   ),
   byRepoId: createDataLoader(
-    repoIds =>
-      context.pgdb.public.discussions.find({
-        repoId: repoIds,
-        hidden: false
-      }),
+    repoIds => context.pgdb.public.discussions.find({ repoId: repoIds }),
     null,
     (key, rows) => rows.find(row => row.repoId === key)
   ),

--- a/packages/migrations/migrations/20190911012939-improvements.js
+++ b/packages/migrations/migrations/20190911012939-improvements.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/cards/migrations/sqls'
+const file = '20190911012939-improvements'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)


### PR DESCRIPTION
* Alter hidden flag behaviour, preventing hidden discussions to appear in `comments` query
* Load `Comment.comments` even if data is not propagated and return accuracte counts
* Insert and link discussions for `CardGroup` entities (script)
* Rename field to remove typo disucussionId/discussionId