### PR TITLE
refactor(republik): Use pre-populated data in MembershipStats.evolution

### DIFF
--- a/packages/scalars/graphql/resolvers/YearMonthDate.js
+++ b/packages/scalars/graphql/resolvers/YearMonthDate.js
@@ -5,11 +5,9 @@ module.exports = new GraphQLScalarType({
   name: 'YearMonthDate',
   description: 'YearMonthDate (format YYYY-MM)',
   parseValue (value) {
-    console.log(value)
     return new Date(`${value}-01`)
   },
   serialize (value) {
-    console.log(value)
     const date = (typeof value) === 'string'
       ? new Date(`${value}-01`)
       : value

--- a/packages/utils/cache.js
+++ b/packages/utils/cache.js
@@ -1,0 +1,103 @@
+const debug = require('debug')
+
+const getRedisKey = ({ namespace, prefix, key }) =>
+  `${namespace}:${prefix}:${key}`
+
+const createGet = ({ options, redis }) => async function () {
+  const key = getRedisKey(options)
+  const payload = await redis.getAsync(key)
+  debug('cache:get')(
+    `${payload ? 'HIT' : 'MISS'} %s`,
+    key
+  )
+
+  return payload
+    ? JSON.parse(payload)
+    : payload
+}
+
+const createSet = ({ options, redis }) => async function (payload) {
+  let payloadString
+
+  try {
+    payloadString = JSON.stringify(payload)
+  } catch (e) {
+    console.info(e, options.key)
+  }
+
+  if (payloadString) {
+    const key = getRedisKey(options)
+    debug('cache:set')('PUT %s', key)
+    return redis.setAsync(
+      key,
+      payloadString,
+      'EX', options.ttl || 60
+    )
+  }
+}
+
+const createCache = ({ options }) => async function (payloadFunction) {
+  debug('cache')('cache')
+
+  if (typeof payloadFunction !== 'function') {
+    throw Error('cache expects function to evaluate payload')
+  }
+
+  if (options.disabled) {
+    return payloadFunction()
+  }
+
+  let data
+  if (!options.forceRecache) {
+    data = await this.get()
+
+    if (data) {
+      return data.payload
+    }
+  }
+
+  data = { payload: await payloadFunction() }
+
+  await this.set(data)
+
+  return data.payload
+}
+
+const createInvalidate = ({ options, redis }) => async function () {
+  debug('cache')('INVALIDATE')
+  await redis.scanMap({
+    pattern: `${options.namespace}:${options.prefix}*`,
+    mapFn: (key, client) => client.delAsync(key)
+  })
+    .catch(() => {})// fails if no keys are matched
+}
+
+module.exports.create = (options_, { redis }) => {
+  const options = {
+    namespace: 'cache',
+    ...options_
+  }
+
+  if (!redis) {
+    throw new Error('context.redis is missing but required')
+  }
+
+  if (!options.prefix) {
+    throw new Error('options.prefix is missing but required')
+  }
+
+  if (!options.key) {
+    throw new Error('options.key is missing but required')
+  }
+
+  if (options.disabled) {
+    console.warn(`WARNING: Cache DISABLED for "${options.namespace}:${options.prefix}"`)
+  }
+
+  return {
+    get: createGet({ options, redis }),
+    set: createSet({ options, redis }),
+    cache: createCache({ options, redis }),
+    invalidate: createInvalidate({ options, redis })
+  }
+}

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -9,5 +9,6 @@ module.exports = {
   getUrls: require('./getUrls'),
   truncate: require('./truncate'),
   remark: require('./remark'),
-  uuidForObject: require('./uuidForObject')
+  uuidForObject: require('./uuidForObject'),
+  cache: require('./cache')
 }

--- a/servers/republik/graphql/resolvers/MembershipStats/evolution.js
+++ b/servers/republik/graphql/resolvers/MembershipStats/evolution.js
@@ -1,202 +1,33 @@
 const moment = require('moment')
-const debug = require('debug')('republik:resolvers:MembershipStats:overview')
 
-const createCache = require('../../../modules/crowdfundings/lib/cache')
-const QUERY_CACHE_TTL_SECONDS = 60 * 5 // 5 min
-
-const dateFormat = 'YYYY-MM-DD'
-
-const query = `
-WITH "minMaxDates" AS (
-  SELECT m.id, m.active, m.renew, m."autoPay", mt.name "membershipTypeName", MIN(mp."beginDate") "minBeginDate", MAX(mp."endDate") "maxEndDate"
-  FROM "memberships" m
-  JOIN "membershipPeriods" mp ON mp."membershipId" = m.id
-  JOIN "membershipTypes" mt ON mt.id = m."membershipTypeId"
-  WHERE m."userId" != 'f0512927-7e03-4ecc-b14f-601386a2a249' -- Jefferson
-  GROUP BY m.id, mt.id
-), "membershipDonation" AS (
-  WITH "pledgeMembership" AS (
-    SELECT p."createdAt", p.donation, COALESCE(pom.id, pm.id) "membershipId"
-    FROM "pledges" p
-    JOIN "pledgeOptions" po ON po."pledgeId" = p.id AND po.amount > 0
-    LEFT JOIN "memberships" pom ON pom.id = po."membershipId" AND pom."userId" = p."userId"
-    LEFT JOIN "memberships" pm ON pm."pledgeId" = p.id AND pm."userId" = p."userId"
-    WHERE p.donation > 0
-      AND (pom.id IS NOT NULL OR pm.id IS NOT NULL)
-      AND p.status != 'DRAFT'
-  )
-
-  SELECT pm.donation, pm."membershipId"
-  FROM (
-    SELECT "membershipId", MAX("createdAt") AS "createdAt"
-    FROM "pledgeMembership"
-    GROUP BY "membershipId"
-  ) AS lpm
-  JOIN "pledgeMembership" pm
-    ON pm."membershipId" = lpm."membershipId"
-    AND pm."createdAt" = lpm."createdAt"
-  GROUP BY pm."membershipId", pm.donation
-), range AS (
-  SELECT
-    unit at time zone :TZ "first",
-    (unit + '1 month'::interval - '1 second'::interval) at time zone :TZ "last"
-
-  FROM generate_series(
-    :min::timestamp,
-    :max::timestamp,
-    '1 month'
-  ) unit
-)
-
-SELECT
-  to_char("first" at time zone :TZ, 'YYYY-MM') "key",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= "first"
-    AND "minBeginDate" < "first"
-  ) "activeBeginningOfMonth",
-
-  COUNT(*) FILTER (
-    WHERE "minBeginDate" >= "first"
-    AND "minBeginDate" <= "last"
-  ) "gaining",
-
-  COUNT(*) FILTER (
-    WHERE "minBeginDate" >= "first"
-    AND "minBeginDate" <= "last"
-    AND "membershipDonation"."membershipId" IS NOT NULL
-  ) "gainingWithDonation",
-
-  COUNT(*) FILTER (
-    WHERE "minBeginDate" >= "first"
-    AND "minBeginDate" <= "last"
-    AND "membershipDonation"."membershipId" IS NULL
-  ) "gainingWithoutDonation",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= "first"
-    AND "maxEndDate" <= "last"
-
-  ) "ending",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= "first"
-    AND "maxEndDate" <= "last"
-    AND (
-      active = TRUE
-      AND renew = TRUE
-    )
-  ) "prolongable",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= "first"
-    AND "maxEndDate" <= "last"
-    AND renew = TRUE
-    AND active = FALSE
-  ) "expired",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= "first"
-    AND "maxEndDate" <= "last"
-    AND renew = FALSE
-  ) "cancelled",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= "last"
-    AND "minBeginDate" < "last"
-  ) "activeEndOfMonth",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= "last"
-    AND "minBeginDate" < "last"
-    AND "membershipDonation"."membershipId" IS NOT NULL
-  ) "activeEndOfMonthWithDonation",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= "last"
-    AND "minBeginDate" < "last"
-    AND "membershipDonation"."membershipId" IS NULL
-  ) "activeEndOfMonthWithoutDonation",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= :min::timestamp
-    AND "maxEndDate" <= "last"
-    AND (
-      active = TRUE
-      AND renew = TRUE
-    )
-  ) "pending",
-
-  COUNT(*) FILTER (
-    WHERE "maxEndDate" >= :min::timestamp
-    AND "maxEndDate" <= "last"
-    AND (
-      active = TRUE
-      AND renew = TRUE
-    )
-    AND "membershipTypeName" IN ('MONTHLY_ABO')
-  ) "pendingSubscriptionsOnly"
-
-FROM range, "minMaxDates"
-
-LEFT JOIN "membershipDonation"
-  ON "membershipDonation"."membershipId" = "minMaxDates".id
-
-GROUP BY 1
-ORDER BY 1
-`
-
-const getBucketsFn = (min, max, pgdb) => async () => {
-  debug(
-    'query for: %o',
-    { min: min.toISOString(), max: max.toISOString() }
-  )
-
-  const result = await pgdb.query(
-    query,
-    {
-      min: min.format(dateFormat),
-      max: max.format(dateFormat),
-      TZ: process.env.TZ || 'Europe/Zurich'
-    }
-  )
-
-  debug('query result: %o', result)
-
-  const switchBucket = result.find(b => b.key === '2020-03')
-  if (switchBucket) {
-    const { activeEndOfMonth, pendingSubscriptionsOnly } = switchBucket
-    const total = activeEndOfMonth + pendingSubscriptionsOnly
-    if (total >= 19000) {
-      const existingDate = await pgdb.public.gsheets.findOneFieldOnly({
-        name: 'RevenueStatsSwitchDate'
-      }, 'data')
-      if (!existingDate) {
-        await pgdb.public.gsheets.insert({
-          name: 'RevenueStatsSwitchDate',
-          data: new Date()
-        })
-          .catch(e => {})
-      }
-    }
-  }
-
-  return { buckets: result, updatedAt: new Date() }
-}
+const { createCache } = require('../../../lib/MembershipStats/evolution')
 
 module.exports = async (_, args, context) => {
-  const { pgdb } = context
+  // Fetch pre-populated data
+  const data = await createCache(context).get()
 
-  const min = moment(args.min)
-  const max = moment(args.max)
+  // In case pre-populated data is not available...
+  if (!data) {
+    throw new Error('Unable to retrieve pre-populated data for MembershipStats.evolution')
+  }
 
-  const queryId = `${min.format(dateFormat)}-${max.format(dateFormat)}`
+  // Retrieve pre-populated data.
+  const { result = [], updatedAt = new Date() } = data
 
-  return createCache({
-    prefix: 'MembershipStats:evolution',
-    key: queryId,
-    ttl: QUERY_CACHE_TTL_SECONDS,
-    forceRecache: args.forceRecache
-  }, context)
-    .cache(getBucketsFn(min, max, pgdb))
+  // A list of desired bucket keys to return
+  const keys = []
+
+  // Add keys to bucket keys due to arguments
+  for (
+    const date = moment(args.min).clone().startOf('month'); // Start with {min}, beginning of months
+    date <= moment(args.max); // Loop while date is lower than {max}
+    date.add(1, 'month') // Add month to {date} before next loop
+  ) {
+    keys.push(date.format('YYYY-MM'))
+  }
+
+  return {
+    buckets: result.filter(({ key }) => keys.includes(key)),
+    updatedAt
+  }
 }

--- a/servers/republik/lib/MembershipStats/evolution.js
+++ b/servers/republik/lib/MembershipStats/evolution.js
@@ -1,0 +1,181 @@
+const debug = require('debug')('republik:lib:MembershipStats:evolution')
+
+const { cache: { create } } = require('@orbiting/backend-modules-utils')
+
+const QUERY_CACHE_TTL_SECONDS = 60 * 60 * 24 // A day
+
+const query = `
+WITH "minMaxDates" AS (
+  SELECT m.id, m.active, m.renew, m."autoPay", mt.name "membershipTypeName", MIN(mp."beginDate") "minBeginDate", MAX(mp."endDate") "maxEndDate"
+  FROM "memberships" m
+  JOIN "membershipPeriods" mp ON mp."membershipId" = m.id
+  JOIN "membershipTypes" mt ON mt.id = m."membershipTypeId"
+  WHERE m."userId" != 'f0512927-7e03-4ecc-b14f-601386a2a249' -- Jefferson
+  GROUP BY m.id, mt.id
+), "membershipDonation" AS (
+  WITH "pledgeMembership" AS (
+    SELECT p."createdAt", p.donation, COALESCE(pom.id, pm.id) "membershipId"
+    FROM "pledges" p
+    JOIN "pledgeOptions" po ON po."pledgeId" = p.id AND po.amount > 0
+    LEFT JOIN "memberships" pom ON pom.id = po."membershipId" AND pom."userId" = p."userId"
+    LEFT JOIN "memberships" pm ON pm."pledgeId" = p.id AND pm."userId" = p."userId"
+    WHERE p.donation > 0
+      AND (pom.id IS NOT NULL OR pm.id IS NOT NULL)
+      AND p.status != 'DRAFT'
+  )
+
+  SELECT pm.donation, pm."membershipId"
+  FROM (
+    SELECT "membershipId", MAX("createdAt") AS "createdAt"
+    FROM "pledgeMembership"
+    GROUP BY "membershipId"
+  ) AS lpm
+  JOIN "pledgeMembership" pm
+    ON pm."membershipId" = lpm."membershipId"
+    AND pm."createdAt" = lpm."createdAt"
+  GROUP BY pm."membershipId", pm.donation
+), range AS (
+  SELECT
+    unit at time zone :TZ "first",
+    (unit + '1 month'::interval - '1 second'::interval) at time zone :TZ "last"
+
+  FROM generate_series(
+    :min::timestamp,
+    :max::timestamp,
+    '1 month'
+  ) unit
+)
+
+SELECT
+  to_char("first" at time zone :TZ, 'YYYY-MM') "key",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "first"
+    AND "minBeginDate" < "first"
+  ) "activeBeginningOfMonth",
+
+  COUNT(*) FILTER (
+    WHERE "minBeginDate" >= "first"
+    AND "minBeginDate" <= "last"
+  ) "gaining",
+
+  COUNT(*) FILTER (
+    WHERE "minBeginDate" >= "first"
+    AND "minBeginDate" <= "last"
+    AND "membershipDonation"."membershipId" IS NOT NULL
+  ) "gainingWithDonation",
+
+  COUNT(*) FILTER (
+    WHERE "minBeginDate" >= "first"
+    AND "minBeginDate" <= "last"
+    AND "membershipDonation"."membershipId" IS NULL
+  ) "gainingWithoutDonation",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "first"
+    AND "maxEndDate" <= "last"
+
+  ) "ending",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "first"
+    AND "maxEndDate" <= "last"
+    AND (
+      active = TRUE
+      AND renew = TRUE
+    )
+  ) "prolongable",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "first"
+    AND "maxEndDate" <= "last"
+    AND renew = TRUE
+    AND active = FALSE
+  ) "expired",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "first"
+    AND "maxEndDate" <= "last"
+    AND renew = FALSE
+  ) "cancelled",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "last"
+    AND "minBeginDate" < "last"
+  ) "activeEndOfMonth",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "last"
+    AND "minBeginDate" < "last"
+    AND "membershipDonation"."membershipId" IS NOT NULL
+  ) "activeEndOfMonthWithDonation",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "last"
+    AND "minBeginDate" < "last"
+    AND "membershipDonation"."membershipId" IS NULL
+  ) "activeEndOfMonthWithoutDonation",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= :min::timestamp
+    AND "maxEndDate" <= "last"
+    AND (
+      active = TRUE
+      AND renew = TRUE
+    )
+  ) "pending",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= :min::timestamp
+    AND "maxEndDate" <= "last"
+    AND (
+      active = TRUE
+      AND renew = TRUE
+    )
+    AND "membershipTypeName" IN ('MONTHLY_ABO')
+  ) "pendingSubscriptionsOnly"
+
+FROM range, "minMaxDates"
+
+LEFT JOIN "membershipDonation"
+  ON "membershipDonation"."membershipId" = "minMaxDates".id
+
+GROUP BY 1
+ORDER BY 1
+`
+
+const createCache = (context) => create(
+  {
+    namespace: 'republik',
+    prefix: 'MembershipStats:evolution',
+    key: 'any',
+    ttl: QUERY_CACHE_TTL_SECONDS
+  },
+  context
+)
+
+const populate = async (context) => {
+  debug('populate')
+
+  const { pgdb } = context
+
+  // Determine range we've to generate data for
+  const [{ min, max }] = await pgdb.query(`
+    SELECT
+      MIN("beginDate") "min",
+      MAX("endDate") "max"
+    
+    FROM "membershipPeriods"
+  `)
+
+  // Generate date for range
+  const result = await pgdb.query(query, { min, max, TZ: process.env.TZ || 'Europe/Zurich' })
+
+  // Cache said data.
+  await createCache(context).set({ result, updatedAt: new Date() })
+}
+
+module.exports = {
+  createCache,
+  populate
+}

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -16,7 +16,7 @@ const { deactivate } = require('./deactivate')
 const { changeover } = require('./changeover')
 
 const surplus = require('../../../../graphql/resolvers/RevenueStats/surplus')
-const evolution = require('../../../../graphql/resolvers/MembershipStats/evolution')
+const { populate: populateMembershipStatsEvolution } = require('../../../../lib/MembershipStats/evolution')
 const countRange = require('../../../../graphql/resolvers/MembershipStats/countRange')
 
 const init = async (context) => {
@@ -78,7 +78,7 @@ const init = async (context) => {
       runFunc: (args, context) =>
         Promise.all([
           surplus(null, { min: '2019-12-01', forceRecache: true }, context),
-          evolution(null, { min: '2019-12', max: '2020-03', forceRecache: true }, context),
+          populateMembershipStatsEvolution(context),
           countRange(null, { min: '2020-02-29T23:00:00Z', max: '2020-03-31T23:00:00Z', forceRecache: true }, context)
         ]),
       lockTtlSecs: 6,

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -70,7 +70,6 @@ const init = async (context) => {
     })
   )
 
-  // remove after campaign
   schedulers.push(
     intervalScheduler.init({
       name: 'stats-cache',
@@ -81,8 +80,8 @@ const init = async (context) => {
           populateMembershipStatsEvolution(context),
           countRange(null, { min: '2020-02-29T23:00:00Z', max: '2020-03-31T23:00:00Z', forceRecache: true }, context)
         ]),
-      lockTtlSecs: 6,
-      runIntervalSecs: 8
+      lockTtlSecs: 10,
+      runIntervalSecs: 60
     })
   )
 

--- a/servers/republik/script/MembershipStats/evolution/populate.js
+++ b/servers/republik/script/MembershipStats/evolution/populate.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+/**
+ * Script will populate underlying data for MembershipStats.evolution
+ *
+ * No options or arguments available.
+ */
+require('@orbiting/backend-modules-env').config()
+const { lib: { ConnectionContext } } = require('@orbiting/backend-modules-base')
+
+const { populate } = require('../../../lib/MembershipStats/evolution')
+
+const applicationName = 'backends republik script MembershipStats evolution populate'
+
+ConnectionContext.create(applicationName).then(async context => {
+  console.log('Begin...')
+  await populate(context)
+  console.log('Done.')
+
+  return context
+})
+  .then(context => ConnectionContext.close(context))


### PR DESCRIPTION
This Pull Request refactors `MembershipStats.evolution`. It uses pre-populated data and returns specified monthly buckets (a date range).

Pre-populated data contains _all_ months and is populated either via scheduler or a script.

Pull Request drops "switchBucket" code parts.

**Script to populate data**

```
$ servers/republik/script/MembershipStats/evolution/populate.js
Begin...
Done.
```

It introduces a preliminary version of `cache` in package `utils`, an almost a blunt copy of servers/republik/modules/crowdfundings/lib/cache.js. If this proves successful, we may adopt it elswhere.

