### PR TITLE
feat(mail): Send some transactionals via nodemailer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,13 @@ SEND_MAILS=false
 # see https://mandrill.zendesk.com/hc/en-us/articles/205582467-How-to-Use-Tags-in-Mandrill
 SEND_MAILS_TAGS=dev,localhost
 
+# If Regular Expression is matched on a template name, nodemailer is used to sent email
+SEND_MAILS_NODEMAILER_REGEX=
+
+# Connection URL to e.g. SMTP account nodemailer uses.
+SEND_MAILS_NODEMAILER_CONNECTION_URL=
+
+
 # required for mails to work, set SEND_MAILS to false for a quick start
 #MANDRILL_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -105,11 +105,10 @@ SEND_MAILS=false
 SEND_MAILS_TAGS=dev,localhost
 
 # If Regular Expression is matched on a template name, nodemailer is used to sent email
-SEND_MAILS_NODEMAILER_REGEX=
+#SEND_MAILS_NODEMAILER_REGEX=^signin*
 
 # Connection URL to e.g. SMTP account nodemailer uses.
-SEND_MAILS_NODEMAILER_CONNECTION_URL=
-
+#SEND_MAILS_NODEMAILER_CONNECTION_URL='smtps://inbox@domain.tld:lengthy-password-with-dashes@asmtp.mail.hostpoint.ch/?pool=true'
 
 # required for mails to work, set SEND_MAILS to false for a quick start
 #MANDRILL_API_KEY=

--- a/packages/mail/MandrillInterface.js
+++ b/packages/mail/MandrillInterface.js
@@ -26,6 +26,9 @@ const MandrillInterface = ({ logger }) => {
         })
       })
     },
+    isUsable () {
+      return true
+    },
     async send (message, templateName, templateContent) {
       const url = this.buildApiUrl(
         templateName
@@ -34,8 +37,8 @@ const MandrillInterface = ({ logger }) => {
       try {
         const body = { message }
         if (templateName) {
-          body['template_name'] = templateName
-          body['template_content'] = templateContent
+          body.template_name = templateName
+          body.template_content = templateContent
         }
         const response = await this.fetchAuthenticated('POST', url, body)
         const json = await response.json()

--- a/packages/mail/MandrillInterface.js
+++ b/packages/mail/MandrillInterface.js
@@ -1,5 +1,4 @@
 const fetch = require('isomorphic-unfetch')
-const checkEnv = require('check-env')
 const { NewsletterMemberMailError } = require('./errors')
 
 const {
@@ -7,9 +6,6 @@ const {
 } = process.env
 
 const MandrillInterface = ({ logger }) => {
-  checkEnv([
-    'MANDRILL_API_KEY'
-  ])
   return {
     buildApiUrl (path) {
       return `https://mandrillapp.com/api/1.0${path}`
@@ -27,7 +23,7 @@ const MandrillInterface = ({ logger }) => {
       })
     },
     isUsable () {
-      return true
+      return !!(MANDRILL_API_KEY && MANDRILL_API_KEY.length)
     },
     async send (message, templateName, templateContent) {
       const url = this.buildApiUrl(

--- a/packages/mail/NodemailerInterface.js
+++ b/packages/mail/NodemailerInterface.js
@@ -1,0 +1,59 @@
+const nodemailer = require('nodemailer')
+
+const { SendMailError } = require('./errors')
+
+const transporter = nodemailer.createTransport(process.env.SEND_MAILS_NODEMAILER_CONNECTION_URL)
+
+const {
+  SEND_MAILS_NODEMAILER_CONNECTION_URL,
+  SEND_MAILS_NODEMAILER_REGEX
+} = process.env
+
+module.exports = () => {
+  return {
+    isUsable (mail) {
+      return (
+        SEND_MAILS_NODEMAILER_CONNECTION_URL &&
+        SEND_MAILS_NODEMAILER_REGEX &&
+        new RegExp(SEND_MAILS_NODEMAILER_REGEX, 'ig').test(mail.templateName)
+      )
+    },
+    async send (message, templateName, templateContent) {
+      const result = await new Promise(function (resolve, reject) {
+        // Default to an empty array so Array.reduce will return initial value
+        const variables = message.global_merge_vars || []
+
+        transporter.sendMail(
+          {
+            from: `"${message.from_name}" <${message.from_email}>`,
+            to: message.to.map(({ email }) => email).join(', '),
+            subject: message.subject,
+            text: message.text && variables.reduce(
+              (template, mergeVar) => {
+                const { name, content } = mergeVar
+                return template.replace(new RegExp(`{?{{ ?${name} ?}}}?`, 'ig'), content)
+              },
+              message.text
+            ),
+            html: message.html && variables.reduce(
+              (template, mergeVar) => {
+                const { name, content } = mergeVar
+                return template.replace(new RegExp(`{?{{ ?${name} ?}}}?`, 'ig'), content)
+              },
+              message.html
+            )
+          },
+          (error, info) => {
+            if (error) {
+              reject(new SendMailError(error))
+            } else {
+              resolve({ ...info, status: 'sent' })
+            }
+          }
+        )
+      })
+
+      return [result]
+    }
+  }
+}

--- a/packages/mail/NodemailerInterface.js
+++ b/packages/mail/NodemailerInterface.js
@@ -2,46 +2,47 @@ const nodemailer = require('nodemailer')
 
 const { SendMailError } = require('./errors')
 
-const transporter = nodemailer.createTransport(process.env.SEND_MAILS_NODEMAILER_CONNECTION_URL)
-
 const {
   SEND_MAILS_NODEMAILER_CONNECTION_URL,
   SEND_MAILS_NODEMAILER_REGEX
 } = process.env
 
+const transporter =
+  !!SEND_MAILS_NODEMAILER_CONNECTION_URL &&
+  nodemailer.createTransport(process.env.SEND_MAILS_NODEMAILER_CONNECTION_URL)
+
+const compile = (template, variables = []) => {
+  if (!template) {
+    return undefined
+  }
+
+  return variables.reduce(
+    (string, mergeVar) => {
+      const { name, content } = mergeVar
+      return string.replace(new RegExp(`{?{{ ?${name} ?}}}?`, 'ig'), content)
+    },
+    template
+  )
+}
+
 module.exports = () => {
   return {
     isUsable (mail) {
-      return (
-        SEND_MAILS_NODEMAILER_CONNECTION_URL &&
+      return !!(
+        transporter &&
         SEND_MAILS_NODEMAILER_REGEX &&
         new RegExp(SEND_MAILS_NODEMAILER_REGEX, 'ig').test(mail.templateName)
       )
     },
-    async send (message, templateName, templateContent) {
+    async send (message) {
       const result = await new Promise(function (resolve, reject) {
-        // Default to an empty array so Array.reduce will return initial value
-        const variables = message.global_merge_vars || []
-
         transporter.sendMail(
           {
             from: `"${message.from_name}" <${message.from_email}>`,
             to: message.to.map(({ email }) => email).join(', '),
             subject: message.subject,
-            text: message.text && variables.reduce(
-              (template, mergeVar) => {
-                const { name, content } = mergeVar
-                return template.replace(new RegExp(`{?{{ ?${name} ?}}}?`, 'ig'), content)
-              },
-              message.text
-            ),
-            html: message.html && variables.reduce(
-              (template, mergeVar) => {
-                const { name, content } = mergeVar
-                return template.replace(new RegExp(`{?{{ ?${name} ?}}}?`, 'ig'), content)
-              },
-              message.html
-            )
+            text: compile(message.text, message.global_merge_vars),
+            html: compile(message.html, message.global_merge_vars)
           },
           (error, info) => {
             if (error) {

--- a/packages/mail/errors.js
+++ b/packages/mail/errors.js
@@ -4,6 +4,7 @@ const INTERESTID_NOT_FOUND_ERROR = 'INTERESTID_NOT_FOUND_ERROR'
 const EMAIL_REQUIRED_ERROR = 'EMAIL_REQUIRED_ERROR'
 const SUBSCRIPTION_CONFIG_MISSING_ERROR = 'SUBSCRIPTION_CONFIG_MISSING_ERROR'
 const SUBSCRIPTION_HANDLER_MISSING_ERROR = 'SUBSCRIPTION_HANDLER_MISSING_ERROR'
+const SEND_ERROR = 'SEND_ERROR'
 
 class MailError extends Error {
   constructor (type, meta) {
@@ -50,11 +51,18 @@ class EmailRequiredMailError extends MailError {
   }
 }
 
+class SendMailError extends MailError {
+  constructor (meta) {
+    super(SEND_ERROR, meta)
+  }
+}
+
 module.exports = {
   NewsletterMemberMailError,
   RolesNotEligibleMailError,
   InterestIdNotFoundMailError,
   EmailRequiredMailError,
   SubscriptionConfigurationMissingMailError,
-  SubscriptionHandlerMissingMailError
+  SubscriptionHandlerMissingMailError,
+  SendMailError
 }

--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "await-sleep": "^0.0.1",
     "check-env": "^1.3.0",
-    "isomorphic-unfetch": "^3.0.0"
+    "isomorphic-unfetch": "^3.0.0",
+    "nodemailer": "^6.4.2"
   },
   "devDependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7014,6 +7014,11 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
+nodemailer@^6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.4.2.tgz#7147550e32cdc37453380ab78d2074533966090a"
+  integrity sha512-g0n4nH1ONGvqYo1v72uSWvF/MRNnnq1LzmSzXb/6EPF3LFb51akOhgG3K2+aETAsJx90/Q5eFNTntu4vBCwyQQ==
+
 nodemon@^1.19.0:
   version "1.19.4"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.19.4.tgz#56db5c607408e0fdf8920d2b444819af1aae0971"


### PR DESCRIPTION
This Pull Request enables to use to send emails via [nodemailer](https://nodemailer.com/about/) instead of Mandrill: `NodemailerInterface`

`NodemailerInterface` also replaces simple handlebars variables.

To test, setup these ENV variables first, here including some examples.
```sh
# If Regular Expression is matched on a template name, nodemailer is used to sent email
SEND_MAILS_NODEMAILER_REGEX=^signin.*

# Connection URL to e.g. SMTP account nodemailer uses.
SEND_MAILS_NODEMAILER_CONNECTION_URL='smtps://inbox@domain.tld:lengthy-password-with-dashes@asmtp.mail.hostpoint.ch/?pool=true'
```

Upcoming changes include:
- Allow to pause sending over either interface e. g. to pause Mandrill
- Script to resume paused emails