### PR TITLE
fix(crowdfundings): Send subscription_failed mail only of there is a next payment attempt scheduled

### DIFF
--- a/packages/mail/templates/subscription_end.html
+++ b/packages/mail/templates/subscription_end.html
@@ -36,14 +36,12 @@
                   <td style="padding:20px;">
                     <p>Guten Tag</p>
                     {{#if is_automatic_overdue_cancel}}
-                      <p>Leider konnten wir wiederholt Ihr Republik-Monatsabonnement nicht Ihrer Kreditkarte belasten und haben nun Ihr Monatsabonnement deaktiviert.</p>
-                      <p>Sie haben jederzeit die Möglichkeit, erneut ein Monatsabonnement oder Jahresmitgliedschaft abzuschliessen.</p>
+                      <p>Leider konnten wir <a href="{{link_account_abos}}">Ihr Republik-Monatsabonnement</a> wiederholt nicht von Ihrer Kreditkarte abbuchen und mussten es aus diesem Grund deaktivieren.</p>
+                      <p>Wir danken Ihnen herzlich für Ihr Interesse und Ihre Unterstützung! Und wir würden uns sehr freuen, wenn Sie zu einem späteren Zeitpunkt wieder bei uns vorbeischauten. Sie haben jederzeit die Möglichkeit, erneut ein <a href="{{link_offer_monthly_abo}}">Monatsabonnement</a> oder eine <a href="{{link_offer_abo}}">Jahresmitgliedschaft</a> abzuschliessen.</p>
+                      <p>Falls Sie Fragen haben, helfen wir Ihnen gerne weiter unter <a href="kontakt@republik.ch">kontakt@republik.ch</a>.</p>
                     {{else}}
                       <p><strong>Heute endete Ihr Republik-Abonnement.</strong> Herzlichen Dank für Ihr Interesse und Ihre Unterstützung!</p>
-                      <p>
-                        Wir würden uns sehr freuen, wenn Sie zu einem späteren Zeitpunkt wieder bei uns vorbeischauten.<br />
-                        Sie sind jederzeit willkommen und können <a href="{{link_account_abos}}">Ihr Monatsabo hier ganz einfach wieder aktivieren</a>.
-                      </p>
+                      <p>Wir würden uns sehr freuen, wenn Sie zu einem späteren Zeitpunkt wieder bei uns vorbeischauten.<br />Sie sind jederzeit willkommen und können <a href="{{link_account_abos}}">Ihr Monatsabo hier ganz einfach wieder aktivieren</a>.</p>
                     {{/if}}
                     <p>Herzlich</p>
                     <p>Ihre Crew der Republik</p>

--- a/packages/mail/templates/subscription_end.html
+++ b/packages/mail/templates/subscription_end.html
@@ -35,11 +35,16 @@
                 <tr>
                   <td style="padding:20px;">
                     <p>Guten Tag</p>
-                    <p><strong>Heute endete Ihr Republik-Abonnement.</strong> Herzlichen Dank für Ihr Interesse und Ihre Unterstützung!</p>
-                    <p>
-                      Wir würden uns sehr freuen, wenn Sie zu einem späteren Zeitpunkt wieder bei uns vorbeischauten.<br />
-	                    Sie sind jederzeit willkommen und können <a href="{{link_account_abos}}">Ihr Monatsabo hier ganz einfach wieder aktivieren</a>.
-                    </p>
+                    {{#if is_automatic_overdue_cancel}}
+                      <p>Leider konnten wir wiederholt Ihr Republik-Monatsabonnement nicht Ihrer Kreditkarte belasten und haben nun Ihr Monatsabonnement deaktiviert.</p>
+                      <p>Sie haben jederzeit die Möglichkeit, erneut ein Monatsabonnement oder Jahresmitgliedschaft abzuschliessen.</p>
+                    {{else}}
+                      <p><strong>Heute endete Ihr Republik-Abonnement.</strong> Herzlichen Dank für Ihr Interesse und Ihre Unterstützung!</p>
+                      <p>
+                        Wir würden uns sehr freuen, wenn Sie zu einem späteren Zeitpunkt wieder bei uns vorbeischauten.<br />
+                        Sie sind jederzeit willkommen und können <a href="{{link_account_abos}}">Ihr Monatsabo hier ganz einfach wieder aktivieren</a>.
+                      </p>
+                    {{/if}}
                     <p>Herzlich</p>
                     <p>Ihre Crew der Republik</p>
                   </td>

--- a/servers/republik/modules/crowdfundings/lib/payments/stripe/webhooks/customerSubscription.js
+++ b/servers/republik/modules/crowdfundings/lib/payments/stripe/webhooks/customerSubscription.js
@@ -87,8 +87,8 @@ module.exports = {
                     .join(' ')
                 },
                 /**
-                 * `overdue_cancel` should be true, if a a subscription is deleted past due
-                 * and event was fired automatic (not via API).
+                 * `is_automatic_overdue_cancel` should be true, if a a subscription is deleted past
+                 * due and event was fired automatic (not via API).
                  */
                 {
                   name: 'is_automatic_overdue_cancel',

--- a/servers/republik/modules/crowdfundings/lib/payments/stripe/webhooks/invoicePaymentFailed.js
+++ b/servers/republik/modules/crowdfundings/lib/payments/stripe/webhooks/invoicePaymentFailed.js
@@ -49,18 +49,22 @@ module.exports = {
         })
       }
 
-      await sendMailTemplate({
-        to: user.email,
-        subject: t('api/email/subscription/payment/failed/subject'),
-        templateName: 'subscription_failed',
-        globalMergeVars: [
-          { name: 'NAME',
-            content: [user.firstName, user.lastName]
-              .filter(Boolean)
-              .join(' ')
-          }
-        ]
-      }, { pgdb })
+      const hasNextPaymentAttempt = !!_.get(event, 'data.object.next_payment_attempt')
+      if (hasNextPaymentAttempt) {
+        await sendMailTemplate({
+          to: user.email,
+          subject: t('api/email/subscription/payment/failed/subject'),
+          templateName: 'subscription_failed',
+          globalMergeVars: [
+            {
+              name: 'NAME',
+              content: [user.firstName, user.lastName]
+                .filter(Boolean)
+                .join(' ')
+            }
+          ]
+        }, { pgdb })
+      }
     }
   }
 }


### PR DESCRIPTION
This Pull Request prevents two transactional emails to be send back-to-back:

a) last failed charge attempt ("payment failed")
b) subscription now ending.

If a payment fails, Stripe reports event `invoice.payment_failed` and a transactional email is sent (a).

Subsequently, if there are no more attempts to be scheduled, subscription will be deleted. Stripe then reports `customer.subscription.deleted`. Once more a transactional email (b) is dispatched, usually within moments of previous event `invoice.payment_failed`.

Event `invoice.payment_failed` holds a property `data.object.next_payment_attempt` and is falsy, if there is no more charge attempt scheduled. In this code change, we use this property to suppress "payment failed" email (a).

Meanwhile "subscription end" email (b) has a new merge variable `is_automated_overdue_cancel` which indicates that a subscription was cancelled automatically and past due. Email templates is updated accordingly but requires a final wording.

This Pull Request requires manual testing.

- [x] Finalize wording in `subscription_end` email template
- [x] Manual testing