### PR TITLE
Improvements to querying and indexed data

### DIFF
--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -82,7 +82,7 @@ const getSimpleQueryStringQuery = (searchTerm) => {
     fuzzySearchTerm
   })
 
-  return fuzzySearchTerm
+  return `(${sanitizedSearchTerm}) | ("${sanitizedSearchTerm}") | (${fuzzySearchTerm})`
 }
 
 const createShould = function (

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -51,11 +51,8 @@ module.exports = {
           number_of_fragments: 0
         }
       },
-      'meta.authors': {
-        boost: 3,
-        highlight: {
-          number_of_fragments: 0
-        }
+      'meta.creditsString': {
+        boost: 3
       },
       contentString: {
         highlight: {
@@ -396,6 +393,10 @@ module.exports = {
             },
             feed: {
               type: 'boolean'
+            },
+            creditsString: {
+              type: 'text',
+              analyzer: 'german'
             },
             credits: {
               ...mdastPartial

--- a/servers/publikator/lib/Document.js
+++ b/servers/publikator/lib/Document.js
@@ -6,6 +6,7 @@ const mp3Duration = require('@rocka/mp3-duration')
 const fetch = require('isomorphic-unfetch')
 
 const { timeFormat } = require('@orbiting/backend-modules-formats')
+const { mdastToString } = require('@orbiting/backend-modules-utils')
 const {
   Redirections: { upsert: upsertRedirection }
 } = require('@orbiting/backend-modules-redirections')
@@ -87,6 +88,8 @@ const prepareMetaForPublish = async ({
     }
   })
 
+  const creditsString = mdastToString({ children: credits })
+
   const { audioSourceMp3, audioSourceAac, audioSourceOgg } = doc.content.meta
   let durationMs = 0
   if (audioSourceMp3) {
@@ -148,6 +151,7 @@ const prepareMetaForPublish = async ({
     lastPublishedAt: lastPublishedAt || now,
     prepublication,
     scheduledAt,
+    creditsString,
     credits,
     audioSource,
     authors,


### PR DESCRIPTION
This should solve too little or no results when querying: `Urs Bruderer`, `Anna Miller`, `An der Bar`.

* feat: Stringify credits to `meta.creditsString` and queries them. `meta.authors` worked only if author names are linked, otherwise array is empty. This change replaces `meta.authors` w/ `meta.creditsString` and boosts it.
* fix(search): Query variations of terms. If there is no search operator used, this is the query pattern submitted: `term | "term" | term~` and resulting in expected, weighted results.

Requires reindexing documents.