### PR TITLE
feat(cards): Add filters for parties and cards a user is subscribed to

### DIFF
--- a/packages/cards/graphql/resolvers/CardGroup.js
+++ b/packages/cards/graphql/resolvers/CardGroup.js
@@ -1,8 +1,12 @@
 const { paginateCards } = require('../../lib/cards')
 
 module.exports = {
-  async cards (cardGroup, args, { loaders }) {
-    return paginateCards(args, await loaders.Card.byCardGroupId.load(cardGroup.id))
+  async cards (cardGroup, args, context) {
+    return paginateCards(
+      await context.loaders.Card.byCardGroupId.load(cardGroup.id),
+      args,
+      context
+    )
   },
 
   async discussion (cardGroup, args, { loaders }) {

--- a/packages/cards/graphql/resolvers/User.js
+++ b/packages/cards/graphql/resolvers/User.js
@@ -1,7 +1,11 @@
 const { paginateCards } = require('../../lib/cards')
 
 module.exports = {
-  async cards (user, args, { loaders }) {
-    return paginateCards(args, await loaders.Card.byUserId.load(user.id))
+  async cards (user, args, context) {
+    return paginateCards(
+      await context.loaders.Card.byUserId.load(user.id),
+      args,
+      context
+    )
   }
 }

--- a/packages/cards/graphql/resolvers/_queries/cards.js
+++ b/packages/cards/graphql/resolvers/_queries/cards.js
@@ -16,5 +16,5 @@ module.exports = async (_, args, context) => {
     ? await loaders.Card.byUserId.load(user.id)
     : await pgdb.public.cards.find({}, { orderBy: { createdAt: 'ASC' } })
 
-  return paginateCards(args, cards)
+  return paginateCards(cards, args, context)
 }

--- a/packages/cards/graphql/schema-types.js
+++ b/packages/cards/graphql/schema-types.js
@@ -13,6 +13,12 @@ type Card {
   totalMatches: Int!
 }
 
+input CardFiltersInput {
+  parties: [String!]
+  partyGroups: [String!]
+  subscribedByMe: Boolean
+}
+
 type CardPageInfo {
   hasNextPage: Boolean!
   endCursor: String
@@ -32,6 +38,7 @@ type CardGroup {
   slug: String!
   cards(
     focus: [ID!]
+    filters: CardFiltersInput
     first: Int
     last: Int
     before: String
@@ -56,6 +63,7 @@ type CardGroupConnection {
 extend type User {
   cards(
     focus: [ID!]
+    filters: CardFiltersInput
     first: Int
     last: Int
     before: String

--- a/packages/cards/graphql/schema.js
+++ b/packages/cards/graphql/schema.js
@@ -15,6 +15,7 @@ type queries {
     id: ID
     accessToken: ID
     focus: [ID!]
+    filters: CardFiltersInput
     first: Int
     last: Int
     before: String


### PR DESCRIPTION
Queries with `CardConnection` as results accept filters, namely `CardFiltersInput`.

Example:

```gql
{
  cards(filters: {parties: ["SVP", "BDP"]}) {
    nodes {
      payload(paths: ["party"])
    }
  }
}
```