### PR TITLE
Kaizen

### DIFF
--- a/packages/access/lib/campaigns.js
+++ b/packages/access/lib/campaigns.js
@@ -10,7 +10,7 @@ const findAvailable = async (pgdb) => {
   const campaigns = await pgdb.public.accessCampaigns.find({
     'beginAt <=': now,
     'endAt >': now
-  })
+  }, { orderBy: { beginAt: 'desc' } })
 
   return campaigns
 }
@@ -19,7 +19,7 @@ const findAll = async (pgdb) => {
   debug('findAll')
   const campaigns = await pgdb.public.accessCampaigns.find({
     'beginAt <=': moment()
-  })
+  }, { orderBy: { beginAt: 'desc' } })
 
   return campaigns
 }

--- a/packages/assets/lib/getWidthHeight.js
+++ b/packages/assets/lib/getWidthHeight.js
@@ -7,13 +7,19 @@ module.exports = (resize) => {
       height: null
     }
   }
-  const [_width, _height] = resize.split('x')
+
+  // some browser seem to erroneous append the srcset info to resize, e.g. "503x 503w" (XXXw is data designated for the browser)
+  // - workaround: ignore everything after the first space in resize
+  const [_width, _height] = resize
+    .split(' ')[0]
+    .split('x')
+
   const width = _width ? Math.ceil(Math.abs(_width)) : null
   const height = _height ? Math.ceil(Math.abs(_height)) : null
-  if (width && (typeof (width) !== 'number' || isNaN(width))) {
+  if (isNaN(width) || (width && typeof width !== 'number')) {
     throw new Error('invalid width')
   }
-  if (height && (typeof (height) !== 'number' || isNaN(height))) {
+  if (isNaN(height) || (height && typeof height !== 'number')) {
     throw new Error('invalid height')
   }
   if (width > maxSize || height > maxSize) {

--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -24,6 +24,13 @@ type AudioSource implements PlayableMedia {
   durationMs: Int!
 }
 
+type Podcast {
+  podigeeSlug: String
+  spotifyUrl: String
+  googleUrl: String
+  appleUrl: String
+}
+
 type Meta {
   title: String
   shortTitle: String
@@ -53,6 +60,7 @@ type Meta {
 
   credits: JSON
   audioSource: AudioSource
+  podcast: Podcast
 
   estimatedReadingMinutes: Int
   totalMediaMinutes: Int

--- a/packages/documents/graphql/schema.js
+++ b/packages/documents/graphql/schema.js
@@ -12,6 +12,7 @@ type queries {
     dossier: String
     format: String
     formats: [String!]
+    repoIds: [ID!]
     section: String
     template: String
     hasDossier: Boolean

--- a/packages/search/graphql/schema-types.js
+++ b/packages/search/graphql/schema-types.js
@@ -41,6 +41,7 @@ enum DocumentTextLengths {
 input SearchFilterInput {
   id: ID
   ids: [ID!]
+  repoIds: [ID!]
   type: SearchTypes
   feed: Boolean
   # repoId

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -121,6 +121,9 @@ const schema = {
   repoId: {
     criteria: termCriteriaBuilder('meta.repoId')
   },
+  repoIds: {
+    criteria: termCriteriaBuilder('meta.repoId')
+  },
   path: {
     criteria: termCriteriaBuilder('meta.path.keyword')
   },


### PR DESCRIPTION
Small improvements here and there.

- fix asset errors from this morning ([example url](https://assets.republik.space/s3/republik-assets/github/republik/article-usa-3-deep-south/images/2be793ce036da1230e8dcbc7dad3b0d33153dd46.jpeg?size=3840x2565&resize=2010x%202010w))
- order access campaigns by begin at date
- expose repo ids filter (e.g. for curated feeds)
- expose meta.podcast via schema (e.g. query via format)