### PR TITLE
Improvements to result weighting

### DIFF
--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -109,16 +109,19 @@ const createShould = function (
     })
 
     if (searchTerm) {
-      must = [
-        {
-          simple_query_string: {
-            query: getSimpleQueryStringQuery(searchTerm),
-            fields,
-            default_operator: 'AND',
-            analyzer: 'german'
-          }
+      const query = {
+        simple_query_string: {
+          query: getSimpleQueryStringQuery(searchTerm),
+          fields,
+          default_operator: 'AND',
+          analyzer: 'german'
         }
-      ]
+      }
+
+      must = [
+        query,
+        search.functionScore && { function_score: search.functionScore(query) }
+      ].filter(Boolean)
     }
 
     const rolebasedFilterArgs = Object.assign(

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -788,6 +788,9 @@ const findTemplates = async function (elastic, template, repoId) {
 }
 
 module.exports = {
+  SHORT_DURATION_MINS,
+  MIDDLE_DURATION_MINS,
+  LONG_DURATION_MINS,
   schema,
   getElasticDoc,
   extractIdsFromNode,

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -1,3 +1,6 @@
+const { meta: { getWordsPerMinute } } = require('@orbiting/backend-modules-documents/lib')
+const { MIDDLE_DURATION_MINS } = require('../Documents')
+
 const keywordPartial = {
   fields: {
     keyword: {
@@ -70,6 +73,45 @@ module.exports = {
         boost: 3
       }
     },
+    functionScore: (query) => ({
+      query,
+      functions: [
+        {
+          filter: {
+            match: {
+              'meta.isSeriesMaster': true
+            }
+          },
+          weight: 20
+        },
+        {
+          filter: {
+            match: {
+              'meta.isSeriesEpisode': true
+            }
+          },
+          weight: 10
+        },
+        {
+          filter: {
+            range: {
+              'contentString.count': {
+                gte: getWordsPerMinute() * MIDDLE_DURATION_MINS
+              }
+            }
+          },
+          weight: 5
+        },
+        {
+          filter: {
+            match: {
+              'meta.template': 'editorialNewsletter'
+            }
+          },
+          weight: 0.1
+        }
+      ]
+    }),
     filter: {
       default: () => {
         const filter = {

--- a/packages/search/lib/utils.js
+++ b/packages/search/lib/utils.js
@@ -74,7 +74,7 @@ const mdastContentToString = mdast =>
       mdast,
       node =>
         node.type === 'code' ||
-        ['TITLE', 'ARTICLECOLLECTION', 'INFOBOX', 'FIGURE', 'NOTE'].includes(node.identifier)
+        ['TITLE', 'ARTICLECOLLECTION', 'INFOBOX', 'FIGURE', 'NOTE', 'HTML'].includes(node.identifier)
     ),
     '\n'
   )


### PR DESCRIPTION
This is a first attempt on weighting results – determined by `query` beforehand – to get a more "reasonable" relevance scoring.

Use function scoring to weight results
* Boost series, and long reads
* Deboost editorial newsletter slightly

Turns out length of an document is a good indicator whether should be ranked higher or not.

Also removes `HTML` identifier blocks in fn `mdastContentToString`.