### PR TITLE
fix(mail): Send plain-text comment notification w/ plain-text content

### DIFF
--- a/packages/mail/templates/cf_comment_notification_new.html
+++ b/packages/mail/templates/cf_comment_notification_new.html
@@ -38,7 +38,7 @@
                 <tr>
                   <td style="padding:20px 20px 0;">
                     <p style="color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"><strong style="{{sg_font_style_sans_serif_medium}}">{{COMMENTER_NAME}}</strong> schreibt:</p>
-                    <div style="background-color:#ebf6e5;padding:10px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_serif_regular}}">{{{CONTENT}}}</div>
+                    <div style="background-color:#ebf6e5;padding:10px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_serif_regular}}">{{{CONTENT_HTML}}}</div>
                     <p style="color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"><a href="{{URL}}">Den Beitrag im Kontext auf republik.ch anzeigen</a>. Dort können Sie antworten und weiter debattieren.<br> 
                     </p>
                   </td>

--- a/packages/mail/templates/cf_comment_notification_new.txt
+++ b/packages/mail/templates/cf_comment_notification_new.txt
@@ -1,8 +1,13 @@
 {{COMMENTER_NAME}} schreibt:
 
-{{{CONTENT}}} Den Beitrag im Kontext auf republik.ch anzeigen [{{URL}}]. Dort können Sie
-antworten und weiter debattieren.
+---
 
+{{CONTENT_PLAIN}}
+
+---
+
+Den Beitrag im Kontext auf republik.ch anzeigen [{{URL}}]. Dort können Sie
+antworten und weiter debattieren.
 
 Sie erhalten diese E-Mail, weil Sie an der Debatte «{{DISCUSSION_TITLE}}
 [{{DISCUSSION_URL}}]» teilgenommen haben und/oder Benachrichtigungen für diese


### PR DESCRIPTION
Merge variable `CONTENT` contains HTML version of (markdown) `comment.content`. This is ill-suited for plain-text part of comment notification email.

This Pull Request converts HTML version to plain-text version and includes that one in plain-text part of comment notification email, similar to plain-text generation script.

Picking converting over simply `comment.content` as it respects padding and and link pattern.