### PR TITLE
fix(discussion): respect maxDepth of first comments

### DIFF
--- a/packages/discussions/graphql/resolvers/Discussion/comments.js
+++ b/packages/discussions/graphql/resolvers/Discussion/comments.js
@@ -8,7 +8,7 @@ const {
 const getSortKey = require('../../../lib/sortKey')
 
 const assembleTree = (_comment, _comments) => {
-  let coveredComments = []
+  const coveredComments = []
 
   const _assembleTree = (comment, comments, depth = -1) => {
     const parentId = comment.id || null
@@ -132,7 +132,7 @@ const cutTreeX = (comment, maxDepth, depth = -1) => {
 // the returned array has the same order as the tree
 // removes nested children
 const flattenTreeHorizontally = (_comment) => {
-  let comments = []
+  const comments = []
   const _flattenTree = (comment, first) => {
     if (!first) { // exclude root
       comments.push(comment)
@@ -149,7 +149,7 @@ const flattenTreeHorizontally = (_comment) => {
 // in the returned array lower depth comes first
 // doesn't remove nested children
 const flattenTreeVertically = (_comment) => {
-  let comments = []
+  const comments = []
   const _flattenTree = comment => {
     if (comment.comments.nodes.length > 0) {
       comments.push(...comment.comments.nodes)
@@ -278,7 +278,7 @@ module.exports = async (discussion, args, context, info) => {
     tree.comments.nodes = tree.comments.nodes.filter(c => exceptIds.indexOf(c.id) === -1)
   }
 
-  let coveredComments = flattenTreeVertically(tree)
+  const coveredComments = flattenTreeVertically(tree)
     .map((c, index) => ({ // remember index for stable sort
       ...c,
       index
@@ -305,6 +305,10 @@ module.exports = async (discussion, args, context, info) => {
         })
     }
     if (first) {
+      if (maxDepth != null) {
+        filterComments = filterComments
+          .filter(c => c.depth < maxDepth)
+      }
       filterComments = filterComments
         .slice(0, first)
     }


### PR DESCRIPTION
fixes discussion.comments queries with `maxDepth` and `first`.
More comments than `first` might be returned if the `first` comments based on `orderBy` are depth > 0, but that's nothing new.
example query: https://api.republik.ch/graphiql/?query=%7B%0A%20%20discussion(id%3A%20%221a521e44-7f88-44bf-bb87-a582e30a0fba%22)%20%7B%0A%20%20%20%20title%0A%20%20%20%20comments(first%3A%203%2C%20orderBy%3A%20DATE%2C%20orderDirection%3A%20DESC)%20%7B%0A%20%20%20%20%20%20totalCount%0A%20%20%20%20%20%20directTotalCount%0A%20%20%20%20%20%20nodes%20%7B%0A%20%20%20%20%20%20%20%20depth%0A%20%20%20%20%20%20%20%20hotness%0A%20%20%20%20%20%20%20%20createdAt%0A%20%20%20%20%20%20%20%20updatedAt%0A%20%20%20%20%20%20%20%20adminUnpublished%0A%20%20%20%20%20%20%20%20preview(length%3A%20240)%20%7B%0A%20%20%20%20%20%20%20%20%20%20string%0A%20%20%20%20%20%20%20%20%20%20more%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D
