### PR TITLE
feat(cards): Add CardConnection.aggregations at our disposal

### DIFF
--- a/packages/cards/graphql/resolvers/CardAggregation.js
+++ b/packages/cards/graphql/resolvers/CardAggregation.js
@@ -1,0 +1,14 @@
+module.exports = {
+  buckets (aggregation, args, context) {
+    const buckets = []
+
+    Object.keys(aggregation.buckets).forEach(value => {
+      buckets.push({
+        value,
+        cards: aggregation.buckets[value]
+      })
+    })
+
+    return buckets
+  }
+}

--- a/packages/cards/graphql/resolvers/CardAggregationBucket.js
+++ b/packages/cards/graphql/resolvers/CardAggregationBucket.js
@@ -1,0 +1,11 @@
+const { paginateCards } = require('../../lib/cards')
+
+module.exports = {
+  cards (bucket, args, context) {
+    return paginateCards(
+      bucket.cards,
+      args,
+      context
+    )
+  }
+}

--- a/packages/cards/graphql/resolvers/CardConnection.js
+++ b/packages/cards/graphql/resolvers/CardConnection.js
@@ -1,0 +1,36 @@
+const _ = require('lodash')
+
+const getAggregationKeyValue = (card, key) => {
+  switch (key) {
+    case 'party': return _.get(card, 'payload.party')
+    case 'fraction': return _.get(card, 'payload.fraction')
+  }
+}
+
+module.exports = {
+  aggregations (connection, args) {
+    const { keys } = args
+
+    const aggregations = []
+
+    keys.forEach(key => {
+      const buckets = {}
+
+      connection._nodes.forEach(card => {
+        const value = getAggregationKeyValue(card, key)
+
+        if (value) {
+          if (!buckets[value]) {
+            buckets[value] = []
+          }
+
+          buckets[value].push(card)
+        }
+      })
+
+      aggregations.push({ key, buckets })
+    })
+
+    return aggregations
+  }
+}

--- a/packages/cards/graphql/schema-types.js
+++ b/packages/cards/graphql/schema-types.js
@@ -15,7 +15,7 @@ type Card {
 
 input CardFiltersInput {
   parties: [String!]
-  partyGroups: [String!]
+  fractions: [String!]
   subscribedByMe: Boolean
 }
 
@@ -30,6 +30,29 @@ type CardConnection {
   totalCount: Int!
   pageInfo: CardPageInfo!
   nodes: [Card!]!
+  aggregations(
+    keys: [CardAggregationKeys!]
+  ): [CardAggregation!]!
+}
+
+enum CardAggregationKeys {
+  party
+  fraction
+}
+
+type CardAggregation {
+  key: String!
+  buckets: [CardAggregationBucket!]!
+}
+
+type CardAggregationBucket {
+  value: String!
+  cards(
+    first: Int
+    last: Int
+    before: String
+    after: String
+  ): CardConnection!
 }
 
 type CardGroup {

--- a/packages/cards/lib/cards.js
+++ b/packages/cards/lib/cards.js
@@ -73,12 +73,12 @@ const filterCards = async (cards, { filters = {} }, context) => {
     ))
   }
 
-  // { partyGroups: [ <partyGroup 1>, ...<partyGroup n> ]}
-  if (filters.partyGroups) {
+  // { fractions: [ <fraction 1>, ...<fraction n> ]}
+  if (filters.fractions) {
     filteredCards = filteredCards.filter(card => (
       card.payload &&
-      card.payload.party &&
-      filters.partyGroups.includes(card.payload.partyGroup)
+      card.payload.fraction &&
+      filters.fractions.includes(card.payload.fraction)
     ))
   }
 

--- a/packages/utils/paginate.js
+++ b/packages/utils/paginate.js
@@ -113,6 +113,7 @@ module.exports.paginator = (args, payloadFn, nodesFn) => {
       hasPreviousPage,
       startCursor: hasPreviousPage ? objectToBase64({ id: startCursor, payload }) : null
     },
-    nodes: nodeSubset
+    nodes: nodeSubset,
+    _nodes: nodes
   }
 }


### PR DESCRIPTION
This puts `CardConnection.aggregations` at our disposal and returns aggregations with "buckets".

Usage example:

```gql
{
  cards {
    totalCount
    aggregations(keys: [fraction]) {
      key
      buckets {
        value
        cards {
          totalCount
        }
      }
    }
  }
}
```

Results in

```json
{
  "data": {
    "cards": {
      "totalCount": 4741,
      "aggregations": [
        {
          "key": "fraction",
          "buckets": [
            {
              "value": "FDP",
              "cards": {
                "totalCount": 537
              }
            },
            [...]
          ]
        }
      ]
    }
  }
}
```