### PR TITLE
feat(crowdfundings): Return reward types other than MembershipType in custom package options

### DIFF
--- a/packages/mail/templates/payment_successful_abo.html
+++ b/packages/mail/templates/payment_successful_abo.html
@@ -44,28 +44,44 @@
                       <p>Wir schicken Ihnen, unserer neusten Verlegerin, unserem neusten Verleger, auch regelmässig Neuigkeiten aus Redaktion und Verlag: zu Vorhaben, Hintergründen, Entscheidungen und Fehlern. Sie können Kritik üben und Vorschläge machen. Und sich mit Ihren {{republik_memberships_count}} Kolleginnen und Kollegen in der Verlagsetage austauschen.</p>
                     {{/if}}
           
+                    <ul>
+                      {{#options}}
+                        <li>
+                          {{#if `this.oamount > 1`}}
+                            {{this.oamount}} {{this.olabel}} à {{this.oprice_formatted}}: {{this.ototal_formatted}}
+                          {{else}}
+                            {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}}
+                          {{/if}}
+                        </li>
+                      {{/options}}
+                      {{#if discount}}
+                        <li>Gewünschte Preisreduktion: –{{discount_formatted}}</li>
+                      {{/if}}
+                      {{#if donation}}
+                        <li>Spende: {{donation_formatted}}</li>
+                      {{/if}}
+                      <li>
+                        <strong>Total: {{total_formatted}}</strong>
+                      </li>
+                    </ul>
+                    
                     {{#if goodies_count}}
                       <p>
-                        <strong>Informationen zu Ihrer Bestellung:</strong><br />
                         {{#if `goodies_count == 1`}}
-                          Sie haben sich zu Ihrer Mitgliedschaft noch ein Republik-Objekt gegönnt.<br />
-                          Wir werden es Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.
+                          Sie haben sich zu Ihrer Mitgliedschaft noch ein Republik-Objekt gegönnt.
                         {{elseif `goodies_count > 1`}}
-                          Sie haben sich zu Ihrer Mitgliedschaft noch mehrere Republik-Objekte gegönnt.<br />
-                          Wir werden sie Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.
+                          Sie haben sich zu Ihrer Mitgliedschaft noch mehrere Republik-Objekte gegönnt.
+                        {{/if}}
+
+                        {{#if goodies_has_tablebook}}
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                        {{/if}}
+                        {{#if goodies_has_totebag}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                        {{elseif goodies_has_notebook}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
                         {{/if}}
                       </p>
-
-                      <ul>
-                        {{#options}}
-                          {{#if `this.otype == "Goodie"`}}
-                          <li>
-                            {{this.oamount}} {{this.olabel}}
-                          </li>
-                          {{/if}}
-                        {{/options}}
-                      </ul>
-
                       <p><strong>Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter <a href="{{link_account_account}}">{{link_account}}</a> korrekt eingetragen haben.</strong></p>
                     {{/if}}
                     

--- a/packages/mail/templates/payment_successful_abo.html
+++ b/packages/mail/templates/payment_successful_abo.html
@@ -74,7 +74,7 @@
                         {{/if}}
 
                         {{#if goodies_has_tablebook}}
-                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                         {{/if}}
                         {{#if goodies_has_totebag}}
                           Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/payment_successful_abo_give.html
+++ b/packages/mail/templates/payment_successful_abo_give.html
@@ -57,7 +57,7 @@
                         {{/if}}
 
                         {{#if goodies_has_tablebook}}
-                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                         {{/if}}
                         {{#if goodies_has_totebag}}
                           Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/payment_successful_abo_give.html
+++ b/packages/mail/templates/payment_successful_abo_give.html
@@ -49,11 +49,22 @@
                     <p>Um den Geschenkcode einzulösen, muss der neue Besitzer oder die neue Besitzerin nur auf die Seite <a href="{{link_claim}}">{{link_claim}}</a> gehen. Und ihn dort eingeben.</p>
 
                     {{#if goodies_count}}
-                      {{#if `goodies_count == 1`}}
-                        <p>Auch Ihr bestelltes Republik-Objekt eignet sich perfekt für die Code-Übergabe. Wir werden es Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                      {{elseif `goodies_count > 1`}}
-                        <p>Auch Ihre bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. Wir werden sie Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                      {{/if}}
+                      <p>
+                        {{#if `goodies_count == 1`}}
+                          Auch Ihr bestelltes Republik-Objekt eignet sich perfekt für die Code-Übergabe.
+                        {{elseif `goodies_count > 1`}}
+                          Auch Ihre bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe.
+                        {{/if}}
+
+                        {{#if goodies_has_tablebook}}
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                        {{/if}}
+                        {{#if goodies_has_totebag}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                        {{elseif goodies_has_notebook}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                        {{/if}}
+                      </p>
 
                       <ul>
                         {{#options}}

--- a/packages/mail/templates/payment_successful_abo_give_months.html
+++ b/packages/mail/templates/payment_successful_abo_give_months.html
@@ -57,7 +57,7 @@
                         {{/if}}
 
                         {{#if goodies_has_tablebook}}
-                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                         {{/if}}
                         {{#if goodies_has_totebag}}
                           Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/payment_successful_abo_give_months.html
+++ b/packages/mail/templates/payment_successful_abo_give_months.html
@@ -49,11 +49,22 @@
                     <p>Um den Geschenkcode einzulösen, muss der neue Besitzer oder die neue Besitzerin nur auf die Seite <a href="{{link_claim}}">{{link_claim}}</a> gehen. Und ihn dort eingeben.</p>
 
                     {{#if goodies_count}}
-                      {{#if `goodies_count == 1`}}
-                        <p>Auch Ihr bestelltes Republik-Objekt eignet sich perfekt für die Code-Übergabe. Wir werden es Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                      {{elseif `goodies_count > 1`}}
-                        <p>Auch Ihre bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. Wir werden sie Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                      {{/if}}
+                      <p>
+                        {{#if `goodies_count == 1`}}
+                          Auch Ihr bestelltes Republik-Objekt eignet sich perfekt für die Code-Übergabe.
+                        {{elseif `goodies_count > 1`}}
+                          Auch Ihre bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe.
+                        {{/if}}
+
+                        {{#if goodies_has_tablebook}}
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                        {{/if}}
+                        {{#if goodies_has_totebag}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                        {{elseif goodies_has_notebook}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                        {{/if}}
+                      </p>
 
                       <ul>
                         {{#options}}

--- a/packages/mail/templates/payment_successful_benefactor.html
+++ b/packages/mail/templates/payment_successful_benefactor.html
@@ -57,7 +57,7 @@
                         {{/if}}
 
                         {{#if goodies_has_tablebook}}
-                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                         {{/if}}
                         {{#if goodies_has_totebag}}
                           Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/payment_successful_benefactor.html
+++ b/packages/mail/templates/payment_successful_benefactor.html
@@ -49,20 +49,31 @@
                     <p>Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter <a href="{{link_account_account}}">{{link_account}}</a> korrekt eingetragen haben.</p>
 
                     {{#if goodies_count}}
-                      {{#if `goodies_count == 1`}}
-                        <p>Sie haben sich zu Ihrer Gönnermitgliedschaft noch ein Republik-Objekt gegönnt. Auch dieses werden wir Ihnen innerhalb der nächsten Tage per Post zustellen.</p>
-                      {{elseif `goodies_count > 1`}}
-                        <p>Sie haben sich zu Ihrer Gönnermitgliedschaft noch mehrere Republik-Objekte gegönnt. Auch diese werden wir Ihnen innerhalb der nächsten Tage per Post zustellen.</p>
-                      {{/if}}
+                      <p>
+                        {{#if `goodies_count == 1`}}
+                          Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch ein Republik-Objekt gegönnt.
+                        {{elseif `goodies_count > 1`}}
+                          Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt.
+                        {{/if}}
+
+                        {{#if goodies_has_tablebook}}
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                        {{/if}}
+                        {{#if goodies_has_totebag}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                        {{elseif goodies_has_notebook}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                        {{/if}}
+                      </p>
+
                       <ul>
                         {{#options}}
                           {{#if `this.otype == "Goodie"`}}
-                          <li>
-                            {{this.oamount}} {{this.olabel}}
-                          </li>
+                            <li>{{this.oamount}} {{this.olabel}}</li>
                           {{/if}}
                         {{/options}}
                       </ul>
+                      <p><strong>Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter <a href="{{link_account_account}}">{{link_account}}</a> korrekt eingetragen haben.</strong></p>
                     {{/if}}
                     
                     {{#if `total > 1000`}}

--- a/packages/mail/templates/payment_successful_prolong.html
+++ b/packages/mail/templates/payment_successful_prolong.html
@@ -90,7 +90,7 @@ Herzlichen Dank für Ihre grosszügige Spende.
                         {{/if}}
 
                         {{#if goodies_has_tablebook}}
-                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                         {{/if}}
                         {{#if goodies_has_totebag}}
                           Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/payment_successful_prolong.html
+++ b/packages/mail/templates/payment_successful_prolong.html
@@ -44,7 +44,11 @@
                     <ul>
                       {{#options}}
                         <li>
-                          {{this.olabel}}: {{this.ototal_formatted}}
+                          {{#if `this.oamount > 1`}}
+                            {{this.oamount}} {{this.olabel}} à {{this.oprice_formatted}}: {{this.ototal_formatted}}
+                          {{else}}
+                            {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}}
+                          {{/if}}
                         </li>
                       {{/options}}
                       {{#if discount}}
@@ -75,6 +79,26 @@ Herzlichen Dank für Ihre grosszügige Spende.
                       <p>Schön, dass Sie die Verbreitung der Republik noch mehr unterstützen: Sie haben auch die Geschenkmitgliedschaft verlängert. Wir haben die Beschenkte darüber per E-Mail informiert.</p>
                     {{elseif `gifted_memberships_count > 1`}}
                       <p>Schön, dass Sie die Verbreitung der Republik noch mehr unterstützen: Sie haben auch Ihre Geschenkmitgliedschaften verlängert. Wir haben die Beschenkten darüber per E-Mail informiert.</p>
+                    {{/if}}
+
+                    {{#if goodies_count}}
+                      <p>
+                        {{#if `goodies_count == 1`}}
+                          Sie haben sich noch ein Republik-Objekt gegönnt.
+                        {{elseif `goodies_count > 1`}}
+                          Sie haben sich noch mehrere Republik-Objekte gegönnt.
+                        {{/if}}
+
+                        {{#if goodies_has_tablebook}}
+                          Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                        {{/if}}
+                        {{#if goodies_has_totebag}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                        {{elseif goodies_has_notebook}}
+                          Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                        {{/if}}
+                      </p>
+                      <p><strong>Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter <a href="{{link_account_account}}">{{link_account}}</a> korrekt eingetragen haben.</strong></p>
                     {{/if}}
 
                     <p>

--- a/packages/mail/templates/pledge_abo.html
+++ b/packages/mail/templates/pledge_abo.html
@@ -67,23 +67,47 @@
                       </p>
                       <p><strong>Bitte vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!</strong></p>
                     {{/if}}
+
+                    <ul>
+                      {{#options}}
+                        <li>
+                          {{#if `this.oamount > 1`}}
+                            {{this.oamount}} {{this.olabel}} à {{this.oprice_formatted}}: {{this.ototal_formatted}}
+                          {{else}}
+                            {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}}
+                          {{/if}}
+                        </li>
+                      {{/options}}
+                      {{#if discount}}
+                        <li>Gewünschte Preisreduktion: –{{discount_formatted}}</li>
+                      {{/if}}
+                      {{#if donation}}
+                        <li>Spende: {{donation_formatted}}</li>
+                      {{/if}}
+                      <li>
+                        <strong>Total: {{total_formatted}}</strong>
+                      </li>
+                    </ul>
                     
                     {{#unless waiting_for_payment}}
                       {{#if goodies_count}}
-                        {{#if `goodies_count == 1`}}
-                          <p>Sie haben sich zu Ihrer Mitgliedschaft auch ein Republik-Objekt gegönnt. Wir werden es Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                        {{elseif `goodies_count > 1`}}
-                          <p>Sie haben sich zu Ihrer Mitgliedschaft noch mehrere Republik-Objekte gegönnt. Wir werden sie Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                        {{/if}}
-                        <ul>
-                        {{#options}}
-                          {{#if `this.otype == "Goodie"`}}
-                          <li>
-                            {{this.oamount}} {{this.olabel}}
-                          </li>
+                        <p>
+                          {{#if `goodies_count == 1`}}
+                            Sie haben sich zu Ihrer Mitgliedschaft noch ein Republik-Objekt gegönnt.
+                          {{elseif `goodies_count > 1`}}
+                            Sie haben sich zu Ihrer Mitgliedschaft noch mehrere Republik-Objekte gegönnt.
                           {{/if}}
-                        {{/options}}
-                        </ul>
+
+                          {{#if goodies_has_tablebook}}
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          {{/if}}
+                          {{#if goodies_has_totebag}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{elseif goodies_has_notebook}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{/if}}
+                        </p>
+                        <p><strong>Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter <a href="{{link_account_account}}">{{link_account}}</a> korrekt eingetragen haben.</strong></p>
                       {{/if}}
                     {{/unless}}
                     

--- a/packages/mail/templates/pledge_abo.html
+++ b/packages/mail/templates/pledge_abo.html
@@ -99,7 +99,7 @@
                           {{/if}}
 
                           {{#if goodies_has_tablebook}}
-                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                           {{/if}}
                           {{#if goodies_has_totebag}}
                             Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/pledge_abo_give.html
+++ b/packages/mail/templates/pledge_abo_give.html
@@ -44,13 +44,23 @@
                       <p>Um den Gutscheincode einzulösen, muss der neue Besitzer oder die neue Besitzerin nur auf die Seite <a href="{{link_claim}}">{{link_claim}}</a> gehen. Und den Code dort eingeben.</p>
                       
                       {{#if goodies_count}}
-                        {{#if `goodies_count == 1`}}
-                          <p>Auch Ihr bestelltes Republik-Objekt eignet sich perfekt für die Code-Übergabe.
-                            Wir werden es Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                        {{elseif `goodies_count > 1`}}
-                          <p>Auch Ihre bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe.
-                            Wir werden sie Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                        {{/if}}
+                        <p>
+                          {{#if `goodies_count == 1`}}
+                            Auch Ihr bestelltes Republik-Objekt eignet sich perfekt für die Code-Übergabe.
+                          {{elseif `goodies_count > 1`}}
+                            Auch Ihre bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe.
+                          {{/if}}
+
+                          {{#if goodies_has_tablebook}}
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          {{/if}}
+                          {{#if goodies_has_totebag}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{elseif goodies_has_notebook}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{/if}}
+                        </p>
+
                         <ul>
                           {{#options}}
                             {{#if `this.otype == "Goodie"`}}

--- a/packages/mail/templates/pledge_abo_give.html
+++ b/packages/mail/templates/pledge_abo_give.html
@@ -52,7 +52,7 @@
                           {{/if}}
 
                           {{#if goodies_has_tablebook}}
-                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                           {{/if}}
                           {{#if goodies_has_totebag}}
                             Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/pledge_abo_give_months.html
+++ b/packages/mail/templates/pledge_abo_give_months.html
@@ -52,7 +52,7 @@
                           {{/if}}
                           
                           {{#if goodies_has_tablebook}}
-                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                           {{/if}}
                           {{#if goodies_has_totebag}}
                             Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/pledge_abo_give_months.html
+++ b/packages/mail/templates/pledge_abo_give_months.html
@@ -44,13 +44,23 @@
                       <p>Um den Gutscheincode einzulösen, muss der neue Besitzer oder die neue Besitzerin nur auf die Seite <a href="{{link_claim}}">{{link_claim}}</a> gehen. Und den Code dort eingeben.</p>
 
                       {{#if goodies_count}}
-                        {{#if `goodies_count == 1`}}
-                          <p>Auch Ihr bestelltes Republik-Objekt eignet sich perfekt für die Code-Übergabe. 
-                            Wir werden es Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                        {{elseif `goodies_count > 1`}}
-                          <p>Auch Ihre bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. 
-                            Wir werden sie Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                        {{/if}}
+                        <p>
+                          {{#if `goodies_count == 1`}}
+                            Auch Ihr bestelltes Republik-Objekt eignet sich perfekt für die Code-Übergabe.
+                          {{elseif `goodies_count > 1`}}
+                            Auch Ihre bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe.
+                          {{/if}}
+                          
+                          {{#if goodies_has_tablebook}}
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          {{/if}}
+                          {{#if goodies_has_totebag}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{elseif goodies_has_notebook}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{/if}}
+                        </p>
+
                         <ul>
                           {{#options}}
                             {{#if `this.otype == "Goodie"`}}

--- a/packages/mail/templates/pledge_benefactor.html
+++ b/packages/mail/templates/pledge_benefactor.html
@@ -73,26 +73,49 @@
                       <p><strong>Bitte vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!</strong></p>
                     {{/if}}
 
+                    <ul>
+                      {{#options}}
+                        <li>
+                          {{#if `this.oamount > 1`}}
+                            {{this.oamount}} {{this.olabel}} à {{this.oprice_formatted}}: {{this.ototal_formatted}}
+                          {{else}}
+                            {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}}
+                          {{/if}}
+                        </li>
+                      {{/options}}
+                      {{#if discount}}
+                        <li>Gewünschte Preisreduktion: –{{discount_formatted}}</li>
+                      {{/if}}
+                      {{#if donation}}
+                        <li>Spende: {{donation_formatted}}</li>
+                      {{/if}}
+                      <li>
+                        <strong>Total: {{total_formatted}}</strong>
+                      </li>
+                    </ul>
+                    
                     {{#unless waiting_for_payment}}
                       {{#if goodies_count}}
-                        {{#if `goodies_count == 1`}}
-                          <p>Sie haben sich zu Ihrer Mitgliedschaft auch ein Republik-Objekt gegönnt. Wir werden es Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                        {{elseif `goodies_count > 1`}}
-                          <p>Sie haben sich zu Ihrer Mitgliedschaft noch mehrere Republik-Objekte gegönnt. Wir werden sie Ihnen innerhalb der nächsten 7 Werktage per Post zustellen.</p>
-                        {{/if}}
-                        <ul>
-                        {{#options}}
-                          {{#if `this.otype == "Goodie"`}}
-                          <li>
-                            {{this.oamount}} {{this.olabel}}
-                          </li>
+                        <p>
+                          {{#if `goodies_count == 1`}}
+                            Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch ein Republik-Objekt gegönnt.
+                          {{elseif `goodies_count > 1`}}
+                            Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt.
                           {{/if}}
-                        {{/options}}
-                        </ul>
+
+                          {{#if goodies_has_tablebook}}
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          {{/if}}
+                          {{#if goodies_has_totebag}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{elseif goodies_has_notebook}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{/if}}
+                        </p>
+                        <p><strong>Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter <a href="{{link_account_account}}">{{link_account}}</a> korrekt eingetragen haben.</strong></p>
                       {{/if}}
                     {{/unless}}
 
-                    
                     <p>Vielen Dank!<br />
                       Und viel Vergnügen beim Start mit der Republik.</p>
                     <p>Ihre Crew der Republik</p>

--- a/packages/mail/templates/pledge_benefactor.html
+++ b/packages/mail/templates/pledge_benefactor.html
@@ -104,7 +104,7 @@
                           {{/if}}
 
                           {{#if goodies_has_tablebook}}
-                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                           {{/if}}
                           {{#if goodies_has_totebag}}
                             Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/pledge_prolong.html
+++ b/packages/mail/templates/pledge_prolong.html
@@ -109,7 +109,7 @@
                           {{/if}}
 
                           {{#if goodies_has_tablebook}}
-                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember.
                           {{/if}}
                           {{#if goodies_has_totebag}}
                             Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.

--- a/packages/mail/templates/pledge_prolong.html
+++ b/packages/mail/templates/pledge_prolong.html
@@ -66,7 +66,11 @@
                     <ul>
                       {{#options}}
                         <li>
-                          {{this.olabel}}: {{this.ototal_formatted}}
+                          {{#if `this.oamount > 1`}}
+                            {{this.oamount}} {{this.olabel}} à {{this.oprice_formatted}}: {{this.ototal_formatted}}
+                          {{else}}
+                            {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}}
+                          {{/if}}
                         </li>
                       {{/options}}
                       {{#if discount}}
@@ -94,6 +98,28 @@
                     {{elseif `gifted_memberships_count > 1`}}
                       <p>Vielen Dank, dass Sie die Republik anderen zukommen lassen: Sie verlängern auch Ihre Geschenkabonnemente. Wir haben die Beschenkten darüber per E-Mail informiert.</p>
                     {{/if}}
+
+                    {{#unless waiting_for_payment}}
+                      {{#if goodies_count}}
+                        <p>
+                          {{#if `goodies_count == 1`}}
+                            Sie haben sich noch ein Republik-Objekt gegönnt.
+                          {{elseif `goodies_count > 1`}}
+                            Sie haben sich noch mehrere Republik-Objekte gegönnt.
+                          {{/if}}
+
+                          {{#if goodies_has_tablebook}}
+                            Versandstart für «Republik bei Stromausfall» ist der 13. Dezember. Bestellungen bis zum 18. Dezember können noch vor Weihnachten geliefert werden.
+                          {{/if}}
+                          {{#if goodies_has_totebag}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{elseif goodies_has_notebook}}
+                            Notizbücher oder Taschen liefern wir innerhalb von 7 Werktagen.
+                          {{/if}}
+                        </p>
+                        <p><strong>Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter <a href="{{link_account_account}}">{{link_account}}</a> korrekt eingetragen haben.</strong></p>
+                      {{/if}}
+                    {{/unless}}
 
                     <p>Herzlich</p>
                     <p>Ihre Crew der Republik</p>

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-11-18T13:02:39.176Z",
+  "updated": "2019-11-22T12:00:32.421Z",
   "title": "live",
   "data": [
     {
@@ -287,6 +287,10 @@
       "value": "Spende"
     },
     {
+      "key": "api/payment/invoice/item/goodie/TABLEBOOK",
+      "value": "Buch «Republik bei Stromausfall»"
+    },
+    {
       "key": "api/payment/invoice/item/goodie/NOTEBOOK",
       "value": "Notizbuch"
     },
@@ -373,6 +377,14 @@
     {
       "key": "api/email/option/goodie/totebag/other",
       "value": "Taschen"
+    },
+    {
+      "key": "api/email/option/goodie/tablebook/1",
+      "value": "Buch «Republik bei Stromausfall»"
+    },
+    {
+      "key": "api/email/option/goodie/tablebook/other",
+      "value": "Bücher «Republik bei Stromausfall»"
     },
     {
       "key": "api/email/option/membershiptype/abo/1",

--- a/servers/republik/modules/crowdfundings/lib/CustomPackages/index.js
+++ b/servers/republik/modules/crowdfundings/lib/CustomPackages/index.js
@@ -2,6 +2,7 @@ const debug = require('debug')('crowdfundings:lib:CustomPackages')
 const moment = require('moment')
 const uuid = require('uuid/v4')
 const Promise = require('bluebird')
+const { ascending, descending } = require('d3-array')
 
 const { applyPgInterval: { add: addInterval } } = require('@orbiting/backend-modules-utils')
 
@@ -88,7 +89,14 @@ const evaluate = async ({
 }) => {
   debug('evaluate')
 
-  const { reward, membershipType: packageOptionMembershipType } = packageOption
+  if (packageOption.reward.type !== 'MembershipType') {
+    return {
+      ...packageOption,
+      templateId: packageOption.id
+    }
+  }
+
+  const { membershipType: packageOptionMembershipType } = packageOption
   const { membershipType, membershipPeriods } = membership
   const now = moment()
 
@@ -96,9 +104,9 @@ const evaluate = async ({
     ...packageOption,
     templateId: packageOption.id,
     package: package_,
-    id: [ packageOption.id, membership.id ].join('-'),
+    id: [packageOption.id, membership.id].join('-'),
     membership,
-    optionGroup: reward.type === 'MembershipType' ? membership.id : false,
+    optionGroup: membership.id,
     additionalPeriods: []
   }
 
@@ -196,23 +204,21 @@ const evaluate = async ({
     }
   })
 
-  if (reward.type === 'MembershipType') {
-    // If membership stems from ABO_GIVE_MONTHS package, default ABO option
-    if (membership.pledge.package.name === 'ABO_GIVE_MONTHS') {
-      if (packageOption.membershipType.name === 'ABO') {
-        payload.defaultAmount = 1
-      }
+  // If membership stems from ABO_GIVE_MONTHS package, default ABO option
+  if (membership.pledge.package.name === 'ABO_GIVE_MONTHS') {
+    if (packageOption.membershipType.name === 'ABO') {
+      payload.defaultAmount = 1
+    }
+  } else {
+    if (membership.userId === package_.user.id) {
+      // If options is to extend membership, set defaultAmount to 1 if reward
+      // of current packageOption evaluated is same as in evaluated
+      // membership.
+      payload.defaultAmount =
+        packageOption.rewardId === membershipType.rewardId ? 1 : 0
     } else {
-      if (membership.userId === package_.user.id) {
-        // If options is to extend membership, set defaultAmount to 1 if reward
-        // of current packageOption evaluated is same as in evaluated
-        // membership.
-        payload.defaultAmount =
-          packageOption.rewardId === membershipType.rewardId ? 1 : 0
-      } else {
-        // If user does not own membership, set userPrice to false
-        payload.userPrice = false
-      }
+      // If user does not own membership, set userPrice to false
+      payload.userPrice = false
     }
   }
 
@@ -225,7 +231,7 @@ const getCustomOptions = async (package_) => {
 
   const { packageOptions } = package_
 
-  const results = []
+  const options = []
 
   await Promise.map(package_.user.memberships, membership => {
     return Promise.map(packageOptions, async packageOption => {
@@ -242,30 +248,44 @@ const getCustomOptions = async (package_) => {
         return false
       }
 
-      results.push(await evaluate({ package_, packageOption, membership }))
+      const evaluatedOption = await evaluate({ package_, packageOption, membership })
+
+      // Add option if there it is not in options already, determine
+      // by option.id.
+      if (!options.find(option => option.id === evaluatedOption.id)) {
+        options.push(evaluatedOption)
+      }
     })
   })
 
-  return results
+  // If there is no MembershipType reward left, return an empty array.
+  if (!options.filter(Boolean).find(option => option.reward.type === 'MembershipType')) {
+    return []
+  }
+
+  return options
     .filter(Boolean)
     // Sort by price
-    .sort((a, b) => a.price > b.price ? 1 : 0)
+    .sort((a, b) => descending(a.price, b.price))
     // Sort by defaultAmount
-    .sort((a, b) => a.defaultAmount < b.defaultAmount ? 1 : 0)
+    .sort((a, b) => descending(a.defaultAmount, b.defaultAmount))
     // Sort by sequenceNumber in an ascending manner
-    .sort(
-      (a, b) =>
-        a.membership.sequenceNumber < b.membership.sequenceNumber ? 1 : 0
-    )
+    .sort((a, b) => ascending(
+      a.membership && a.membership.sequenceNumber,
+      b.membership && b.membership.sequenceNumber
+    ))
     // Sort by membership "endDate", ascending
-    .sort((a, b) => {
-      const aDate = getLastEndDate(a.membership.membershipPeriods)
-      const bDate = getLastEndDate(b.membership.membershipPeriods)
-
-      return aDate < bDate ? 1 : 0
-    })
+    .sort((a, b) => ascending(
+      a.membership && getLastEndDate(a.membership.membershipPeriods),
+      b.membership && getLastEndDate(b.membership.membershipPeriods)
+    ))
     // Sort by userID, own ones up top.
-    .sort((a, b) => a.membership.userId !== package_.user.id ? 1 : 0)
+    .sort((a, b) => descending(
+      a.membership && a.membership.userId === package_.user.id,
+      b.membership && b.membership.userId === package_.user.id
+    ))
+    // Sort by sortOrder at lat
+    .sort((a, b) => ascending(a.order, b.order))
 }
 
 /*

--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -553,6 +553,20 @@ mail.getPledgeMergeVars = async (
   const donation = pledge.donation > 0 ? pledge.donation / 100 : 0
   const total = pledge.total / 100
 
+  const hasGoodies = rewardGoodies.map(goodie => {
+    return {
+      name: `goodies_has_${goodie.name.toLowerCase()}`,
+      content: !!pledgeOptions
+        .filter(
+          pledgeOption =>
+            pledgeOption.packageOption.reward &&
+            pledgeOption.packageOption.reward.name === goodie.name &&
+            pledgeOption.amount > 0
+        )
+        .length
+    }
+  })
+
   return [
     // Purchase itself
     {
@@ -685,6 +699,7 @@ mail.getPledgeMergeVars = async (
         )
         .reduce((agg, pledgeOption) => agg + pledgeOption.amount, 0)
     },
+    ...hasGoodies, // goodies_has_[goodies.name]
     {
       name: 'address',
       content: address

--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -1,5 +1,6 @@
 const debug = require('debug')('crowdfundings:lib:Mail')
 const moment = require('moment')
+const { ascending, descending } = require('d3-array')
 
 const { createMail, sendMailTemplate } = require('@orbiting/backend-modules-mail')
 const { grants } = require('@orbiting/backend-modules-access')
@@ -522,24 +523,23 @@ mail.getPledgeMergeVars = async (
   })
 
   pledgeOptions
-    // Sort by packageOption.order in an ascending manner
-    .sort(
-      (a, b) =>
-        a.packageOption &&
-        b.packageOption &&
-        a.packageOption.order > b.packageOption.order ? 1 : 0
-    )
+    // Sort by price
+    .sort((a, b) => descending(a.price, b.price))
     // Sort by sequenceNumber in an ascending manner
-    .sort(
-      (a, b) =>
-        a.membership &&
-        b.membership &&
-        a.membership.sequenceNumber < b.membership.sequenceNumber ? 1 : 0
-    )
+    .sort((a, b) => ascending(
+      a.membership && a.membership.sequenceNumber,
+      b.membership && b.membership.sequenceNumber
+    ))
     // Sort by userID, own ones up top.
-    .sort(
-      (a, b) => a.membership && a.membership.userId !== pledge.userId ? 1 : 0
-    )
+    .sort((a, b) => descending(
+      a.membership && a.membership.userId === user.id,
+      b.membership && b.membership.userId === user.id
+    ))
+    // Sort by packageOption.order in an ascending manner
+    .sort((a, b) => ascending(
+      a.packageOption && a.packageOption.order,
+      b.packageOption && b.packageOption.order
+    ))
 
   const pledgerMemberships = memberships
     .filter(membership => pledge.userId === membership.userId)


### PR DESCRIPTION
Also sorting of options in `lib/CustomPackages`, `lib/Mail` and `Pledge.options` resolver got improved.

This Pull Request should enable us to list package options other than memberships in `User.customPackages` as well as validated and accept them when submitting a pledge.