### PR TITLE
feat(documents): Merge repo URL search params before resolving document URL

### DIFF
--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -22,29 +22,34 @@ const getRepoId = (url, requireQuery) => {
   ])
 
   if (!url) {
-    return
+    return {}
   }
-  const {
-    hostname,
-    pathname,
-    searchParams
-  } = new URL(String(url), FRONTEND_BASE_URL)
+
+  const parsedUrl = new URL(String(url), FRONTEND_BASE_URL)
+  const { hostname, pathname, searchParams } = parsedUrl
+
   if (!pathname) { // empty for mailto
-    return
+    return {}
   }
+
   const pathSegments = pathname.split('/').filter(Boolean)
   if (
     hostname !== 'github.com' ||
     pathSegments.length !== 2 ||
     !GITHUB_ORGS.split(',').includes(pathSegments[0])
   ) {
-    return
+    return {}
   }
+
   if (requireQuery && !searchParams.has(requireQuery)) {
-    return
+    return {}
   }
+
+  searchParams.delete(requireQuery)
+
   pathSegments[0] = GITHUB_LOGIN
-  return pathSegments.join('/')
+
+  return { repoId: pathSegments.join('/'), parsedUrl }
 }
 
 const userPath = /^\/~([^/?#]+)/
@@ -97,28 +102,52 @@ const createUrlReplacer = (allDocuments = [], usernames = [], errors = [], urlPr
     }
   }
 
-  const repoId = getRepoId(url, 'autoSlug')
+  const { repoId, parsedUrl } = getRepoId(url, 'autoSlug')
+  // {url} lacks {repoId} and is nothing to resolve further.
   if (!repoId) {
     return url
   }
+
+  // Return early if {stripDocLinks} argument is set as nothing has to be resolved.
   if (stripDocLinks) {
     return ''
   }
+
   const linkedDoc = allDocuments
     .find(d => d.meta.repoId === repoId)
+
   if (linkedDoc) {
-    const hash = url.split('#')[1]
-    return `${urlPrefix}${linkedDoc.content.meta.path}${searchString}${hash ? `#${hash}` : ''}`
+    // Stitch and parse simple URL version including arguments {urlPrefix}, {searchString}
+    const resolvedUrl = new URL(
+      `${urlPrefix}${linkedDoc.content.meta.path}${searchString}`,
+      FRONTEND_BASE_URL
+    )
+
+    // Add {parsedUrl.hash} to {resolvedUrl.hash}, incase there is one provided.
+    resolvedUrl.hash = parsedUrl.hash
+
+    // Merge {parsedUrl.searchParams} into {resolvedUrl.searchParams}
+    // parsedUrl overwrites same keys in resolvedUrl.
+    // resolvedUrl may contain searchParams from parsed {searchString}.
+    parsedUrl.searchParams.forEach((value, name) => resolvedUrl.searchParams.set(name, value))
+
+    // If {urlPrefix} is set, return stringified {resolvedUrl}.
+    if (urlPrefix) {
+      return resolvedUrl.toString()
+    }
+
+    // If {urlPrefix} is not set, replace {FRONTEND_BASE_URL} to return relative URLs.
+    return resolvedUrl.toString().replace(new RegExp(`^${FRONTEND_BASE_URL}`), '')
   } else {
     errors.push(repoId)
   }
-  // autoSlug links pointing to
-  // not published or missing documents are stripped
+
+  // autoSlug links pointing to not published or missing documents are stripped
   return ''
 }
 
 const createResolver = (allDocuments, errors = []) => url => {
-  const repoId = getRepoId(url)
+  const { repoId } = getRepoId(url)
   if (!repoId) {
     return null
   }
@@ -164,13 +193,13 @@ const contentUrlResolver = (doc, allDocuments = [], usernames = [], errors, urlP
           publishDate: linkedDoc.meta.publishDate,
           section: linkedDoc.meta.template === 'section'
             ? linkedDoc.meta.repoId
-            : getRepoId(linkedDoc.meta.section),
+            : getRepoId(linkedDoc.meta.section).repoId,
           format: linkedDoc.meta.template === 'format'
             ? linkedDoc.meta.repoId
-            : getRepoId(linkedDoc.meta.format),
+            : getRepoId(linkedDoc.meta.format).repoId,
           series: linkedDoc.meta.series ? (
             typeof linkedDoc.meta.series === 'string'
-              ? getRepoId(linkedDoc.meta.series)
+              ? getRepoId(linkedDoc.meta.series).repoId
               : linkedDoc.meta.repoId
           ) : undefined
         }

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -123,7 +123,7 @@ const createUrlReplacer = (allDocuments = [], usernames = [], errors = [], urlPr
       FRONTEND_BASE_URL
     )
 
-    // Add {parsedUrl.hash} to {resolvedUrl.hash}, incase there is one provided.
+    // Replace {parsedUrl.hash} with {resolvedUrl.hash}
     resolvedUrl.hash = parsedUrl.hash
 
     // Merge {parsedUrl.searchParams} into {resolvedUrl.searchParams}

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -29,7 +29,7 @@ const getRepoId = (url, requireQuery) => {
   const { hostname, pathname, searchParams } = parsedUrl
 
   if (!pathname) { // empty for mailto
-    return {}
+    return { parsedUrl }
   }
 
   const pathSegments = pathname.split('/').filter(Boolean)
@@ -38,11 +38,11 @@ const getRepoId = (url, requireQuery) => {
     pathSegments.length !== 2 ||
     !GITHUB_ORGS.split(',').includes(pathSegments[0])
   ) {
-    return {}
+    return { parsedUrl }
   }
 
   if (requireQuery && !searchParams.has(requireQuery)) {
-    return {}
+    return { parsedUrl }
   }
 
   searchParams.delete(requireQuery)

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -26,7 +26,7 @@ const getRepoId = (url, requireQuery) => {
   }
 
   const parsedUrl = new URL(String(url), FRONTEND_BASE_URL)
-  const { hostname, pathname, searchParams } = parsedUrl
+  const { hostname, pathname } = parsedUrl
 
   if (!pathname) { // empty for mailto
     return { parsedUrl }
@@ -41,11 +41,13 @@ const getRepoId = (url, requireQuery) => {
     return { parsedUrl }
   }
 
-  if (requireQuery && !searchParams.has(requireQuery)) {
+  if (requireQuery && !parsedUrl.searchParams.has(requireQuery)) {
     return { parsedUrl }
   }
 
-  searchParams.delete(requireQuery)
+  // Remove {requireQuery} key-value from {parsedUrl.searchParams}.
+  // Value should not be propagated, as this fn acted on it.
+  parsedUrl.searchParams.delete(requireQuery)
 
   pathSegments[0] = GITHUB_LOGIN
 

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -246,8 +246,8 @@ const extractIdsFromNode = (haystack, contextRepoId) => {
   const users = []
   visit(haystack, 'zone', node => {
     if (node.data) {
-      repos.push(getRepoId(node.data.url))
-      repos.push(getRepoId(node.data.formatUrl))
+      repos.push(getRepoId(node.data.url).repoId)
+      repos.push(getRepoId(node.data.formatUrl).repoId)
     }
   })
   visit(haystack, 'link', node => {
@@ -264,7 +264,7 @@ const extractIdsFromNode = (haystack, contextRepoId) => {
         )
       }
     }
-    const repoId = getRepoId(node.url, 'autoSlug')
+    const { repoId } = getRepoId(node.url, 'autoSlug')
     if (repoId) {
       repos.push(repoId)
     }
@@ -350,20 +350,20 @@ const addRelatedDocs = async ({
     // from meta
     const meta = doc.content.meta
     // TODO get keys from packages/documents/lib/resolve.js
-    repoIds.push(getRepoId(meta.dossier))
-    repoIds.push(getRepoId(meta.format))
-    repoIds.push(getRepoId(meta.section))
-    repoIds.push(getRepoId(meta.discussion))
+    repoIds.push(getRepoId(meta.dossier).repoId)
+    repoIds.push(getRepoId(meta.format).repoId)
+    repoIds.push(getRepoId(meta.section).repoId)
+    repoIds.push(getRepoId(meta.discussion).repoId)
     if (meta.series) {
       // If a string, probably a series master (tbc.)
       if (typeof meta.series === 'string') {
-        const seriesRepoId = getRepoId(meta.series)
+        const { repoId: seriesRepoId } = getRepoId(meta.series)
         if (seriesRepoId) {
           seriesRepoIds.push(seriesRepoId)
         }
       } else {
         meta.series.episodes && meta.series.episodes.forEach(episode => {
-          repoIds.push(getRepoId(episode.document))
+          repoIds.push(getRepoId(episode.document).repoId)
         })
       }
     }
@@ -386,8 +386,8 @@ const addRelatedDocs = async ({
     seriesRelatedDocs.forEach(doc => {
       const meta = doc.content.meta
       meta.series.episodes && meta.series.episodes.forEach(episode => {
-        debug(getRepoId(episode.document))
-        repoIds.push(getRepoId(episode.document))
+        debug(getRepoId(episode.document).repoId)
+        repoIds.push(getRepoId(episode.document).repoId)
       })
     })
   }

--- a/packages/subscriptions/graphql/resolvers/Document.js
+++ b/packages/subscriptions/graphql/resolvers/Document.js
@@ -22,7 +22,7 @@ const getRepoIdsForDoc = (doc, includeParents) => ([
   (doc.meta && doc.meta.repoId) || (doc._meta && doc._meta.repoId),
   includeParents && getRepoId(
     (doc.meta && doc.meta.format) || (doc._meta && doc._meta.format)
-  )
+  ).repoId
 ].filter(Boolean))
 
 const getTemplate = (doc) =>

--- a/servers/publikator/graphql/resolvers/Meta.js
+++ b/servers/publikator/graphql/resolvers/Meta.js
@@ -14,7 +14,7 @@ const resolveRepoId = field => async (meta, args, context) => {
     return meta[field]
   }
 
-  const repoId = resolve.getRepoId(meta[field])
+  const { repoId } = resolve.getRepoId(meta[field])
   if (!repoId) {
     return null
   }

--- a/servers/publikator/lib/Notifications.js
+++ b/servers/publikator/lib/Notifications.js
@@ -21,7 +21,7 @@ const notifyPublish = async (repoId, context) => {
   const doc = await loaders.Document.byRepoId.load(repoId)
   const docRepoId = doc.meta.repoId
 
-  const formatRepoId = getRepoId(doc.meta.format)
+  const { repoId: formatRepoId } = getRepoId(doc.meta.format)
   if (!formatRepoId) {
     return
   }
@@ -62,8 +62,7 @@ const notifyPublish = async (repoId, context) => {
         users: subscribers,
         content: {
           app: {
-            title: t('api/notifications/doc/title', { title: inQuotes(subscriptionDoc.meta.title) }
-            ),
+            title: t('api/notifications/doc/title', { title: inQuotes(subscriptionDoc.meta.title) }),
             body: doc.meta.shortTitle || [doc.meta.title, doc.meta.description].join(' - '),
             url: `${FRONTEND_BASE_URL}${doc.meta.path}`,
             type: 'document',


### PR DESCRIPTION
This Pull Requests changes return type of `getRepoId(url, requireQuery)`, and merges search parameters of repo URL with resolved document URL.

**Return type of `getRepoId(url, requireQuery)`**

Instead of a string, it returns an object with these props:

- `repoId`: set if repo ID is parseable
- `parsedUrl`: returns an `URL` object with parsed argument `url`

Changing return type here reduces `new URL` calls on same URL.

**Merge search parameters of repo URL with resolved document URL**

Keeps repo URL search parameters when resolving to a document URL.

_Example_

https://github.com/republik-dev/pae-article-zielartikel?autoSlug&foo=bar&audio=1#irgend-ein-hash

becomes

https://frontend.url/2022/02/22/web-slug?foo=bar&audio=1#irgend-ein-hash
