### PR TITLE
feat(mail): Schedule some emails instead of sending them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,9 @@ SEND_MAILS_TAGS=dev,localhost
 # Connection URL to e.g. SMTP account nodemailer uses.
 #SEND_MAILS_NODEMAILER_CONNECTION_URL='smtps://inbox@domain.tld:lengthy-password-with-dashes@asmtp.mail.hostpoint.ch/?pool=true'
 
+# If Regular Expression is matched on a template name, mail is schedule instead of sent
+#SEND_MAILS_SCHEDULE_REGEX=^[^signin].*
+
 # required for mails to work, set SEND_MAILS to false for a quick start
 #MANDRILL_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -105,13 +105,13 @@ SEND_MAILS=false
 SEND_MAILS_TAGS=dev,localhost
 
 # If Regular Expression is matched on a template name, nodemailer is used to sent email
-#SEND_MAILS_NODEMAILER_REGEX=^signin*
+#SEND_MAILS_NODEMAILER_TEMPLATE_REGEX=^signin*
 
 # Connection URL to e.g. SMTP account nodemailer uses.
 #SEND_MAILS_NODEMAILER_CONNECTION_URL='smtps://inbox@domain.tld:lengthy-password-with-dashes@asmtp.mail.hostpoint.ch/?pool=true'
 
 # If Regular Expression is matched on a template name, mail is schedule instead of sent
-#SEND_MAILS_SCHEDULE_REGEX=^[^signin].*
+#SEND_MAILS_SCHEDULE_TEMPLATE_REGEX=^[^signin].*
 
 # required for mails to work, set SEND_MAILS to false for a quick start
 #MANDRILL_API_KEY=

--- a/packages/mail/NodemailerInterface.js
+++ b/packages/mail/NodemailerInterface.js
@@ -4,7 +4,7 @@ const { SendMailError } = require('./errors')
 
 const {
   SEND_MAILS_NODEMAILER_CONNECTION_URL,
-  SEND_MAILS_NODEMAILER_REGEX
+  SEND_MAILS_NODEMAILER_TEMPLATE_REGEX
 } = process.env
 
 const transporter =
@@ -30,8 +30,8 @@ module.exports = () => {
     isUsable (mail) {
       return !!(
         transporter &&
-        SEND_MAILS_NODEMAILER_REGEX &&
-        new RegExp(SEND_MAILS_NODEMAILER_REGEX, 'ig').test(mail.templateName)
+        SEND_MAILS_NODEMAILER_TEMPLATE_REGEX &&
+        new RegExp(SEND_MAILS_NODEMAILER_TEMPLATE_REGEX, 'ig').test(mail.templateName)
       )
     },
     async send (message) {

--- a/packages/mail/lib/sendMail.js
+++ b/packages/mail/lib/sendMail.js
@@ -1,11 +1,11 @@
 const checkEnv = require('check-env')
 
-const NodemailerInterface = require('../NodemailerInterface')
-const MandrillInterface = require('../MandrillInterface')
-
-const { send } = require('./mailLog')
+const shouldScheduleMessage = require('../utils/shouldScheduleMessage')
 const shouldSendMessage = require('../utils/shouldSendMessage')
 const sendResultNormalizer = require('../utils/sendResultNormalizer')
+const NodemailerInterface = require('../NodemailerInterface')
+const MandrillInterface = require('../MandrillInterface')
+const { send } = require('./mailLog')
 
 checkEnv([
   'DEFAULT_MAIL_FROM_ADDRESS',
@@ -41,10 +41,9 @@ module.exports = async (mail, context, log) => {
 
   const message = { ...mail }
 
-  const shouldSend = shouldSendMessage(mail)
-
   const sendFunc = sendResultNormalizer(
-    shouldSend,
+    shouldScheduleMessage(mail, message),
+    shouldSendMessage(message),
     () => {
       // Backup method to send emails
       const nodemailer = NodemailerInterface({ logger: console })

--- a/packages/mail/lib/sendMailTemplate.js
+++ b/packages/mail/lib/sendMailTemplate.js
@@ -3,12 +3,12 @@ const debug = require('debug')('mail:lib:sendMailTemplate')
 const fs = require('fs')
 const path = require('path')
 
-const NodemailerInterface = require('../NodemailerInterface')
-const MandrillInterface = require('../MandrillInterface')
-
-const { send } = require('./mailLog')
+const shouldScheduleMessage = require('../utils/shouldScheduleMessage')
 const shouldSendMessage = require('../utils/shouldSendMessage')
 const sendResultNormalizer = require('../utils/sendResultNormalizer')
+const NodemailerInterface = require('../NodemailerInterface')
+const MandrillInterface = require('../MandrillInterface')
+const { send } = require('./mailLog')
 
 checkEnv([
   'DEFAULT_MAIL_FROM_ADDRESS',
@@ -219,10 +219,9 @@ module.exports = async (mail, context, log) => {
 
   debug({ ...message, html: !!message.html })
 
-  const shouldSend = shouldSendMessage(message)
-
   const sendFunc = sendResultNormalizer(
-    shouldSend,
+    shouldScheduleMessage(mail, message),
+    shouldSendMessage(message),
     () => {
       // Backup method to send emails
       const nodemailer = NodemailerInterface({ logger: console })

--- a/packages/mail/migrations/sqls/20200108103449-maillog-status-pending-down.sql
+++ b/packages/mail/migrations/sqls/20200108103449-maillog-status-pending-down.sql
@@ -1,0 +1,15 @@
+UPDATE "mailLog"
+SET status = 'FAILED'
+WHERE status = 'SCHEDULED'
+;
+
+ALTER DOMAIN mail_log_status
+  DROP CONSTRAINT mail_log_status_check
+;
+
+ALTER DOMAIN mail_log_status
+  ADD CONSTRAINT mail_log_status_check
+  CHECK(
+    VALUE IN ('SENDING', 'SENT', 'FAILED')
+  )
+;

--- a/packages/mail/migrations/sqls/20200108103449-maillog-status-pending-up.sql
+++ b/packages/mail/migrations/sqls/20200108103449-maillog-status-pending-up.sql
@@ -1,0 +1,10 @@
+ALTER DOMAIN mail_log_status
+  DROP CONSTRAINT mail_log_status_check
+;
+
+ALTER DOMAIN mail_log_status
+  ADD CONSTRAINT mail_log_status_check
+  CHECK(
+    VALUE IN ('SENDING', 'SENT', 'FAILED', 'SCHEDULED')
+  )
+;

--- a/packages/mail/utils/sendResultNormalizer.js
+++ b/packages/mail/utils/sendResultNormalizer.js
@@ -1,7 +1,14 @@
 const sleep = require('await-sleep')
 
-module.exports = (shouldSend, sendFunc) =>
+module.exports = (shouldSchedule = false, shouldSend = true, sendFunc) =>
   async () => {
+    if (shouldSchedule) {
+      return {
+        result: { status: 'scheduled' },
+        status: 'SCHEDULED'
+      }
+    }
+
     let results
     if (shouldSend) {
       try {

--- a/packages/mail/utils/shouldScheduleMessage.js
+++ b/packages/mail/utils/shouldScheduleMessage.js
@@ -1,7 +1,7 @@
 const {
   NODE_ENV,
   SEND_MAILS,
-  SEND_MAILS_SCHEDULE_REGEX
+  SEND_MAILS_SCHEDULE_TEMPLATE_REGEX
 } = process.env
 
 const DEV = NODE_ENV && NODE_ENV !== 'production'
@@ -20,8 +20,8 @@ module.exports = (mail, message) => {
   }
 
   if (
-    SEND_MAILS_SCHEDULE_REGEX &&
-    new RegExp(SEND_MAILS_SCHEDULE_REGEX, 'ig').test(mail.templateName)
+    SEND_MAILS_SCHEDULE_TEMPLATE_REGEX &&
+    new RegExp(SEND_MAILS_SCHEDULE_TEMPLATE_REGEX, 'ig').test(mail.templateName)
   ) {
     return true
   }

--- a/packages/mail/utils/shouldScheduleMessage.js
+++ b/packages/mail/utils/shouldScheduleMessage.js
@@ -1,0 +1,30 @@
+const {
+  NODE_ENV,
+  SEND_MAILS,
+  SEND_MAILS_SCHEDULE_REGEX
+} = process.env
+
+const DEV = NODE_ENV && NODE_ENV !== 'production'
+
+module.exports = (mail, message) => {
+  const { SEND_MAILS_LOG = true } = process.env
+  const logger = SEND_MAILS_LOG && SEND_MAILS_LOG !== 'false'
+    ? console.log
+    : a => {}
+
+  // don't send in dev, expect SEND_MAILS is true
+  // don't send mails if SEND_MAILS is false
+  if (SEND_MAILS === 'false' || (DEV && SEND_MAILS !== 'true')) {
+    logger('\n\nSEND_MAILS prevented mail from being scheduled')
+    return false
+  }
+
+  if (
+    SEND_MAILS_SCHEDULE_REGEX &&
+    new RegExp(SEND_MAILS_SCHEDULE_REGEX, 'ig').test(mail.templateName)
+  ) {
+    return true
+  }
+
+  return false
+}

--- a/packages/mail/utils/shouldScheduleMessage.js
+++ b/packages/mail/utils/shouldScheduleMessage.js
@@ -12,8 +12,8 @@ module.exports = (mail, message) => {
     ? console.log
     : a => {}
 
-  // don't send in dev, expect SEND_MAILS is true
-  // don't send mails if SEND_MAILS is false
+  // don't schedule in dev, expect SEND_MAILS is true
+  // don't schedule mails if SEND_MAILS is false
   if (SEND_MAILS === 'false' || (DEV && SEND_MAILS !== 'true')) {
     logger('\n\nSEND_MAILS prevented mail from being scheduled')
     return false

--- a/packages/migrations/migrations/20200108103449-maillog-status-pending.js
+++ b/packages/migrations/migrations/20200108103449-maillog-status-pending.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/mail/migrations/sqls'
+const file = '20200108103449-maillog-status-pending'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)


### PR DESCRIPTION
This Pull Request can deem emails to be "scheduled" and be placed in `mailLog` as such.

ENV variable `SEND_MAILS_SCHEDULE_REGEX` accepts a regular expression and matches mail template names against it; if true, an email is scheduled instead of send.

Due to factors unbeknownst to us, we may need to hold off on sending emails but still have them queued. `mailLog` with records on status `SCHEDULED` just to that.

To test, setup ENV variable first, here including some examples.

```sh
# If Regular Expression is matched on a template name, mail is schedule instead of sent
SEND_MAILS_SCHEDULE_REGEX=^[^signin].*
```

Upcoming changes include:
- Script to sent previously scheduled emails