### PR TITLE
Replace time scheduled w/ interval publication scheduler

### DIFF
--- a/packages/schedulers/lib/intervalScheduler.js
+++ b/packages/schedulers/lib/intervalScheduler.js
@@ -20,7 +20,7 @@ const init = async ({
     throw new Error(`missing input, scheduler ${name}`)
   }
   if (runIntervalSecs < lockTtlSecs) {
-    console.error(`lockTtlSecs bigger than runIntervalSecs`, { runIntervalSecs, lockTtlSecs })
+    console.error('lockTtlSecs bigger than runIntervalSecs', { runIntervalSecs, lockTtlSecs })
     throw new Error(`lockTtlSecs bigger than runIntervalSecs, scheduler ${name}`)
   }
   if (dryRun) {
@@ -124,6 +124,7 @@ const init = async ({
   }
 
   return {
+    run,
     close
   }
 }

--- a/packages/schedulers/lib/timeScheduler.js
+++ b/packages/schedulers/lib/timeScheduler.js
@@ -141,6 +141,7 @@ const init = async ({
   }
 
   return {
+    run,
     close
   }
 }

--- a/servers/publikator/graphql/resolvers/_mutations/publish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/publish.js
@@ -10,7 +10,6 @@ const {
   upsertRef,
   deleteRef
 } = require('../../../lib/github')
-const { channelKey } = require('../../../lib/PublicationScheduler')
 const {
   createCampaign,
   updateCampaignContent,
@@ -39,9 +38,11 @@ const {
     }
   }
 } = require('@orbiting/backend-modules-documents')
-const { lib: {
-  Repo: { uploadImages }
-} } = require('@orbiting/backend-modules-assets')
+const {
+  lib: {
+    Repo: { uploadImages }
+  }
+} = require('@orbiting/backend-modules-assets')
 const uniq = require('lodash/uniq')
 const { upsert: repoCacheUpsert } = require('../../../lib/cache/upsert')
 
@@ -150,9 +151,9 @@ module.exports = async (
   const resolvedDoc = JSON.parse(JSON.stringify(doc))
 
   const utmParams = {
-    'utm_source': 'newsletter',
-    'utm_medium': 'email',
-    'utm_campaign': repoId
+    utm_source: 'newsletter',
+    utm_medium: 'email',
+    utm_campaign: repoId
   }
 
   const searchString = '?' + querystring.stringify(utmParams)
@@ -335,7 +336,7 @@ module.exports = async (
       gitOps = gitOps.concat(
         upsertRef(
           repoId,
-          `tags/prepublication`,
+          'tags/prepublication',
           milestone.sha
         )
       )
@@ -398,8 +399,6 @@ module.exports = async (
     meta: repoMeta,
     publications: await getLatestPublications({ id: repoId })
   }, context)
-
-  await redis.publishAsync(channelKey, 'refresh')
 
   // release for nice view on github
   // this is optional, the release is not read back again

--- a/servers/publikator/graphql/resolvers/_mutations/unpublish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/unpublish.js
@@ -1,6 +1,5 @@
 const { Roles: { ensureUserHasRole } } = require('@orbiting/backend-modules-auth')
 
-const { channelKey } = require('../../../lib/PublicationScheduler')
 const { deleteRef } = require('../../../lib/github')
 const {
   latestPublications: getLatestPublications,
@@ -50,8 +49,6 @@ module.exports = async (
     meta: await getRepoMeta({ id: repoId }),
     publications: await getLatestPublications({ id: repoId })
   }, context)
-
-  await redis.publishAsync(channelKey, 'refresh')
 
   await pubsub.publish('repoUpdate', {
     repoUpdate: {

--- a/servers/publikator/lib/PublicationScheduler.js
+++ b/servers/publikator/lib/PublicationScheduler.js
@@ -70,8 +70,6 @@ const init = async (_context) => {
         debug('scheduled documents found', docs.length)
       }
 
-      // await new Promise(resolve => setTimeout(() => resolve(), 1000 * 4))
-
       await Promise.each(docs, async doc => {
         // repos:republik/article-briefing-aus-bern-14/scheduled-publication
         const repoId = doc.meta.repoId

--- a/servers/publikator/lib/PublicationScheduler.js
+++ b/servers/publikator/lib/PublicationScheduler.js
@@ -1,9 +1,12 @@
-const CronJob = require('cron').CronJob
-const Redlock = require('redlock')
-const debug = require('debug')('publikator:lib:publicationScheduler')
-const Redis = require('@orbiting/backend-modules-base/lib/Redis')
+const debug = require('debug')('publikator:lib:scheduler')
+const Promise = require('bluebird')
+
 const PgDb = require('@orbiting/backend-modules-base/lib/PgDb')
-const Elasticsearch = require('@orbiting/backend-modules-base/lib/Elasticsearch')
+const Redis = require('@orbiting/backend-modules-base/lib/Redis')
+const Elastic = require('@orbiting/backend-modules-base/lib/Elasticsearch')
+const {
+  intervalScheduler
+} = require('@orbiting/backend-modules-schedulers')
 const indices = require('@orbiting/backend-modules-search/lib/indices')
 const index = indices.dict.documents
 const { getIndexAlias } = require('@orbiting/backend-modules-search/lib/utils')
@@ -18,34 +21,21 @@ const {
 } = require('./github')
 const { upsert: repoCacheUpsert } = require('./cache/upsert')
 
-const lockKey = 'locks:scheduling'
-const ttl = 1000 * 60 * 2 // 2 minutes
-const channelKey = 'scheduling'
+const lockTtlSecs = 10 // 10 seconds
 
-let singleton
-
-const redlock = (redis) =>
-  new Redlock(
-    [redis],
-    {
-      driftFactor: 0.01, // time in ms
-      retryCount: 10,
-      retryDelay: 600,
-      retryJitter: 200
-    }
-  )
-
-const getSchedulableDocuments = async (elastic) => {
+const getScheduledDocuments = async (elastic) => {
   const response = await elastic.search({
     index: getIndexAlias(index.name, 'read'),
-    size: 1,
+    size: lockTtlSecs, // Amount publishing 1 document a second
     body: {
       sort: { 'meta.scheduledAt': 'asc' },
       query: {
         bool: {
           must: [
             { term: { __type: 'Document' } },
-            { exists: { field: 'meta.scheduledAt' } }
+            { range: { 'meta.scheduledAt': { lte: new Date() } } },
+            { term: { '__state.published': false } },
+            { term: { '__state.prepublished': false } }
           ]
         }
       }
@@ -55,52 +45,34 @@ const getSchedulableDocuments = async (elastic) => {
   return response.hits.hits.map(hit => hit._source)
 }
 
-const init = async () => {
+const init = async (_context) => {
   debug('init')
 
-  if (singleton) {
-    throw new Error('publicationScheduler must not be initiated twice!')
-  }
-  singleton = 'init'
-
-  const elastic = await Elasticsearch.connect()
-  const redis = await Redis.connect()
   const pgdb = await PgDb.connect()
+  const redis = Redis.connect()
+  const elastic = Elastic.connect()
+  const context = {
+    ..._context,
+    pgdb,
+    redis,
+    elastic
+  }
 
-  const context = { elastic, redis, pgdb }
+  const scheduler = await intervalScheduler.init({
+    name: 'publication',
+    context,
+    runFunc: async (args, context) => {
+      const { elastic } = context
 
-  // subscribe to messages
-  const subClient = await redis.duplicate()
-  subClient.on('message', async (channel, message) => {
-    debug('incoming', { channel, message })
-    if (message === 'refresh') {
-      await refresh()
-    }
-  })
-  await subClient.subscribeAsync(channelKey)
+      const docs = await getScheduledDocuments(elastic)
 
-  let nextJob
+      if (docs.length > 0) {
+        debug('scheduled documents found', docs.length)
+      }
 
-  const run = async (_lock) => {
-    const lock = _lock || await redlock(redis).lock(lockKey, ttl)
+      // await new Promise(resolve => setTimeout(() => resolve(), 1000 * 4))
 
-    const docs = await getSchedulableDocuments(elastic)
-
-    if (docs.length > 0) {
-      const doc = docs.shift()
-
-      const delta = new Date(doc.meta.scheduledAt) - new Date()
-
-      debug(
-        'publishing...', {
-          repoId: doc.meta.repoId,
-          versionName: doc.versionName,
-          scheduledAt: doc.meta.scheduledAt,
-          delta
-        }
-      )
-
-      if (delta < 10 * 1000) { // max 10sec early
+      await Promise.each(docs, async doc => {
         // repos:republik/article-briefing-aus-bern-14/scheduled-publication
         const repoId = doc.meta.repoId
         const prepublication = doc.meta.prepublication
@@ -162,94 +134,19 @@ const init = async () => {
             refs: newRefs
           }
         )
-      } else {
-        console.error('Error: publicationScheduler was timed wrong.')
-      }
-    }
-
-    nextJob = null
-    await refresh(lock)
-
-    if (!_lock) {
-      await lock.unlock().catch((err) => { console.error(err) })
-    }
-  }
-
-  const refresh = async (_lock) => {
-    const lock = _lock || await redlock(redis).lock(lockKey, ttl)
-    const docs = await getSchedulableDocuments(elastic)
-
-    if (docs.length > 0) {
-      const doc = docs.shift()
-      const delta = new Date(doc.meta.scheduledAt) - new Date()
-
-      if (delta < 10 * 1000) { // max 10sec early
-        console.log('scheduler: unpublished documents found. catching up...')
-        await run()
-      } else {
-        debug(
-          'scheduled', {
-            repoId: doc.meta.repoId,
-            versionName: doc.versionName,
-            scheduledAt: doc.meta.scheduledAt
-          }
-        )
-
-        const nextScheduledAt = new Date(doc.meta.scheduledAt)
-        if (nextJob && nextJob.nextDate() > nextScheduledAt) {
-          nextJob.stop()
-          nextJob = null
-        }
-
-        if (!nextJob) {
-          nextJob = new CronJob(
-            nextScheduledAt,
-            run,
-            null,
-            true
-          )
-        }
-      }
-    } else if (nextJob) {
-      debug('no more scheduled documents found. removing scheduled job')
-
-      nextJob.stop()
-      nextJob = null
-    } else {
-      debug('no scheduled documents found')
-    }
-
-    if (!_lock) {
-      await lock.unlock().catch((err) => { console.error(err) })
-    }
-  }
+      })
+    },
+    lockTtlSecs,
+    runIntervalSecs: lockTtlSecs
+  })
 
   const close = async () => {
-    if (nextJob) {
-      nextJob.stop()
-      nextJob = null
-    }
-
-    // wait for job to finish
-    const lock = await redlock(redis).lock(lockKey, ttl * 10)
-
-    await subClient.unsubscribeAsync()
-
+    await scheduler.close()
     await Promise.all([
-      subClient.quit(),
-      Elasticsearch.disconnect(elastic),
-      PgDb.disconnect(pgdb)
+      PgDb.disconnect(pgdb),
+      Redis.disconnect(redis)
     ])
-
-    await lock.unlock()
-      .catch((err) => { console.error(err) })
-    await Redis.disconnect(redis)
-
-    singleton = null
   }
-
-  // An initial run
-  await refresh()
 
   return {
     close
@@ -257,6 +154,5 @@ const init = async () => {
 }
 
 module.exports = {
-  channelKey,
   init
 }


### PR DESCRIPTION
This Pull Request replaces current publication scheduler to become more robust.

It uses an interval scheduler and runs every 10 seconds. This resolves some long-standing issues in case an error is thrown while publishing or scheduling next run: A short interval ensures quick recovery on temporary issues and interval scheduled is more error prone. Publication scheduler contains a little less code to maintain.

There were no code changes to publishing procedure itself.