### PR TITLE
Notice email about automated charge to membership owners

### DIFF
--- a/packages/mail/lib/sendMailTemplate.js
+++ b/packages/mail/lib/sendMailTemplate.js
@@ -38,82 +38,108 @@ const getTemplate = (name) => {
 }
 
 const envMergeVars = [
-  { name: 'frontend_base_url',
+  {
+    name: 'frontend_base_url',
     content: FRONTEND_BASE_URL
   },
-  { name: 'link_faq',
+  {
+    name: 'link_faq',
     content: `${FRONTEND_BASE_URL}/faq`
   },
-  { name: 'link_manifest',
+  {
+    name: 'link_manifest',
     content: `${FRONTEND_BASE_URL}/manifest`
   },
-  { name: 'link_imprint',
+  {
+    name: 'link_imprint',
     content: `${FRONTEND_BASE_URL}/impressum`
   },
-  { name: 'assets_server_base_url',
+  {
+    name: 'assets_server_base_url',
     content: ASSETS_SERVER_BASE_URL
   },
-  { name: 'link_signin',
+  {
+    name: 'link_signin',
     content: `${FRONTEND_BASE_URL}/anmelden`
   },
-  { name: 'link_claim_contextless',
+  {
+    name: 'link_claim_contextless',
     content: `${FRONTEND_BASE_URL}/abholen`
   },
-  { name: 'link_account',
+  {
+    name: 'link_account',
     content: `${FRONTEND_BASE_URL}/konto`
   },
-  { name: 'link_account_abos',
+  {
+    name: 'link_account_abos',
     content: `${FRONTEND_BASE_URL}/konto#abos`
   },
-  { name: 'link_account_share',
+  {
+    name: 'link_account_share',
     content: `${FRONTEND_BASE_URL}/konto#teilen`
   },
-  { name: 'link_account_account',
+  {
+    name: 'link_account_account',
     content: `${FRONTEND_BASE_URL}/konto#account`
   },
-  { name: 'link_account_notifications',
+  {
+    name: 'link_account_notifications',
     content: `${FRONTEND_BASE_URL}/konto#benachrichtigungen`
   },
-  { name: 'link_profile',
+  {
+    name: 'link_profile',
     content: `${FRONTEND_BASE_URL}/~me`
   },
-  { name: 'link_offers_overview',
+  {
+    name: 'link_offers_overview',
     content: `${FRONTEND_BASE_URL}/angebote`
   },
-  { name: 'link_offers',
+  {
+    name: 'link_offers',
     content: `${FRONTEND_BASE_URL}/angebote?package=ABO`
   },
-  { name: 'link_offer_abo',
+  {
+    name: 'link_offer_abo',
     content: `${FRONTEND_BASE_URL}/angebote?package=ABO`
   },
-  { name: 'link_offer_monthly_abo',
+  {
+    name: 'link_offer_monthly_abo',
     content: `${FRONTEND_BASE_URL}/angebote?package=MONTHLY_ABO`
   },
-  { name: 'link_offer_benefactor',
+  {
+    name: 'link_offer_benefactor',
     content: `${FRONTEND_BASE_URL}/angebote?package=BENEFACTOR`
   },
-  { name: 'link_offer_donate',
+  {
+    name: 'link_offer_donate',
     content: `${FRONTEND_BASE_URL}/angebote?package=BENEFACTOR`
   },
-  { name: 'link_offer_reduced_ausbildung',
+  {
+    name: 'link_offer_reduced_ausbildung',
     content: `${FRONTEND_BASE_URL}/angebote?package=ABO&userPrice=1&price=14000&reason=Ausbildung%3A%20`
   },
-  { name: 'link_dialog',
+  {
+    name: 'link_dialog',
     content: `${FRONTEND_BASE_URL}/dialog`
   },
-  { name: 'link_app',
+  {
+    name: 'link_app',
     content: `${FRONTEND_BASE_URL}/app`
   },
-  { name: 'link_manual',
+  {
+    name: 'link_manual',
     content: `${FRONTEND_BASE_URL}/anleitung`
   },
-  { name: 'link_listen',
+  {
+    name: 'link_listen',
     content: `${FRONTEND_BASE_URL}/vorgelesen`
   },
-  { name: 'link_projectr',
+  {
+    name: 'link_projectr',
     content: 'https://project-r.construction/'
   },
-  { name: 'link_project_r',
+  {
+    name: 'link_project_r',
     content: 'https://project-r.construction/news'
   }
 ]
@@ -166,7 +192,7 @@ module.exports = async (mail, context, log) => {
   const mergeVars = [
     ...mail.globalMergeVars || [],
     ...envMergeVars
-  ]
+  ].filter(Boolean)
 
   const message = {
     to: [{ email: mail.to }],

--- a/packages/mail/templates/membership_owner_autopay_notice_5.html
+++ b/packages/mail/templates/membership_owner_autopay_notice_5.html
@@ -39,7 +39,7 @@
                       Sehr geehrter Herr
                     </p>
                     <p>Am {{end_date}} erneuert sich Ihre Mitgliedschaft um ein weiteres Jahr. Bei Ihrem letzten Kauf haben Sie angegeben, dass Sie uns erlauben, Ihre hinterlegte Kreditkarte automatisch zu belasten.</p>
-                    <p>Diese E-Mail informiert Sie darüber, dass wir das in {{days_left}} Tagen tatsächlich und unverfroren tun werden: Ihre {{card_brand}}-Kreditkarte mit den Endziffern {{card_last4}} belasten wir am {{end_date}} mit {{last_pledge_total}}.</p>
+                    <p>Diese E-Mail informiert Sie darüber, dass wir das in {{days_left}} Tagen tatsächlich und unverfroren tun werden: Ihre {{autopay_card_brand}}-Kreditkarte mit den Endziffern {{autopay_card_last4}} belasten wir am {{end_date}} mit {{autopay_total}}.</p>
                     <p>Bis dahin können Sie, falls gewünscht, <a href="{{prolong_url}}">eine andere Kreditkarte hinterlegen</a>, <a href="{{prolong_url}}">eine andere Zahlungsart wählen</a> oder <a href="{{link_account_abos}}">im Konto die Mitgliedschaft verwalten</a>.</p>
                     <p>Wir melden uns erneut, sobald Ihr Abonnement erfolgreich verlängert wurde. In der Zwischenzeit können Sie sich bei Fragen unter <a href="mailto:kontakt@republik.ch">kontakt@republik.ch</a> melden.</p>
                     <p>Herzlich</p>

--- a/packages/mail/templates/membership_owner_autopay_notice_5.html
+++ b/packages/mail/templates/membership_owner_autopay_notice_5.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="x-ua-compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <!--[if gte mso 15]>
+    <xml>
+      <o:officedocumentsettings>
+        <o:allowpng />
+        <o:pixelsperinch>96</o:pixelsperinch>
+      </o:officedocumentsettings>
+    </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff;">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:640px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}">
+              <tbody>
+                <tr>
+                  <td style="padding:20px;">
+                    <p>
+                      Sehr geehrte Dame<br />
+                      Sehr geehrter Herr
+                    </p>
+                    <p>Am {{end_date}} erneuert sich Ihre Mitgliedschaft um ein weiteres Jahr. Bei Ihrem letzten Kauf haben Sie angegeben, dass Sie uns erlauben, Ihre hinterlegte Kreditkarte automatisch zu belasten.</p>
+                    <p>Diese E-Mail informiert Sie darüber, dass wir das in {{days_left}} Tagen tatsächlich und unverfroren tun werden: Ihre {{card_brand}}-Kreditkarte mit den Endziffern {{card_last4}} belasten wir am {{end_date}} mit {{last_pledge_total}}.</p>
+                    <p>Bis dahin können Sie, falls gewünscht, <a href="{{prolong_url}}">eine andere Kreditkarte hinterlegen</a>, <a href="{{prolong_url}}">eine andere Zahlungsart wählen</a> oder <a href="{{link_account_abos}}">im Konto die Mitgliedschaft verwalten</a>.</p>
+                    <p>Wir melden uns erneut, sobald Ihr Abonnement erfolgreich verlängert wurde. In der Zwischenzeit können Sie sich bei Fragen unter <a href="mailto:kontakt@republik.ch">kontakt@republik.ch</a> melden.</p>
+                    <p>Herzlich</p>
+                    <p>Ihre Crew der Republik</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:20px;">
+                    <p style="font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}">
+                      Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik, Wirtschaft, Gesellschaft und Kultur. 
+                      Es wird von seinen Leserinnen und Lesern finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen Beiträgen. In der App, auf der Website und als Newsletter.
+                    </p>
+                    <p style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}">
+                      <img height="79" src="{{frontend_base_url}}/static/logo_republik_newsletter.png" style="border:0px;width:180px !important; height:79px !important;margin:0px;" width="180" alt="">
+                      <br>
+                      Republik AG<br>
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br>
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br>
+                      <a href="mailto:kontakt@republik.ch">kontakt@republik.ch</a>
+                    </p>
+                    <p style="font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}">
+                        <a href="{{link_manifest}}">Unser Manifest</a><br />
+                        <a href="{{link_imprint}}">Das Impressum</a><br />
+                        <a href="{{link_faq}}">Häufig gestellte Fragen</a>
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-09-09T17:58:10.645Z",
+  "updated": "2019-11-18T13:02:39.176Z",
   "title": "live",
   "data": [
     {
@@ -549,6 +549,10 @@
     {
       "key": "api/email/membership_owner_prolong_notice_0/subject",
       "value": "Ihre Abonnementsrechnung"
+    },
+    {
+      "key": "api/email/membership_owner_autopay_notice_5/subject",
+      "value": "Ihre Mitgliedschaft erneuert sich automatisch"
     },
     {
       "key": "api/email/membership_deactivated_abo_uncancelled/sequenceNumber/true/subject",
@@ -1616,7 +1620,7 @@
     },
     {
       "key": "profile/cards/needed",
-      "value": "Ihr Profil ist im Moment einer Kandidatur zugeordnet und kann im Moment nicht zurückgenommen werden."
+      "value": "Ihr Profil ist im Moment einer Wahltindär-Karte zugeordnet und kann im Moment nicht zurückgenommen werden."
     }
   ]
 }

--- a/packages/utils/findLastMembershipPledge.js
+++ b/packages/utils/findLastMembershipPledge.js
@@ -35,14 +35,13 @@ module.exports = async (membershipId, pgdb) => {
     { orderBy: { createdAt: 'DESC' }, limit: 1 }
   )
 
-  // Used card in payment (if available)
-  const card =
-    payment.pspPayload &&
-    payment.pspPayload.source &&
-    payment.pspPayload.source.card
-
   return {
-    ...pledge,
-    card
+    pledge,
+    autoPayPreferences: {
+      card: payment.pspPayload &&
+        payment.pspPayload.source &&
+        payment.pspPayload.source.card,
+      total: pledge.total
+    }
   }
 }

--- a/packages/utils/findLastMembershipPledge.js
+++ b/packages/utils/findLastMembershipPledge.js
@@ -6,7 +6,7 @@ module.exports = async (membershipId, pgdb) => {
     return false
   }
 
-  // Find pledgeOptions, in which autoPay-flag is set
+  // Find pledgeOptions
   const relatedPledgeOptions = await pgdb.public.pledgeOptions.find(
     {
       or: [

--- a/packages/utils/findLastMembershipPledge.js
+++ b/packages/utils/findLastMembershipPledge.js
@@ -1,0 +1,48 @@
+module.exports = async (membershipId, pgdb) => {
+  // Find membership
+  const membership = await pgdb.public.memberships.findOne({ id: membershipId })
+
+  if (!membership) {
+    return false
+  }
+
+  // Find pledgeOptions, in which autoPay-flag is set
+  const relatedPledgeOptions = await pgdb.public.pledgeOptions.find(
+    {
+      or: [
+        { membershipId },
+        { pledgeId: membership.pledgeId }
+      ]
+    }
+  )
+
+  if (relatedPledgeOptions.length < 1) {
+    return false
+  }
+
+  // Find latest pledge
+  const pledge = await pgdb.public.pledges.findOne(
+    { id: relatedPledgeOptions.map(po => po.pledgeId), status: 'SUCCESSFUL' },
+    { orderBy: { createdAt: 'DESC' }, limit: 1 }
+  )
+
+  // Find latest pledge payments
+  const pledgePayments = await pgdb.public.pledgePayments.find({ pledgeId: pledge.id })
+
+  // Find latest pledge payment
+  const payment = await pgdb.public.payments.findOne(
+    { id: pledgePayments.map(p => p.paymentId) },
+    { orderBy: { createdAt: 'DESC' }, limit: 1 }
+  )
+
+  // Used card in payment (if available)
+  const card =
+    payment.pspPayload &&
+    payment.pspPayload.source &&
+    payment.pspPayload.source.card
+
+  return {
+    ...pledge,
+    card
+  }
+}

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -4,5 +4,6 @@ module.exports = {
   paginate: require('./paginate'),
   naming: require('./naming'),
   mdastToString: require('./mdastToString'),
-  hasUserActiveMembership: require('./hasUserActiveMembership')
+  hasUserActiveMembership: require('./hasUserActiveMembership'),
+  findLastMembershipPledge: require('./findLastMembershipPledge')
 }

--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -6,7 +6,6 @@ const { grants } = require('@orbiting/backend-modules-access')
 const { transformUser, AccessToken } = require('@orbiting/backend-modules-auth')
 const { timeFormat, formatPriceChf } =
   require('@orbiting/backend-modules-formats')
-const { findLastMembershipPledge } = require('@orbiting/backend-modules-utils')
 
 const { getLastEndDate } = require('./utils')
 const { count: memberStatsCount } = require('../../../lib/memberStats')
@@ -372,7 +371,7 @@ mail.prepareMembershipOwnerNotice = async ({ user, endDate, graceEndDate, cancel
   const membershipId = user.membershipId || false
   const sequenceNumber = user.membershipSequenceNumber || false
 
-  const { total, card } = await findLastMembershipPledge(membershipId, pgdb)
+  const autoPayPreferences = user.lastPledge && user.lastPledge.autoPayPreferences
 
   return ({
     to: user.email,
@@ -420,17 +419,17 @@ mail.prepareMembershipOwnerNotice = async ({ user, endDate, graceEndDate, cancel
         name: 'sequence_number',
         content: sequenceNumber
       },
-      total && {
-        name: 'last_pledge_total',
-        content: formatPriceChf(total / 100)
+      autoPayPreferences && {
+        name: 'autopay_total',
+        content: formatPriceChf(autoPayPreferences.total / 100)
       },
-      card && {
-        name: 'card_brand',
-        content: card.brand
+      autoPayPreferences && {
+        name: 'autopay_card_brand',
+        content: autoPayPreferences.card.brand
       },
-      card && {
-        name: 'card_last4',
-        content: card.last4
+      autoPayPreferences && {
+        name: 'autopay_card_last4',
+        content: autoPayPreferences.card.last4
       }
     ]
   })

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -8,7 +8,7 @@ const {
   timeScheduler
 } = require('@orbiting/backend-modules-schedulers')
 
-const lockTtlSecs = 5 * 60 // 10min
+const lockTtlSecs = 60 * 5 // 5 mins
 
 const { inform: informGivers } = require('./givers')
 const { inform: informCancellers } = require('./winbacks')
@@ -41,13 +41,12 @@ const init = async (_context) => {
   )
 
   schedulers.push(
-    timeScheduler.init({
+    intervalScheduler.init({
       name: 'memberships-owners',
       context,
       runFunc: informOwners,
       lockTtlSecs,
-      runAtTime: '06:30',
-      runInitially: DEV
+      runIntervalSecs: 60 * 10
     })
   )
 


### PR DESCRIPTION
This Pull Request sends earliest 5 days before a membership is planned to be renewed a transactional email, notify a user about upcoming charge.

Code is run [in membership owner scheduler](https://github.com/orbiting/backends/compare/feat-autopay-notice-5?expand=1#diff-7fd8e0d8a72be494c664c0b3c22c555d) in which we hold now a new bucket ("membership_owner_autopay_notice_5"), and altered scheduler to allow `autoPay` to be a bucket condition.

Membership owner scheduler [runs every 10 minutes](https://github.com/orbiting/backends/compare/feat-autopay-notice-5?expand=1#diff-588ec577936693da893ff2fc8d4b4424R43-R51) instead of once a day.

Upcoming charge is determined using [last membership pledge and it's (most recent) payment](https://github.com/orbiting/backends/compare/feat-autopay-notice-5?expand=1#diff-21d5bc1d878369209a6114907a73e222). This is subject to change depending on upcoming business logic.

Credit card details are [retrieved from payment service provider payload in a payment](https://github.com/orbiting/backends/compare/feat-autopay-notice-5?expand=1#diff-21d5bc1d878369209a6114907a73e222R39-R47) (`payment.pspPayload`) and passed along.