### PR TITLE
feat(auth): Authorize w/ an AUTHORIZE_SESSION access token

### DIFF
--- a/packages/auth/graphql/resolvers/User.js
+++ b/packages/auth/graphql/resolvers/User.js
@@ -97,11 +97,9 @@ module.exports = {
   isUserOfCurrentSession: (user, args, { user: me }) =>
     !!(me && user.id === me.id),
 
-  accessToken: (user, { scope }, { user: me }) => {
-    if (Roles.userIsMeOrInRoles(user, me, DEFAULT_USER_ACCESS_ROLES)) {
-      return AccessToken.issueForUser(me, user, scope)
-    }
-  },
+  accessToken: (user, { scope }, { user: me }) =>
+    AccessToken.generateForUserByUser(user, scope, me, DEFAULT_USER_ACCESS_ROLES),
+
   hasConsentedTo: (user, { name }, { pgdb, user: me }) => {
     if (Roles.userIsMeOrInRoles(user, me, DEFAULT_USER_ACCESS_ROLES)) {
       return Consents.statusForPolicyForUser({

--- a/packages/auth/graphql/resolvers/User.js
+++ b/packages/auth/graphql/resolvers/User.js
@@ -99,7 +99,7 @@ module.exports = {
 
   accessToken: (user, { scope }, { user: me }) => {
     if (Roles.userIsMeOrInRoles(user, me, DEFAULT_USER_ACCESS_ROLES)) {
-      return AccessToken.generateForUser(user, scope)
+      return AccessToken.issueForUser(me, user, scope)
     }
   },
   hasConsentedTo: (user, { name }, { pgdb, user: me }) => {

--- a/packages/auth/graphql/resolvers/_mutations/signIn.js
+++ b/packages/auth/graphql/resolvers/_mutations/signIn.js
@@ -5,8 +5,9 @@ module.exports = async (_, args, { pgdb, req }) => {
     email,
     context,
     consents,
-    tokenType
+    tokenType,
+    accessToken
   } = args
 
-  return signIn(email, context, pgdb, req, consents, tokenType)
+  return signIn(email, context, pgdb, req, consents, tokenType, accessToken)
 }

--- a/packages/auth/graphql/schema-types.js
+++ b/packages/auth/graphql/schema-types.js
@@ -76,7 +76,7 @@ enum QRCodeErrorCorrectionLevel {
 enum SignInTokenType {
   EMAIL_TOKEN
   EMAIL_CODE
-  AUTHORIZE_TOKEN
+  ACCESS_TOKEN
   TOTP
   SMS
   APP

--- a/packages/auth/graphql/schema-types.js
+++ b/packages/auth/graphql/schema-types.js
@@ -76,6 +76,7 @@ enum QRCodeErrorCorrectionLevel {
 enum SignInTokenType {
   EMAIL_TOKEN
   EMAIL_CODE
+  AUTHORIZE_TOKEN
   TOTP
   SMS
   APP
@@ -128,5 +129,6 @@ enum AccessTokenScope {
   CUSTOM_PLEDGE
   CUSTOM_PLEDGE_EXTENDED
   CLAIM_CARD
+  AUTHORIZE_SESSION
 }
 `

--- a/packages/auth/graphql/schema.js
+++ b/packages/auth/graphql/schema.js
@@ -39,6 +39,7 @@ type mutations {
     context: String,
     consents: [String!],
     tokenType: SignInTokenType,
+    # accessToken w/ scope AUTHORIZE_SESSION
     accessToken: ID
   ): SignInResponse!
   signOut: Boolean!

--- a/packages/auth/graphql/schema.js
+++ b/packages/auth/graphql/schema.js
@@ -34,7 +34,13 @@ type queries {
 type mutations {
   # signIn
   # default tokenType: EMAIL_TOKEN
-  signIn(email: String!, context: String, consents: [String!], tokenType: SignInTokenType): SignInResponse!
+  signIn(
+    email: String!,
+    context: String,
+    consents: [String!],
+    tokenType: SignInTokenType,
+    accessToken: ID
+  ): SignInResponse!
   signOut: Boolean!
 
   # if userId is null, the logged in user's email is changed

--- a/packages/auth/lib/AccessToken.js
+++ b/packages/auth/lib/AccessToken.js
@@ -27,7 +27,7 @@ const scopeConfigs = {
   AUTHORIZE_SESSION: {
     rolesIssuer: ['admin', 'supporter'],
     authorizeSession: true,
-    ttlDays: 7,
+    ttlDays: 5,
     expireAtFormat: 'YYYY-MM-DDTHH:mm:ss.SSSZZ'
   }
 }

--- a/packages/auth/lib/AccessToken.js
+++ b/packages/auth/lib/AccessToken.js
@@ -24,6 +24,10 @@ const scopeConfigs = {
   CLAIM_CARD: {
     exposeFields: ['email', 'cards'],
     ttlDays: 90
+  },
+  AUTHORIZE_SESSION: {
+    authorizeSession: true,
+    ttlDays: 7
   }
 }
 
@@ -119,9 +123,17 @@ const ensureCanPledgePackage = (user, packageName) => {
   }
 }
 
+const hasAuthorizeSession = (user) =>
+  !!(
+    user &&
+    user._scopeConfig &&
+    user._scopeConfig.authorizeSession
+  )
+
 module.exports = {
   generateForUser,
   getUserByAccessToken,
   isFieldExposed,
-  ensureCanPledgePackage
+  ensureCanPledgePackage,
+  hasAuthorizeSession
 }

--- a/packages/auth/lib/Users.js
+++ b/packages/auth/lib/Users.js
@@ -181,7 +181,7 @@ const signIn = async (_email, context, pgdb, req, consents, _tokenType, accessTo
 
     let authorizeToken = null
 
-    // Check {accessToken} and if is valid, try to generate a token in {authorizeToken}
+    // Check {accessToken} and if valid, try to generate a token in {authorizeToken}
     if (accessToken) {
       const accessTokenUser = await getUserByAccessToken(accessToken, { pgdb })
 
@@ -203,8 +203,7 @@ const signIn = async (_email, context, pgdb, req, consents, _tokenType, accessTo
       }
     }
 
-    // Either user obtained token in {authorizeToken}, or generate a new
-    // token (because {authorizeSessionToken} is empty)
+    // Either user obtained token in {authorizeToken}, or generate a new token.
     const token = authorizeToken || await generateNewToken(tokenType, {
       pgdb,
       session,

--- a/packages/auth/lib/challenges/AccessTokenChallenge.js
+++ b/packages/auth/lib/challenges/AccessTokenChallenge.js
@@ -2,22 +2,22 @@ const { newAuthError } = require('../AuthError')
 
 const AccessTokenMissingError = newAuthError(
   'authorize-token-challenge-access-token-missing',
-  'api/auth/authorizeToken/accessTokenMissing'
+  'api/auth/accessToken/accessTokenMissing'
 )
 const TokensExceededError = newAuthError(
   'authorize-token-challenge-tokens-exceeded',
-  'api/auth/authorizeToken/tokensExceeded'
+  'api/auth/accessToken/tokensExceeded'
 )
 
 const MAX_VALID_TOKENS = 1
 const TTL = 1000 * 60 // 1 minute
-const Type = 'AUTHORIZE_TOKEN'
+const Type = 'ACCESS_TOKEN'
 
 module.exports = {
   Type,
   generateNewToken: async ({ email, accessToken: payload, pgdb }) => {
     if (!payload) {
-      console.error('Unable to generate a new token: Access token is missing.')
+      console.error('Unable to generate a new token: accessToken is missing.')
       throw new AccessTokenMissingError({ email })
     }
 

--- a/packages/auth/lib/challenges/AuthorizeTokenChallenge.js
+++ b/packages/auth/lib/challenges/AuthorizeTokenChallenge.js
@@ -1,0 +1,47 @@
+const { newAuthError } = require('../AuthError')
+
+const TokensExceededError = newAuthError('email-code-challenge-tokens-exceeded', 'api/auth/authorizeToken/tokensExceeded')
+
+const MAX_VALID_TOKENS = 5
+const TTL = 1000 * 60 * 10 // 10 minutes
+const Type = 'AUTHORIZE_TOKEN'
+
+module.exports = {
+  Type,
+  generateNewToken: async ({ email, accessToken, pgdb }) => {
+    const existingPayloads = (await pgdb.public.tokens.find(
+      {
+        type: Type,
+        email,
+        'expireAction !=': null,
+        'sessionId !=': null
+      }
+    ))
+      .map(token => token.payload)
+
+    if (existingPayloads.length >= MAX_VALID_TOKENS) {
+      console.error('Unable to generate a new token: Found too many valid tokens.')
+      throw new TokensExceededError({ email, MAX_VALID_TOKENS })
+    }
+
+    const expiresAt = new Date(new Date().getTime() + TTL)
+    return { payload: accessToken, expiresAt }
+  },
+  startChallenge: async () => {}, // accessToken is generated and validated elsewhere
+  validateChallenge: async ({ email, session, req, pgdb }, { payload }) => {
+    if (session.sid !== req.sessionID) {
+      console.warn('Faild validation, sessions did not match', { email })
+      return false
+    }
+
+    const token = await pgdb.public.tokens.findOne({
+      type: Type,
+      email,
+      payload,
+      sessionId: session.id,
+      'expiresAt >=': new Date()
+    })
+
+    return token && token.id
+  }
+}

--- a/packages/auth/lib/challenges/index.js
+++ b/packages/auth/lib/challenges/index.js
@@ -3,7 +3,7 @@ const EmailCodeChallenge = require('./EmailCodeChallenge')
 const TOTPChallenge = require('./TOTPChallenge')
 const SMSCodeChallenge = require('./SMSCodeChallenge')
 const AppChallenge = require('./AppChallenge')
-const AuthorizeTokenChallenge = require('./AuthorizeTokenChallenge')
+const AccessTokenChallenge = require('./AccessTokenChallenge')
 
 const { newAuthError } = require('../AuthError')
 
@@ -19,7 +19,7 @@ const TokenTypeMap = {
   [TOTPChallenge.Type]: TOTPChallenge,
   [SMSCodeChallenge.Type]: SMSCodeChallenge,
   [AppChallenge.Type]: AppChallenge,
-  [AuthorizeTokenChallenge.Type]: AuthorizeTokenChallenge
+  [AccessTokenChallenge.Type]: AccessTokenChallenge
 }
 
 const TokenTypes = Object

--- a/packages/auth/lib/challenges/index.js
+++ b/packages/auth/lib/challenges/index.js
@@ -3,6 +3,7 @@ const EmailCodeChallenge = require('./EmailCodeChallenge')
 const TOTPChallenge = require('./TOTPChallenge')
 const SMSCodeChallenge = require('./SMSCodeChallenge')
 const AppChallenge = require('./AppChallenge')
+const AuthorizeTokenChallenge = require('./AuthorizeTokenChallenge')
 
 const { newAuthError } = require('../AuthError')
 
@@ -17,7 +18,8 @@ const TokenTypeMap = {
   [EmailCodeChallenge.Type]: EmailCodeChallenge,
   [TOTPChallenge.Type]: TOTPChallenge,
   [SMSCodeChallenge.Type]: SMSCodeChallenge,
-  [AppChallenge.Type]: AppChallenge
+  [AppChallenge.Type]: AppChallenge,
+  [AuthorizeTokenChallenge.Type]: AuthorizeTokenChallenge
 }
 
 const TokenTypes = Object

--- a/packages/auth/migrations/sqls/20200415071450-token-type-authorize-down.sql
+++ b/packages/auth/migrations/sqls/20200415071450-token-type-authorize-down.sql
@@ -1,0 +1,10 @@
+ALTER DOMAIN token_type
+  DROP CONSTRAINT token_type_check
+;
+
+ALTER DOMAIN token_type
+  ADD CONSTRAINT token_type_check
+  CHECK(
+    VALUE IN ('EMAIL_TOKEN', 'EMAIL_CODE', 'TOTP', 'SMS', 'APP')
+  )
+;

--- a/packages/auth/migrations/sqls/20200415071450-token-type-authorize-up.sql
+++ b/packages/auth/migrations/sqls/20200415071450-token-type-authorize-up.sql
@@ -5,6 +5,6 @@ ALTER DOMAIN token_type
 ALTER DOMAIN token_type
   ADD CONSTRAINT token_type_check
   CHECK(
-    VALUE IN ('EMAIL_TOKEN', 'EMAIL_CODE', 'AUTHORIZE_TOKEN', 'TOTP', 'SMS', 'APP')
+    VALUE IN ('EMAIL_TOKEN', 'EMAIL_CODE', 'ACCESS_TOKEN', 'TOTP', 'SMS', 'APP')
   )
 ;

--- a/packages/auth/migrations/sqls/20200415071450-token-type-authorize-up.sql
+++ b/packages/auth/migrations/sqls/20200415071450-token-type-authorize-up.sql
@@ -1,0 +1,10 @@
+ALTER DOMAIN token_type
+  DROP CONSTRAINT token_type_check
+;
+
+ALTER DOMAIN token_type
+  ADD CONSTRAINT token_type_check
+  CHECK(
+    VALUE IN ('EMAIL_TOKEN', 'EMAIL_CODE', 'AUTHORIZE_TOKEN', 'TOTP', 'SMS', 'APP')
+  )
+;

--- a/packages/discussions/package.json
+++ b/packages/discussions/package.json
@@ -20,7 +20,7 @@
     "link": "yarn link"
   },
   "dependencies": {
-    "@project-r/styleguide": "^9.9.0",
+    "@project-r/styleguide": "^9.15.0",
     "dataloader": "^2.0.0"
   }
 }

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -20,7 +20,7 @@
     "link": "yarn link"
   },
   "dependencies": {
-    "@project-r/styleguide": "^9.9.0",
+    "@project-r/styleguide": "^9.15.0",
     "@project-r/template-newsletter": "^1.5.0",
     "apollo-modules-node": "^0.1.4",
     "check-env": "^1.3.0",

--- a/packages/migrations/migrations/20200415071450-token-type-authorize.js
+++ b/packages/migrations/migrations/20200415071450-token-type-authorize.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/auth/migrations/sqls'
+const file = '20200415071450-token-type-authorize'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1639,6 +1639,14 @@
       "value": "Kollision des zu generierenden Codes"
     },
     {
+      "key": "api/auth/authorizeToken/accessTokenMissing",
+      "value": "Access Token fehlt"
+    },
+    {
+      "key": "api/auth/authorizeToken/tokensExceeded",
+      "value": "Anzahl der gleichzeitig gültigen Tokens überschritten"
+    },
+    {
       "key": "api/commit/parentId/required",
       "value": "Please provide a parentId to commit to the existing repo \"{repoId}\"."
     },

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1499,6 +1499,10 @@
       "value": "Zu viele Anmeldeversuche. Probieren Sie es in {mins} Minuten erneut."
     },
     {
+      "key": "api/auth/errorAccessToken",
+      "value": "Access Token kann nicht verwendet werden"
+    },
+    {
       "key": "api/signin/mail/subject",
       "value": "Zugriff bestätigen: {phrase}"
     },

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1639,11 +1639,11 @@
       "value": "Kollision des zu generierenden Codes"
     },
     {
-      "key": "api/auth/authorizeToken/accessTokenMissing",
+      "key": "api/auth/accessToken/accessTokenMissing",
       "value": "Access Token fehlt"
     },
     {
-      "key": "api/auth/authorizeToken/tokensExceeded",
+      "key": "api/auth/accessToken/tokensExceeded",
       "value": "Anzahl der gleichzeitig gültigen Tokens überschritten"
     },
     {

--- a/servers/republik/package.json
+++ b/servers/republik/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "license": "AGPL-3.0",
   "dependencies": {
-    "@project-r/styleguide": "^9.9.0",
+    "@project-r/styleguide": "^9.15.0",
     "apollo-modules-node": "^0.1.4",
     "d3-array": "^2.4.0",
     "d3-dsv": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,10 +611,10 @@
     stringify-entities "^1.3.1"
     unified "^6.1.5"
 
-"@project-r/styleguide@^9.9.0":
-  version "9.14.2"
-  resolved "https://registry.yarnpkg.com/@project-r/styleguide/-/styleguide-9.14.2.tgz#600a83d01cb7c05060533a6cf62f64b9578f896f"
-  integrity sha512-3RwLFaBSjz84qcKCW0StDN37SZNWW06DgR/iBbpEObkOod7eBK98iGTX4ylu0tx+3/tAxeS9p/dSa2GthmNMrA==
+"@project-r/styleguide@^9.15.0":
+  version "9.15.0"
+  resolved "https://registry.yarnpkg.com/@project-r/styleguide/-/styleguide-9.15.0.tgz#78c63c6cc81e2bd7a17e5ec9accd028fed2b4617"
+  integrity sha512-KT4UgV6d4eLEeRZK6t5//s4T0mNAnhaTY+JCYAOeQiRTVWte1yhOvVRVo9wC1gjuaG1L7QiDa4R2WevEdIfL4g==
   dependencies:
     body-scroll-lock "2.6.4"
     react-icons "^2.2.7"


### PR DESCRIPTION
This Pull Request adds a new flow on how users can authorize a session.  It allows users to authorize with an access token, scoped to `AUTHORIZE_SESSION`.

**Access Token with `AUTHORIZE_SESSION` scope**

Access token can only be generated _by users_ with `admin` or `supporter` role via `AccessToken.issueForUser`, or _the system_ itself, for transactional emails via `AccessToken.generateForUser`.

This scoped access token …
- … is valid for 5 days
- … can be used 1 time as an "authorize" token

To enable us to generate more than a single token a day, it's hashed payload is fitted with an ISO 8601 timestamp down to milliseconds (instead of a date).

**Usage Flow**

1. Request `mutation { signIn(...) }` with email and access token.

A session is initialized, attempts to a) validated an access token and if that succeeds it attempts to b) create an authorize token in database. In case either of it fails, it will fallback to a specified or enabled token.

Check `SignInResponse.tokenType` which is set to `ACCESS_TOKEN` if attempt succeeded.

2. Request `mutation { authorizeSession(...) }` with token type `ACCESS_TOKEN` and used access token in payload.

**Development Checklist**
- [x] Restrict generation on GraphQL to admin users
- [x] Access Token via `toISOString()` instead per day
- [x] Limit authorization tokens usage

**Post-Deployment Checklist**
- [ ] Run migrations

**In Development**

1. Run migrations

```sh
yarn db:migrate:up
```

2. Generate an `AUTHORIZE_SESSION` access token. You need to be logged in already:

```gql
query generateAuthorizeSessionAccessToken {
  me {
    accessToken(scope:AUTHORIZE_SESSION)
  }
}
```

3. `signIn` to initiate session and generate token, later used to authorize:

```gql
mutation signIn(
  $email: String!
  $accessToken: ID
) {
  signIn(
    email: $email
    accessToken: $accessToken
  ) {
    phrase
    tokenType
    expiresAt
    alternativeFirstFactors
  }
}
```
```json
{
  "email": "inbox@domain.tld",
  "accessToken": "[ previously generated access token here ]"
}

```

4. `authorizeSession` to authorize a session with a token setup before

```gql
mutation authorizeSession(
  $email: String!
  $tokens: [SignInToken!]!
) {
  authorizeSession(
    email: $email
    tokens: $tokens
  )
}
```
```json
{
  "email": "inbox@domain.tld",
  "tokens": [
    {
      "type": "ACCESS_TOKEN",
      "payload": "[ previously generated access token here ]"
    }
  ]
}
```