### PR TITLE
feat: Add T+7 template and bucket

### DIFF
--- a/packages/mail/templates/membership_owner_prolong_winback_7.html
+++ b/packages/mail/templates/membership_owner_prolong_winback_7.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="x-ua-compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <!--[if gte mso 15]>
+    <xml>
+      <o:officedocumentsettings>
+        <o:allowpng />
+        <o:pixelsperinch>96</o:pixelsperinch>
+      </o:officedocumentsettings>
+    </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff;">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:640px;color:#444;font-size:18px;{{sg_font_style_sans_serif_regular}}">
+              <tbody>
+                <tr>
+                  <td style="padding:20px;">
+                    <p>Guten Tag</p>
+                    <p>Am {{grace_end_date}} verlieren Ihre Zugangsdaten zu republik.ch ihre Gültigkeit, da Ihre Mitgliedschaft ausgelaufen ist.</p>
+                    <p>Um dies zu verhindern, können Sie einfach die Rechnung für das nächste Jahr bezahlen, <a href="{{prolong_url}}">was mit einem Klick in drei Minuten erledigt ist</a>.</p>
+                    <p>Dies ist derzeit umso wichtiger, weil sich die Republik in einem Kampf um ihre Zukunft befindet: Wir müssen bis zum 31. März 19’000 Mitglieder haben und eine zweite Anschubfinanzierung finden. Jede Mitgliedschaft zählt. <a href="{{cockpit_url}}">Sehen Sie hier den Stand der Dinge, lesen Sie, wie wir das schaffen möchten und was Sie sonst noch tun können</a>. Und sollten Sie ihn verpasst haben, können Sie hier unseren <a href="https://project-r.construction/newsletter/2019-12-09-der-wichtigste-newsletter">wichtigsten Newsletter seit dem Start der Republik</a> nochmals nachlesen.</p>
+                    <p>Sollte uns ein Fehler unterlaufen sein, schreiben Sie uns auf <a href="mailto:kontakt@republik.ch">kontakt@republik.ch</a>.</p>
+                    <p>Und sollten Sie einen finanziellen Engpass haben, schreiben Sie uns ebenso auf <a href="mailto:kontakt@republik.ch">kontakt@republik.ch</a>. Wir finden eine Lösung.</p>
+                    <p>
+                      Mit grossem Dank für das letzte Jahr!<br />
+                      Und in Vorfreude auf ein neues.
+                    </p>
+                    <p>Ihre Crew der Republik</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:20px;">
+                    <p style="font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}">
+                      Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik, Wirtschaft, Gesellschaft und Kultur.
+                      Es wird von seinen Leserinnen und Lesern finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen Beiträgen. In der App, auf der Website und als Newsletter.
+                    </p>
+                    <p style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}">
+                      <img height="79" src="{{frontend_base_url}}/static/logo_republik_newsletter.png" style="border:0px;width:180px !important; height:79px !important;margin:0px;" width="180" alt="">
+                      <br>
+                      Republik AG<br>
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br>
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br>
+                      <a href="mailto:kontakt@republik.ch">kontakt@republik.ch</a>
+                    </p>
+                    <p style="font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}">
+                        <a href="{{link_manifest}}">Unser Manifest</a><br />
+                        <a href="{{link_imprint}}">Das Impressum</a><br />
+                        <a href="{{link_faq}}">Häufig gestellte Fragen</a>
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -575,6 +575,10 @@
       "value": "Ihre Abonnementsrechnung"
     },
     {
+      "key": "api/email/membership_owner_prolong_winback_7/subject",
+      "value": "Ihr Mitgliedschaftsbeitrag ist überfällig"
+    },
+    {
       "key": "api/email/membership_owner_autopay_notice/subject",
       "value": "Ihre Mitgliedschaft erneuert sich automatisch"
     },

--- a/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/owners.js
@@ -103,6 +103,28 @@ const createBuckets = (now) => [
     handler: mailings
   },
   {
+    name: 'membership_owner_prolong_winback_7',
+    endDate: {
+      min: getMinEndDate(now, -10),
+      max: getMaxEndDate(now, -7)
+    },
+    predicate: ({ id: userId, membershipType, membershipAutoPay, autoPay }) => {
+      return ['ABO', 'BENEFACTOR_ABO'].includes(membershipType) && (
+        membershipAutoPay === false ||
+        (
+          membershipAutoPay === true && (
+            !autoPay ||
+            (autoPay && userId !== autoPay.userId)
+          )
+        )
+      )
+    },
+    payload: {
+      templateName: 'membership_owner_prolong_winback_7'
+    },
+    handler: mailings
+  },
+  {
     name: 'membership_owner_autopay_notice',
     endDate: {
       min: moment(now).add(1, 'days'),


### PR DESCRIPTION
- Template name: `membership_owner_prolong_winback_7` (mails before prolong date `membership_owner_prolong_notice_*`).
- Time windows: between 7 and 10 days after prolong date