### PR TITLE
switch to counting all payments instead of surplus after 19000 memberships, fix surplus

### DIFF
--- a/servers/republik/graphql/resolvers/MembershipStats/countRange.js
+++ b/servers/republik/graphql/resolvers/MembershipStats/countRange.js
@@ -1,0 +1,20 @@
+const moment = require('moment')
+
+module.exports = (_, args, context) => {
+  const { pgdb } = context
+
+  const min = moment(args.min)
+  const max = moment(args.max)
+
+  return pgdb.queryOneField(`
+    SELECT
+      count(*)
+    FROM
+      memberships m
+    WHERE
+      m."createdAt" BETWEEN :min AND :max
+  `, {
+    min,
+    max
+  })
+}

--- a/servers/republik/graphql/resolvers/MembershipStats/countRange.js
+++ b/servers/republik/graphql/resolvers/MembershipStats/countRange.js
@@ -1,20 +1,34 @@
 const moment = require('moment')
 
+const createCache = require('../../../modules/crowdfundings/lib/cache')
+const QUERY_CACHE_TTL_SECONDS = 60 * 5 // 5 min
+
+const getCount = (min, max, pgdb) => () => pgdb.queryOneField(`
+  SELECT
+    count(*)
+  FROM
+    memberships m
+  WHERE
+    m."createdAt" BETWEEN :min AND :max
+`, {
+  min,
+  max
+})
+
 module.exports = (_, args, context) => {
   const { pgdb } = context
 
   const min = moment(args.min)
   const max = moment(args.max)
 
-  return pgdb.queryOneField(`
-    SELECT
-      count(*)
-    FROM
-      memberships m
-    WHERE
-      m."createdAt" BETWEEN :min AND :max
-  `, {
-    min,
-    max
-  })
+  const dateFormat = 'YYYY-MM-DD'
+  const queryId = `${min.format(dateFormat)}-${max.format(dateFormat)}`
+
+  return createCache({
+    prefix: 'MembershipStats:countRange',
+    key: queryId,
+    ttl: QUERY_CACHE_TTL_SECONDS,
+    forceRecache: args.forceRecache
+  }, context)
+    .cache(getCount(min, max, pgdb))
 }

--- a/servers/republik/graphql/resolvers/MembershipStats/evolution.js
+++ b/servers/republik/graphql/resolvers/MembershipStats/evolution.js
@@ -163,6 +163,24 @@ const getBucketsFn = (min, max, pgdb) => async () => {
 
   debug('query result: %o', result)
 
+  const switchBucket = result.find(b => b.key === '2020-03')
+  if (switchBucket) {
+    const { activeEndOfMonth, pendingSubscriptionsOnly } = switchBucket
+    const total = activeEndOfMonth + pendingSubscriptionsOnly
+    if (total >= 19000) {
+      const existingDate = await pgdb.public.gsheets.findOneFieldOnly({
+        name: 'RevenueStatsSwitchDate'
+      }, 'data')
+      if (!existingDate) {
+        await pgdb.public.gsheets.insert({
+          name: 'RevenueStatsSwitchDate',
+          data: new Date()
+        })
+          .catch(e => {})
+      }
+    }
+  }
+
   return { buckets: result, updatedAt: new Date() }
 }
 

--- a/servers/republik/graphql/resolvers/RevenueStats/surplus.js
+++ b/servers/republik/graphql/resolvers/RevenueStats/surplus.js
@@ -94,7 +94,7 @@ WITH "totals" AS (
   GROUP BY rd."paymentId", rd."paymentCreatedAt", rd."paymentTotal", rd."packageName", mas."pledgeId", mas."numActive"
   --ORDER BY rd."paymentCreatedAt" DESC
 )
-SELECT SUM("surplusTotal") "total"
+SELECT COALESCE(SUM("surplusTotal"), 0)::int "total"
 FROM "totals"
 WHERE "surplusTotal" > 0
 `

--- a/servers/republik/graphql/resolvers/RevenueStats/surplus.js
+++ b/servers/republik/graphql/resolvers/RevenueStats/surplus.js
@@ -13,17 +13,18 @@ WITH "totals" AS (
       FROM "packageOptions" pkgo
       JOIN "rewards" r ON r.id = pkgo."rewardId"
     )
-
     SELECT
       pay.id "paymentId",
       pay.total "paymentTotal",
       pay."createdAt" "paymentCreatedAt",
       p.id "pledgeId",
+      pkg.name "packageName",
 
       -- Memberships
       pom.id,
-      pom.amount "memberhipAmount",
-      pom.amount * 24000 "membershipTotal",
+      pom.amount * COALESCE(pom.periods, 1) "membershipAmount",
+      LEAST(pom.price, 24000) "membershipPrice",
+      pom.amount * COALESCE(pom.periods, 1) * LEAST(pom.price, 24000) "membershipTotal",
 
       -- Goodies
       pog.id,
@@ -33,6 +34,8 @@ WITH "totals" AS (
     FROM payments pay
     JOIN "pledgePayments" ppay ON ppay."paymentId" = pay.id
     JOIN "pledges" p ON p.id = ppay."pledgeId"
+
+    JOIN "packages" pkg ON p."packageId" = pkg.id
 
     JOIN "pledgeOptions" po ON po."pledgeId" = p.id
 
@@ -45,28 +48,55 @@ WITH "totals" AS (
       pog."templateId" IN (SELECT id FROM "packageOptionsWithRewardType" WHERE type != 'MembershipType')
 
     WHERE
-      (pay.total >= 24000 OR p.donation > 0) AND
       pay.status = 'PAID' AND
-      pay."createdAt" BETWEEN :min AND :max
-    GROUP BY pay.id, p.id, po.id, pom.id, pog.id
+      pay."createdAt" BETWEEN :min AND :max AND
+      pkg.name != 'MONTHLY_ABO'
+    GROUP BY pay.id, p.id, pkg.name, po.id, pom.id, pog.id
+    --ORDER BY pay."createdAt" DESC
+  ),
+  "membershipActivationStats" AS (
+    SELECT
+      p.id "pledgeId",
+      COUNT(*) FILTER (
+        WHERE m."active" = true
+      ) "numActive"
+    FROM
+      pledges p
+    JOIN
+      memberships m
+      ON m."pledgeId" = p.id
+    GROUP BY
+      p.id
   )
 
   SELECT
-    rd."paymentId",
-    rd."paymentCreatedAt",
-    rd."paymentTotal",
-    SUM(rd."membershipTotal") "membershipTotal",
-    SUM(rd."goodieTotal") "goodieTotal",
-    rd."paymentTotal" - COALESCE(SUM(rd."membershipTotal"), 0) - COALESCE(SUM(rd."goodieTotal"), 0) "surplusTotal"
+    --rd."paymentId",
+    --rd."paymentCreatedAt",
+    --rd."paymentTotal",
+    --SUM(rd."membershipTotal") "membershipTotal",
+    --SUM(rd."goodieTotal") "goodieTotal",
+    --mas."numActive",
+    --SUM(rd."membershipAmount") "membershipAmount",
+    --SUM(rd."membershipPrice") "membershipPrice",
+    --(mas."numActive" * COALESCE(SUM(rd."membershipTotal"), 0)/SUM("membershipAmount")) "subtract",
+    CASE
+      WHEN rd."packageName" = 'ABO_GIVE' THEN
+        rd."paymentTotal" - (mas."numActive" * COALESCE(SUM(rd."membershipTotal"), 0)/SUM("membershipAmount")) - COALESCE(SUM(rd."goodieTotal"), 0)
+      ELSE
+        rd."paymentTotal" - COALESCE(SUM(rd."membershipTotal"), 0) - COALESCE(SUM(rd."goodieTotal"), 0)
+    END AS "surplusTotal"
 
   FROM "resolvedData" rd
 
-  GROUP BY rd."paymentId", rd."paymentCreatedAt", rd."paymentTotal"
-)
+  LEFT JOIN "membershipActivationStats" mas
+  ON rd."pledgeId" = mas."pledgeId"
 
-SELECT COALESCE(SUM("surplusTotal"), 0)::int "total"
+  GROUP BY rd."paymentId", rd."paymentCreatedAt", rd."paymentTotal", rd."packageName", mas."pledgeId", mas."numActive"
+  --ORDER BY rd."paymentCreatedAt" DESC
+)
+SELECT SUM("surplusTotal") "total"
 FROM "totals"
-LIMIT 1
+WHERE "surplusTotal" > 0
 `
 
 const normalPaymentsQuery = `

--- a/servers/republik/graphql/schema-types.js
+++ b/servers/republik/graphql/schema-types.js
@@ -214,6 +214,11 @@ type MembershipStats {
     "Maximum month (YYYY-MM)"
     max: YearMonthDate!
   ): MembershipStatsEvolution!
+
+  countRange(
+    min: DateTime!
+    max: DateTime!
+  ): Int!
 }
 type MemberStats {
   count: Int!

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -18,6 +18,7 @@ const { changeover } = require('./changeover')
 
 const surplus = require('../../../../graphql/resolvers/RevenueStats/surplus')
 const evolution = require('../../../../graphql/resolvers/MembershipStats/evolution')
+const countRange = require('../../../../graphql/resolvers/MembershipStats/countRange')
 
 const init = async (_context) => {
   debug('init')
@@ -86,7 +87,8 @@ const init = async (_context) => {
       runFunc: (args, context) =>
         Promise.all([
           surplus(null, { min: '2019-12-01', forceRecache: true }, context),
-          evolution(null, { min: '2019-12', max: '2020-03', forceRecache: true }, context)
+          evolution(null, { min: '2019-12', max: '2020-03', forceRecache: true }, context),
+          countRange(null, { min: '2020-02-29T23:00:00Z', max: '2020-03-31T23:00:00Z', forceRecache: true }, context)
         ]),
       lockTtlSecs: 6,
       runIntervalSecs: 8


### PR DESCRIPTION
quick and dirty solution to counter switch.
[count range query](http://api.republik.test/graphiql/?query=query%20StatusPage%20%7B%0A%20%20revenueStats%20%7B%0A%20%20%20%20surplus(min%3A%20%222019-11-30T23%3A00%3A00Z%22%20%20forceRecache%3A%20true)%20%7B%0A%20%20%20%20%20%20total%0A%20%20%20%20%20%20updatedAt%0A%20%20%20%20%20%20__typename%0A%20%20%20%20%7D%0A%20%20%20%20__typename%0A%20%20%7D%0A%20%20membershipStats%20%7B%0A%20%20%20%20count%0A%20%20%20%20countRange(min%3A%20%222020-02-29T23%3A00%3A00Z%22%20max%3A%20%222020-03-31T23%3A00%3A00Z%22)%20%0A%20%20%20%20evolution(min%3A%20%222019-12%22%2C%20max%3A%20%222020-03%22%20forceRecache%3A%20true)%20%7B%0A%20%20%20%20%20%20buckets%20%7B%0A%20%20%20%20%20%20%20%20key%0A%20%20%20%20%20%20%20%20gaining%0A%20%20%20%20%20%20%20%20ending%0A%20%20%20%20%20%20%20%20expired%0A%20%20%20%20%20%20%20%20cancelled%0A%20%20%20%20%20%20%20%20activeEndOfMonth%0A%20%20%20%20%20%20%20%20pending%0A%20%20%20%20%20%20%20%20pendingSubscriptionsOnly%0A%20%20%20%20%20%20%20%20__typename%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20updatedAt%0A%20%20%20%20%20%20__typename%0A%20%20%20%20%7D%0A%20%20%20%20__typename%0A%20%20%7D%0A%20%20questionnaire(slug%3A%20%221-minute%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20turnout%20%7B%0A%20%20%20%20%20%20submitted%0A%20%20%20%20%20%20__typename%0A%20%20%20%20%7D%0A%20%20%20%20__typename%0A%20%20%7D%0A%7D%0A&operationName=StatusPage)