### PR TITLE
feat(documents): expose meta.newsletter

### DIFF
--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -31,6 +31,11 @@ type Podcast {
   appleUrl: String
 }
 
+type Newsletter {
+  name: String
+  free: Boolean
+}
+
 type Meta {
   title: String
   shortTitle: String
@@ -61,6 +66,8 @@ type Meta {
   credits: JSON
   audioSource: AudioSource
   podcast: Podcast
+
+  newsletter: Newsletter
 
   estimatedReadingMinutes: Int
   totalMediaMinutes: Int


### PR DESCRIPTION
usage: get it from formats directly and from formats of newsletters
```graphql
{
  document(path: "/format/covid-19-uhr-newsletter") {
    id
    meta {
      title
      newsletter {
        name
        free
      }
    }
  }
  doc: document(path: "/2020/03/16/test-123") {
    id
    meta {
      title
      format {
        id
        meta {
          title
          newsletter {
            name
            free
          }
        }
      }
    }
  }
}
```
<img width="1333" alt="Screenshot 2020-03-16 at 14 14 56" src="https://user-images.githubusercontent.com/410211/76761928-9cb0b780-6790-11ea-83f0-fd3634e2b6dc.png">
