### PR TITLE
Expand MailChimp Sync

### DIFF
--- a/packages/mail/lib/index.js
+++ b/packages/mail/lib/index.js
@@ -6,8 +6,15 @@ const handlers = {
   sendMail: require('./sendMail'),
   sendMailTemplate: require('./sendMailTemplate'),
   unsubscribeEmail: require('./unsubscribeEmail'),
+  updateMergeFields: require('./updateMergeFields'),
   updateNewsletterSubscription: require('./updateNewsletterSubscription'),
-  updateNewsletterSubscriptions: require('./updateNewsletterSubscriptions')
+  updateNewsletterSubscriptions: require('./updateNewsletterSubscriptions'),
+
+  // MailChimp batch operations types
+  operations: {
+    covidAccessToken: require('./operations/covidAccessTokens'),
+    nameAndEmailBase64u: require('./operations/nameAndEmailBase64u')
+  }
 }
 const { withConfiguration } = require('../NewsletterSubscription')
 const errors = require('../errors')

--- a/packages/mail/lib/operations/covidAccessTokens.js
+++ b/packages/mail/lib/operations/covidAccessTokens.js
@@ -1,0 +1,37 @@
+const Promise = require('bluebird')
+
+const { transformUser, AccessToken } = require('@orbiting/backend-modules-auth')
+const { encode } = require('@orbiting/backend-modules-base64u')
+
+module.exports = async ({ pgdb }) => {
+  const users = await pgdb.query(`
+    WITH "grantsAndRevokes" AS (
+      SELECT c."userId"
+      FROM "consents" c
+      WHERE c.policy = 'NEWSLETTER_COVID19'
+    )
+    
+    SELECT u.*, md5(lower(u.email)) "__subscriberHash", COUNT(*) % 2 > 0 "__subscribed"
+    FROM "grantsAndRevokes" gr
+    JOIN "users" u ON u.id = gr."userId"
+    WHERE u.verified = TRUE
+    GROUP BY u.id
+    ORDER BY RANDOM()
+  `)
+    .then(users => users.filter(u => !!u.__subscribed).map(transformUser))
+
+  const operations = await Promise.map(users, user => ({
+    subscriberHash: user._raw.__subscriberHash,
+    method: 'PATCH',
+    body: {
+      merge_fields: {
+        EMAILB64U: encode(user.email),
+        AS_ATOKEN: AccessToken.generateForUser(user, 'AUTHORIZE_SESSION')
+      }
+    }
+  }), { concurrency: 1 })
+
+  console.log(users.length, operations.length)
+
+  return operations
+}

--- a/packages/mail/lib/operations/nameAndEmailBase64u.js
+++ b/packages/mail/lib/operations/nameAndEmailBase64u.js
@@ -6,7 +6,7 @@ module.exports = async ({ pgdb }) => {
   const users = await pgdb.query(`
     SELECT u."firstName", u."lastName", md5(lower(u.email)) "__subscriberHash"
     FROM "users" u
-    WHERE u.verified = TRUE
+    WHERE u.verified = TRUE AND u."deletedAt" IS NULL
     ORDER BY RANDOM()
   `)
 
@@ -20,9 +20,7 @@ module.exports = async ({ pgdb }) => {
         EMAILB64U: encode(user.email)
       }
     }
-  }), { concurrency: 1 })
-
-  console.log(users.length, operations.length)
+  }))
 
   return operations
 }

--- a/packages/mail/lib/operations/nameAndEmailBase64u.js
+++ b/packages/mail/lib/operations/nameAndEmailBase64u.js
@@ -1,0 +1,28 @@
+const Promise = require('bluebird')
+
+const { encode } = require('@orbiting/backend-modules-base64u')
+
+module.exports = async ({ pgdb }) => {
+  const users = await pgdb.query(`
+    SELECT u."firstName", u."lastName", md5(lower(u.email)) "__subscriberHash"
+    FROM "users" u
+    WHERE u.verified = TRUE
+    ORDER BY RANDOM()
+  `)
+
+  const operations = await Promise.map(users, user => ({
+    subscriberHash: user.__subscriberHash,
+    method: 'PATCH',
+    body: {
+      merge_fields: {
+        FNAME: user.firstName || '',
+        LNAME: user.lastName || '',
+        EMAILB64U: encode(user.email)
+      }
+    }
+  }), { concurrency: 1 })
+
+  console.log(users.length, operations.length)
+
+  return operations
+}

--- a/packages/mail/lib/updateMergeFields.js
+++ b/packages/mail/lib/updateMergeFields.js
@@ -1,0 +1,16 @@
+const MailchimpInterface = require('../MailchimpInterface')
+const logger = console
+
+module.exports = async ({ user }) => {
+  const { email, firstName, lastName } = user
+
+  const body = {
+    merge_fields: {
+      FNAME: firstName || '',
+      LNAME: lastName || ''
+    }
+  }
+
+  const mailchimp = MailchimpInterface({ logger })
+  await mailchimp.updateMember(email, body)
+}

--- a/packages/mail/lib/updateNewsletterSubscription.js
+++ b/packages/mail/lib/updateNewsletterSubscription.js
@@ -40,6 +40,8 @@ module.exports = async ({
     // from mailchimp to re-subscribe.
     body.status = MailchimpInterface.MemberStatus.Pending
   }
+
   await mailchimp.updateMember(email, body)
+
   return NewsletterSubscription.buildSubscription(user.id, interestId, subscribed)
 }

--- a/packages/mail/lib/updateNewsletterSubscriptions.js
+++ b/packages/mail/lib/updateNewsletterSubscriptions.js
@@ -1,23 +1,26 @@
 const MailchimpInterface = require('../MailchimpInterface')
 const {
   SubscriptionHandlerMissingMailError
- } = require('../errors')
+} = require('../errors')
 const logger = console
 
-module.exports = async ({
-  user, interests
-}, NewsletterSubscription) => {
+module.exports = async ({ user, interests }, NewsletterSubscription) => {
   if (!NewsletterSubscription) throw new SubscriptionHandlerMissingMailError()
 
-  const { email, roles } = user
+  const { email, firstName, lastName, roles } = user
 
-  const mailchimp = MailchimpInterface({ logger })
-  const member = await mailchimp.getMember(email)
   const body = {
     email_address: email,
     status_if_new: MailchimpInterface.MemberStatus.Subscribed,
-    interests
+    interests,
+    merge_fields: {
+      FNAME: firstName || '',
+      LNAME: lastName || ''
+    }
   }
+
+  const mailchimp = MailchimpInterface({ logger })
+  const member = await mailchimp.getMember(email)
   if (member && member.status !== MailchimpInterface.MemberStatus.Unsubscribed) {
     // if a user is unsubscribed we don't update a status
     body.status = MailchimpInterface.MemberStatus.Subscribed

--- a/packages/mail/script/mailchimp/checkBatch.js
+++ b/packages/mail/script/mailchimp/checkBatch.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+require('@orbiting/backend-modules-env').config()
+
+/**
+ * Script to check status of a MailChimp batch with a batch ID.
+ *
+ * $ checkBatch.js --id {batch ID}
+ *
+ */
+const yargs = require('yargs')
+
+const MailchimpInterface = require('../../MailchimpInterface')
+
+const mailchimp = MailchimpInterface({ logger: console })
+
+const argv = yargs
+  .option('id', { required: true })
+  .argv
+
+mailchimp
+  .getBatch(argv.id)
+  .then(r => r.json())
+  .then(r => { console.log('status', r) })

--- a/packages/mail/script/mailchimp/runOperations.js
+++ b/packages/mail/script/mailchimp/runOperations.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+require('@orbiting/backend-modules-env').config()
+
+/**
+ * Script to run MailChimp batch operations (check lib/operations) and
+ * return batch status every {interval} until finished:
+ *
+ * $ runOperations.js --type {operations type} --interval 10
+ *
+ * Set no interval to skip batch status check:
+ *
+ * $ runOperations.js --type {operations type} --no-interval
+ *
+ */
+const Promise = require('bluebird')
+const yargs = require('yargs')
+
+const PgDb = require('@orbiting/backend-modules-base/lib/PgDb')
+
+const MailchimpInterface = require('../../MailchimpInterface')
+const { operations: operationsFns } = require('../../lib')
+
+const mailchimp = MailchimpInterface({ logger: console })
+
+const argv = yargs
+  .option('type', {
+    description: 'type of operations to run',
+    required: true,
+    choices: Object.keys(operationsFns)
+  })
+  .option('interval', {
+    description: 'status interval (in seconds)',
+    default: 4
+  })
+  .argv
+
+Promise.props({ pgdb: PgDb.connect() }).then(async connections => {
+  const context = { ...connections }
+
+  const operations = await operationsFns[argv.type](context)
+
+  if (!operations.length) {
+    console.warn(`type of operations "${argv.type}" yielded in no operations`)
+    return connections
+  }
+
+  await mailchimp
+    .postBatch(operations)
+    .then(r => r.json())
+    .then(async batch => {
+      const { id } = batch
+
+      if (argv.interval) {
+        let isRunning = false
+
+        do {
+          const {
+            status,
+            submitted_at: submittedAt,
+            total_operations: totalOperations,
+            finished_operations: finishedOperations
+          } = await mailchimp.getBatch(id).then(r => r.json())
+
+          console.log(
+            'status',
+            { batch: id, status, submittedAt, totalOperations, finishedOperations }
+          )
+
+          isRunning = status !== 'finished'
+
+          if (isRunning) {
+            await Promise.delay(1000 * argv.interval)
+          }
+        } while (isRunning)
+      } else { // if (argv.interval) {
+        const {
+          status,
+          submitted_at: submittedAt,
+          total_operations: totalOperations
+        } = batch
+
+        console.log(
+          'status',
+          { batch: id, status, submittedAt, totalOperations }
+        )
+      }
+    })
+
+  return connections
+})
+  .then(async connections => {
+    const { pgdb } = connections
+
+    await pgdb.close()
+  })
+  .catch(e => { console.error(e) })

--- a/servers/republik/graphql/resolvers/_mutations/updateMe.js
+++ b/servers/republik/graphql/resolvers/_mutations/updateMe.js
@@ -12,10 +12,12 @@ const {
   isInCandidacyInElectionPhase,
   hasCards
 } = require('../../../lib/profile')
-const { Redirections: {
-  upsert: upsertRedirection,
-  delete: deleteRedirection
-} } = require('@orbiting/backend-modules-redirections')
+const {
+  Redirections: {
+    upsert: upsertRedirection,
+    delete: deleteRedirection
+  }
+} = require('@orbiting/backend-modules-redirections')
 
 const { lib: { Portrait } } = require('@orbiting/backend-modules-assets')
 const { ensureStringLength } = require('@orbiting/backend-modules-utils')
@@ -50,7 +52,7 @@ const createEnsureStringLengthForProfile = (values, t) => (key, translationKey, 
   )
 
 module.exports = async (_, args, context) => {
-  const { pgdb, req, user: me, t } = context
+  const { pgdb, req, user: me, t, mail } = context
   ensureSignedIn(req)
 
   const {
@@ -249,7 +251,10 @@ module.exports = async (_, args, context) => {
     }
 
     await transaction.transactionCommit()
+
     const updatedUser = await pgdb.public.users.findOne({ id: me.id })
+    await mail.updateMergeFields({ user: updatedUser })
+
     return transformUser(updatedUser)
   } catch (e) {
     await transaction.transactionRollback()

--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/updateUser.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_mutations/updateUser.js
@@ -1,38 +1,40 @@
 const { Roles, transformUser } = require('@orbiting/backend-modules-auth')
 const logger = console
 
-module.exports = async (_, args, {pgdb, req, t}) => {
+module.exports = async (_, args, { pgdb, req, t, mail }) => {
   Roles.ensureUserHasRole(req.user, 'supporter')
 
-  const user = await pgdb.public.users.findOne({id: args.userId})
+  const user = await pgdb.public.users.findOne({ id: args.userId })
   if (!user) {
     logger.error('user not found', { req: req._log() })
     throw new Error(t('api/users/404'))
   }
 
-  const {firstName, lastName, birthday, address, phoneNumber} = args
+  const { firstName, lastName, birthday, address, phoneNumber } = args
   const transaction = await pgdb.transactionBegin()
   try {
     if (firstName || lastName || birthday || phoneNumber) {
-      await transaction.public.users.update({id: user.id}, {
+      await transaction.public.users.update({ id: user.id }, {
         firstName,
         lastName,
         birthday,
         phoneNumber
-      }, {skipUndefined: true})
+      }, { skipUndefined: true })
     }
     if (address) {
       if (user.addressId) { // update address of user
-        await transaction.public.addresses.update({id: user.addressId}, address)
+        await transaction.public.addresses.update({ id: user.addressId }, address)
       } else { // user has no address yet
         const userAddress = await transaction.public.addresses.insertAndGet(address)
-        await transaction.public.users.update({id: user.id}, {addressId: userAddress.id})
+        await transaction.public.users.update({ id: user.id }, { addressId: userAddress.id })
       }
     }
     await transaction.transactionCommit()
-    return transformUser(
-      await pgdb.public.users.findOne({id: user.id})
-    )
+
+    const updatedUser = await pgdb.public.users.findOne({ id: user.id })
+    await mail.updateMergeFields({ user: updatedUser })
+
+    return transformUser(updatedUser)
   } catch (e) {
     await transaction.transactionRollback()
     logger.error('error in transaction', { req: req._log(), args, error: e })

--- a/servers/republik/modules/crowdfundings/lib/Mail.js
+++ b/servers/republik/modules/crowdfundings/lib/Mail.js
@@ -122,8 +122,11 @@ mail.enforceSubscriptions = async ({
     pgdb
   })
 
-  const sanitizedUser = user || { email }
-  return mail.updateNewsletterSubscriptions({ user: sanitizedUser, interests, ...rest })
+  return mail.updateNewsletterSubscriptions({
+    user: user || { email },
+    interests,
+    ...rest
+  })
 }
 
 mail.sendMembershipProlongConfirmation = async ({


### PR DESCRIPTION
This Pull Requests updates first and last name merge fields (`FNAME`, `LNAME`) on MailChimp whenever there is a chance of a change, as well as email base64 url-safe encoded merge field (`EMAILBASE64U`).

It also helps updating MailChimp data in batches. You can run individual "operation types" with

```
$ packages/mail/script/mailchimp/runOperations.js --type nameAndEmailBase64u
```

Operation types can be extended in packages/mail/lib/operations and available thus far are:
- `covidAccessToken` to updated Authorize Session Access Tokens in lieu of COVID-19 newsletter
- `nameAndEmailBase64u` to updated name and email base64u fields

Batches can take several hours to complete. Run `runOperations.js --no-interval` to end script once batch is submitted and a batch can be checked manually:

```
$ packages/mail/script/mailchimp/checkBatch.js --id 123123123
```