### PR TITLE
feat(auth): Default auth challenge to EMAIL_TOKEN if RepublikApp user agent is detected

### DIFF
--- a/packages/auth/graphql/resolvers/_queries/echo.js
+++ b/packages/auth/graphql/resolvers/_queries/echo.js
@@ -11,6 +11,7 @@ module.exports = async (_, args, { req }) => {
   return {
     ipAddress: ip,
     userAgent: useragent.detect(ua),
+    isApp: useragent.isApp(ua),
     country,
     countryFlag: countryCode ? flag(countryCode) : '🏴',
     city

--- a/packages/auth/graphql/schema-types.js
+++ b/packages/auth/graphql/schema-types.js
@@ -94,6 +94,7 @@ input RequiredUserFields {
 type RequestInfo {
   ipAddress: String!
   userAgent: String
+  isApp: Boolean!
   country: String
   countryFlag: String
   city: String

--- a/packages/auth/lib/Users.js
+++ b/packages/auth/lib/Users.js
@@ -6,6 +6,7 @@ const Promise = require('bluebird')
 const debug = require('debug')('auth:lib:Users')
 const { sendMailTemplate, moveNewsletterSubscriptions } = require('@orbiting/backend-modules-mail')
 const t = require('./t')
+const useragent = require('./useragent')
 const { newAuthError } = require('./AuthError')
 const {
   ensureAllRequiredConsents,
@@ -149,12 +150,13 @@ const signIn = async (_email, context, pgdb, req, consents, _tokenType) => {
   })
 
   const { email } = (user || { email: _email })
+  const isApp = useragent.isApp(req.headers['user-agent'])
 
   const { EMAIL_TOKEN, EMAIL_CODE } = TokenTypes
   // check if tokenType is enabled as firstFactor
   // email is always enabled
   const enabledTokenTypes = await enabledFirstFactors(email, pgdb)
-  let tokenType = _tokenType
+  let tokenType = _tokenType || (isApp && EMAIL_TOKEN)
   if (!tokenType || tokenType !== EMAIL_TOKEN) {
     if (!tokenType) {
       tokenType = enabledTokenTypes[0]

--- a/packages/auth/lib/useragent.js
+++ b/packages/auth/lib/useragent.js
@@ -17,3 +17,12 @@ module.exports.detect = (ua) => {
 
   return info.toString()
 }
+
+module.exports.isApp = (ua) => {
+  if (ua) {
+    const match = ua.match(appRegex)
+    return !!match
+  }
+
+  return false
+}


### PR DESCRIPTION
When signing in in Republik app, default first factor (token, challenge) becomes `EMAIL_TOKEN`.

Can be overwritten if token type is explicitly stated.

And for fun, `echo` query returns `isApp` flag.