### PR TITLE
feat(base): Add redis.scanMap helper function and replace EVAL calls

### DIFF
--- a/packages/base/lib/Redis.js
+++ b/packages/base/lib/Redis.js
@@ -15,10 +15,15 @@ const connect = () => {
   client.__shortExpireSeconds = 3 * 24 * 60 * 60 // 3 days
 
   // Paginate through keys and apply async mapFn(key, client)
-  client.scanMap = async ({
-    pattern = '*',
-    mapFn = () => {}
-  }) => {
+  client.scanMap = async ({ pattern, mapFn }) => {
+    if (!pattern) {
+      throw new Error('argument pattern missing')
+    }
+
+    if (!mapFn) {
+      throw new Error('argument mapFn missing')
+    }
+
     let nextCursor = '0'
 
     do {

--- a/packages/base/lib/Redis.js
+++ b/packages/base/lib/Redis.js
@@ -1,9 +1,9 @@
 const debug = require('debug')('base:lib:redis')
 const redis = require('redis')
-const bluebird = require('bluebird')
+const Promise = require('bluebird')
 
-bluebird.promisifyAll(redis.RedisClient.prototype)
-bluebird.promisifyAll(redis.Multi.prototype)
+Promise.promisifyAll(redis.RedisClient.prototype)
+Promise.promisifyAll(redis.Multi.prototype)
 
 const connect = () => {
   const url = process.env.REDIS_URL
@@ -13,6 +13,31 @@ const connect = () => {
 
   client.__defaultExpireSeconds = 3 * 7 * 24 * 60 * 60 // 3 weeks
   client.__shortExpireSeconds = 3 * 24 * 60 * 60 // 3 days
+
+  // Paginate through keys and apply async mapFn(client, key)
+  client.scanMap = async ({
+    pattern = '*',
+    mapFn = () => {},
+    cursor = 0,
+    results = []
+  }) => {
+    debug('scanMap iteration: %o', { cursor, pattern })
+    const [nextCursor, keys] = await client.scanAsync([cursor, 'MATCH', pattern])
+
+    debug('scanMap, scanned page: %o', { cursor, pattern, nextCursor: nextCursor !== '0', keys: keys.length })
+
+    const pageResults = await Promise.map(keys, mapFn.bind(this, client))
+
+    results = [...results, ...pageResults]
+
+    // nextCursor is "0" if scan is completed.
+    if (!!nextCursor && nextCursor !== '0') {
+      return client.scanMap({ pattern, mapFn, cursor: nextCursor, results })
+    }
+
+    debug('scanMap reached full iteration: %o', { results: results && results.length })
+    return results
+  }
 
   return client
 }

--- a/packages/search/lib/cache.js
+++ b/packages/search/lib/cache.js
@@ -57,7 +57,10 @@ const createSet = (redis) => async (query, payload, options = {}) => {
 
 const createInvalidate = (redis) => async () => {
   debug('search:cache')('INVALIDATE')
-  await redis.evalAsync(`return redis.call('del', unpack(redis.call('keys', ARGV[1])))`, 0, `${keyPrefix}*`)
+  await redis.scanMap({
+    pattern: `${keyPrefix}*`,
+    mapFn: (client, key) => client.delAsync(key)
+  })
     .catch(() => {})// fails if no keys are matched
 }
 

--- a/packages/search/lib/cache.js
+++ b/packages/search/lib/cache.js
@@ -59,7 +59,7 @@ const createInvalidate = (redis) => async () => {
   debug('search:cache')('INVALIDATE')
   await redis.scanMap({
     pattern: `${keyPrefix}*`,
-    mapFn: (client, key) => client.delAsync(key)
+    mapFn: (key, client) => client.delAsync(key)
   })
     .catch(() => {})// fails if no keys are matched
 }

--- a/servers/republik/modules/crowdfundings/lib/cache.js
+++ b/servers/republik/modules/crowdfundings/lib/cache.js
@@ -67,12 +67,10 @@ const createCache = ({ options }) => async function (payloadFunction) {
 
 const createInvalidate = ({ options, redis }) => async function () {
   debug('crowdfundings:cache')('INVALIDATE')
-  await redis
-    .evalAsync(
-      'return redis.call(\'del\', unpack(redis.call(\'keys\', ARGV[1])))',
-      0,
-      `${namespace}:${options.prefix}*`
-    )
+  await redis.scanMap({
+    pattern: `${namespace}:${options.prefix}*`,
+    mapFn: (client, key) => client.delAsync(key)
+  })
     .catch(() => {})// fails if no keys are matched
 }
 

--- a/servers/republik/modules/crowdfundings/lib/cache.js
+++ b/servers/republik/modules/crowdfundings/lib/cache.js
@@ -69,7 +69,7 @@ const createInvalidate = ({ options, redis }) => async function () {
   debug('crowdfundings:cache')('INVALIDATE')
   await redis.scanMap({
     pattern: `${namespace}:${options.prefix}*`,
-    mapFn: (client, key) => client.delAsync(key)
+    mapFn: (key, client) => client.delAsync(key)
   })
     .catch(() => {})// fails if no keys are matched
 }


### PR DESCRIPTION
Scans trough a key pattern and applies `async mapFn(client, key)` to each key.

- [x] Use `scanMap` instead of `EVAL ...` to invalidate cache keys