### PR TITLE
feat(crowdfundings): Exclude membership with auto pay flag from prolong notices flow

### DIFF
--- a/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
@@ -81,6 +81,7 @@ const getBuckets = async ({ now }, context) => {
       m."userId" != :PARKING_USER_ID
       AND m.active = true
       AND m.renew = true
+      AND m."autoPay" = false
   `, {
     PARKING_USER_ID
   })


### PR DESCRIPTION
These users will slip into a dedicated, yet-to-be-defined flow.