### PR TITLE
feat(republik): Add hiddenAt, disabledAt attributes and respect in queries, mutations

### DIFF
--- a/packages/migrations/migrations/20191203081148-hide-package-options.js
+++ b/packages/migrations/migrations/20191203081148-hide-package-options.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'servers/republik/migrations/sqls'
+const file = '20191203081148-hide-package-options'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)

--- a/servers/republik/migrations/sqls/20191203081148-hide-package-options-down.sql
+++ b/servers/republik/migrations/sqls/20191203081148-hide-package-options-down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."packageOptions"
+  DROP COLUMN "hiddenAt",
+  DROP COLUMN "disabledAt";

--- a/servers/republik/migrations/sqls/20191203081148-hide-package-options-up.sql
+++ b/servers/republik/migrations/sqls/20191203081148-hide-package-options-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."packageOptions"
+  ADD COLUMN "hiddenAt" timestamp with time zone,
+  ADD COLUMN "disabledAt" timestamp with time zone;

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/Crowdfunding.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/Crowdfunding.js
@@ -1,12 +1,43 @@
+const { ascending } = require('d3-array')
+
 module.exports = {
-  async packages (crowdfunding, args, {pgdb}) {
-    return pgdb.public.packages.find(
+  async packages (crowdfunding, args, { pgdb }) {
+    const now = new Date()
+
+    const packages = await pgdb.public.packages.find(
       { crowdfundingId: crowdfunding.id, custom: false },
       { orderBy: { order: 'asc' } }
     )
+
+    const packageOptions =
+      await pgdb.public.packageOptions.find(
+        {
+          packageId: packages.map(p => p.id),
+          and: [
+            { or: [{ 'disabledAt >': now }, { disabledAt: null }] },
+            { or: [{ 'hiddenAt >': now }, { hiddenAt: null }] }
+          ]
+        },
+        { orderBy: { order: 'asc' } }
+      )
+
+    return packages
+      .map(package_ => ({
+        ...package_,
+        options: packageOptions
+          .filter(po => po.packageId === package_.id)
+          .map(option => ({
+            ...option,
+            templateId: option.id,
+            package: package_
+          }))
+          .sort((a, b) => ascending(a.order, b.order))
+      }))
+      .filter(package_ => package_.options.length > 0)
+      .sort((a, b) => ascending(a.order, b.order))
   },
-  async goals (crowdfunding, args, {pgdb}) {
-    return pgdb.public.crowdfundingGoals.find({crowdfundingId: crowdfunding.id}, {
+  async goals (crowdfunding, args, { pgdb }) {
+    return pgdb.public.crowdfundingGoals.find({ crowdfundingId: crowdfunding.id }, {
       orderBy: ['people asc', 'money asc']
     })
   },

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/Package.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/Package.js
@@ -3,25 +3,5 @@ module.exports = {
     return pgdb.public.companies.findOne(
       { id: package_.companyId }
     )
-  },
-  async options (package_, args, { pgdb }) {
-    if (package_.options) {
-      return package_.options
-    }
-
-    const packageOptions =
-      await pgdb.public.packageOptions.find(
-        { packageId: package_.id, disabled: false },
-        { orderBy: { order: 'asc' } }
-      )
-
-    // Default, raw package options
-    return packageOptions.map(
-      packageOption => ({
-        ...packageOption,
-        templateId: packageOption.id,
-        package: package_
-      })
-    )
   }
 }

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/submitPledge.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/submitPledge.js
@@ -139,9 +139,9 @@ module.exports = async (_, args, context) => {
         throw new Error(t('api/unexpected'))
       }
 
-      if (pko.disabled) {
+      if (pko.disabledAt && pko.disabledAt <= new Date()) {
         logger.error(
-          'option must be enabled',
+          `option must be enabled (disabledAt: ${pko.disabledAt.toISOString()})`,
           { req: req._log(), args, plo, pko }
         )
         throw new Error(t('api/unexpected'))

--- a/servers/republik/modules/crowdfundings/lib/CustomPackages/index.js
+++ b/servers/republik/modules/crowdfundings/lib/CustomPackages/index.js
@@ -331,8 +331,8 @@ const getCustomOptions = async (package_) => {
     }
   }
 */
-const resolvePackages = async ({ packages, pledger = {}, pgdb }) => {
-  debug('resolvePackages', packages.length)
+const resolvePackages = async ({ packages, pledger = {}, strict = false, pgdb }) => {
+  debug('resolvePackages', { packages: packages.length, strict })
 
   if (packages.length === 0) {
     debug('no packages to resolve')
@@ -391,10 +391,15 @@ const resolvePackages = async ({ packages, pledger = {}, pgdb }) => {
 
   Object.assign(pledger, { memberships })
 
+  const now = moment()
+
   const allPackageOptions =
     await pgdb.public.packageOptions.find({
       packageId: packages.map(package_ => package_.id),
-      disabled: false
+      and: [
+        { or: [{ 'disabledAt >': now }, { disabledAt: null }] },
+        strict && { or: [{ 'hiddenAt >': now }, { hiddenAt: null }] }
+      ].filter(Boolean)
     })
 
   const allRewards =

--- a/servers/republik/modules/crowdfundings/lib/User.js
+++ b/servers/republik/modules/crowdfundings/lib/User.js
@@ -30,7 +30,7 @@ const getCustomPackages = async ({ user, crowdfundingName, pgdb }) => {
 
   return Promise
     .map(
-      await resolvePackages({ packages, pledger: user, pgdb }),
+      await resolvePackages({ packages, pledger: user, strict: true, pgdb }),
       async package_ => {
         if (package_.custom === true) {
           const options = await getCustomOptions(package_)


### PR DESCRIPTION
This Pull Request allows to gracefully "phase-out" `packageOptions`. Each option hold two new attributes:
- `hiddenAt`: Once set, package option is no longer returned after a specific date
- `disabledAt`: Once set, creating pledges with package option will fail it after a specific date (

If all package options are hidden, package is no longer returned. This applies to queries `me.customPackages[]` and `crowdfunding.packages[].options[]`.

(Boolean attribute `disabled` is removed in a subsequent Pull Request: https://github.com/orbiting/backends/pull/344)

Changes include:

* Add fields to packageOptions table
* Alter custom package code to hide disabled, hidden options
* Move Package.options query to Crowdfunding.packages
* Change Crowdfunding.packages resolver to respect hiddenAt, disabledAt props and
* Prevent submitting pledges w/ options which are disabled, while hidden ones are