### PR TITLE
Autopay: Fallout

### DIFF
--- a/packages/mail/templates/membership_owner_autopay_failed.html
+++ b/packages/mail/templates/membership_owner_autopay_failed.html
@@ -47,7 +47,12 @@
                       <p>Wir sehen uns daher zu unserem grossen Bedauern gezwungen, Ihre Mitgliedschaft am {{grace_end_date}} zu deaktivieren.</p>
                       <p>Wollen Sie dies verhindern, können Sie <a href="{{prolong_url}}">den ausstehenden Jahresbeitrag begleichen</a>, wenn Sie möchten, auch mit einer anderen Zahlungsart.</p>
                     {{else}}
-                      <p>Ihre Mitgliedschaft erneuerte sich am {{end_date}} um ein weiteres Jahr. Bei Ihrem letzten Kauf haben Sie angegeben, dass Sie uns erlauben, Ihre hinterlegte Kreditkarte automatisch zu belasten. Bedauerlicherweise konnten wir den Jahresbeitrag von {{autopay_total}} von Ihrer hinterlegten {{autopay_card_brand}}-Kreditkarte mit den Endziffern {{autopay_card_last4}} nicht abbuchen.</p>
+                      {{#if `attempt_number == 1`}}
+                        <p>Aufgrund einer Fehlkonfiguration haben Sie heute früh eine Abonnementsrechnung erhalten, obwohl Sie uns bei Ihrem letzten Kauf angegeben haben, dass wir Ihre Kreditkarte automatisch belasten dürfen. Wir bitten Sie um Entschuldigung.</p>
+                        <p>Inzwischen haben wir versucht, Ihre Kreditkarte zu belasten: Bedauerlicherweise konnten wir den Jahresbeitrag von {{autopay_total}} von Ihrer hinterlegten {{autopay_card_brand}}-Kreditkarte mit den Endziffern {{autopay_card_last4}} nicht abbuchen.</p>
+                      {{else}}
+                        <p>Ihre Mitgliedschaft erneuerte sich am {{end_date}} um ein weiteres Jahr. Bei Ihrem letzten Kauf haben Sie angegeben, dass Sie uns erlauben, Ihre hinterlegte Kreditkarte automatisch zu belasten. Bedauerlicherweise konnten wir den Jahresbeitrag von {{autopay_total}} von Ihrer hinterlegten {{autopay_card_brand}}-Kreditkarte mit den Endziffern {{autopay_card_last4}} nicht abbuchen.</p>
+                      {{/if}}
                       {{#if attempt_is_last}}
                         <p>Wir sehen uns daher zu unserem grossen Bedauern gezwungen, Ihre Mitgliedschaft am {{grace_end_date}} zu deaktivieren.</p>
                       {{elseif attempt_next_is_last}}

--- a/packages/mail/templates/membership_owner_autopay_successful.html
+++ b/packages/mail/templates/membership_owner_autopay_successful.html
@@ -40,6 +40,7 @@
                     </p>
                     <p>Wir haben Ihre Mitgliedschaft automatisch um ein weiteres Jahr verlängert und dafür Ihre {{autopay_card_brand}}-Kreditkarte mit den Endziffern {{autopay_card_last4}} mit {{autopay_total}} belastet. Wir bedanken uns für Ihre Treue und Ihr Vertrauen.</p>
                     <p>Ihre Mitgliedschaft läuft neu bis zum {{prolonged_end_date}}.</p>
+                    <p>Hinweis: Aufgrund einer Fehlkonfiguration haben Sie heute früh eine Abonnementsrechnung erhalten, obwohl Sie uns bei Ihrem letzten Kauf angegeben haben, dass wir Ihre Kreditkarte automatisch belasten dürfen. Wir bitten Sie um Entschuldigung. Die Abonnementsrechnung können Sie ignorieren, Ihre Mitgliedschaft läuft weiter.</p>
                     <p>Herzlich</p>
                     <p>Ihre Crew der Republik</p>
                   </td>

--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -457,6 +457,15 @@ mail.prepareMembershipOwnerNotice = async ({ user, endDate, graceEndDate, cancel
 }
 
 mail.sendMembershipOwnerAutoPay = async ({ autoPay, payload, pgdb, t }) => {
+  // Ditch sending email if it's not a card_error
+  if (
+    payload.chargeAttemptStatus !== 'SUCCESS' &&
+    payload.chargeAttemptError &&
+    (!payload.chargeAttemptError.raw || payload.chargeAttemptError.raw.type !== 'card_error')
+  ) {
+    return
+  }
+
   const user = await pgdb.public.users.findOne({ id: autoPay.userId })
   const customPledgeToken = AccessToken.generateForUser(user, 'CUSTOM_PLEDGE')
   const version = payload.chargeAttemptStatus === 'SUCCESS' ? 'successful' : 'failed'

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -12,7 +12,7 @@ const lockTtlSecs = 60 * 5 // 5 mins
 
 const { inform: informGivers } = require('./givers')
 const { inform: informCancellers } = require('./winbacks')
-// const { run: membershipsOwnersHandler } = require('./owners')
+const { run: membershipsOwnersHandler } = require('./owners')
 const { deactivate } = require('./deactivate')
 const { changeover } = require('./changeover')
 
@@ -43,7 +43,6 @@ const init = async (_context) => {
     })
   )
 
-  /*
   schedulers.push(
     intervalScheduler.init({
       name: 'memberships-owners',
@@ -53,7 +52,6 @@ const init = async (_context) => {
       runIntervalSecs: 60 * 10
     })
   )
-  */
 
   schedulers.push(
     timeScheduler.init({

--- a/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
@@ -14,7 +14,8 @@ const mailings = require('./owners/mailings')
 const charging = require('./owners/charging')
 
 const {
-  PARKING_USER_ID
+  PARKING_USER_ID,
+  MEMBERSHIP_SCHEDULER_USER_LIMIT = 100
 } = process.env
 
 const STATS_INTERVAL_SECS = 3
@@ -163,8 +164,10 @@ const getBuckets = async ({ now }, context) => {
       AND m.active = true
       AND m.renew = true
     ORDER BY RANDOM()
+    LIMIT :MEMBERSHIP_SCHEDULER_USER_LIMIT
   `, {
-    PARKING_USER_ID
+    PARKING_USER_ID,
+    MEMBERSHIP_SCHEDULER_USER_LIMIT
   })
     .then(users => users
       .map(user => ({

--- a/servers/republik/modules/crowdfundings/lib/scheduler/owners/charging.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/owners/charging.js
@@ -64,6 +64,7 @@ module.exports = async (user, bucket, context) => {
     const isNextAttemptLast = previousAttempts.length + 2 === attempts.length
     const payload = {
       chargeAttemptStatus: chargeAttempt.status,
+      chargeAttemptError: chargeAttempt.error,
       attemptNumber: previousAttempts.length + 1,
       isLastAttempt: previousAttempts.length + 1 === attempts.length,
       isNextAttemptLast,


### PR DESCRIPTION
- Won't send emails if charge attempt was anything but `type: 'card_error'`. These errors will have to be checked manually.
- Auto-Pay related mail templates updated with a (temporary) apology
- Restore membership-owners scheduler, and limit amount of users looked at per run (`MEMBERSHIP_SCHEDULER_USER_LIMIT`)