### PR TITLE
feat(maillog): Add errornous record filter for mail log records

### DIFF
--- a/packages/maillog/graphql/resolvers/MailLogRecord.js
+++ b/packages/maillog/graphql/resolvers/MailLogRecord.js
@@ -2,21 +2,13 @@ const moment = require('moment')
 
 const { Roles } = require('@orbiting/backend-modules-auth')
 
+const { getTemplate, getSubject, getStatus, getError } = require('../../lib/record')
+
 module.exports = {
-  template: record => record.info && record.info.template,
-  subject: record => record.info && record.info.message && record.info.message.subject,
-  status: record =>
-    (record.mandrillLastEvent && record.mandrillLastEvent.msg.state) ||
-    (record.result && record.result.status) ||
-    record.status.toLowerCase(),
-  error: record =>
-    (record.mandrillLastEvent && record.mandrillLastEvent.msg && record.mandrillLastEvent.msg.diag) ||
-    (record.mandrillLastEvent && record.mandrillLastEvent.msg && record.mandrillLastEvent.msg.bounce_description) ||
-    (record.result && record.result.reject_reason) ||
-    (record.result && record.result.error) ||
-    (record.error && record.error.message) ||
-    (record.error && record.error.meta && record.error.meta.error && record.error.meta.error.type) ||
-    (record.error && record.error.meta && record.error.meta.response),
+  template: getTemplate,
+  subject: getSubject,
+  status: getStatus,
+  error: getError,
   user: async (record, args, { loaders }) => loaders.User.byIdOrEmail.load(record.userId || record.email),
   mandrill: (record, args, { user: me }) => {
     if (!Roles.userIsInRoles(me, ['admin', 'supporter'])) {

--- a/packages/maillog/graphql/resolvers/User.js
+++ b/packages/maillog/graphql/resolvers/User.js
@@ -1,5 +1,6 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
-const { paginate: { paginator } } = require('@orbiting/backend-modules-utils')
+
+const { paginate } = require('../../lib/paginate')
 
 module.exports = {
   async mailLog (user, args, { pgdb, user: me }) {
@@ -14,6 +15,6 @@ module.exports = {
       ]
     }, { orderBy: { createdAt: 'DESC' } })
 
-    return paginator({ first: 100, ...args }, a => a, () => records)
+    return paginate(records, args)
   }
 }

--- a/packages/maillog/graphql/resolvers/_queries/mailLog.js
+++ b/packages/maillog/graphql/resolvers/_queries/mailLog.js
@@ -1,5 +1,6 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
-const { paginate: { paginator } } = require('@orbiting/backend-modules-utils')
+
+const { paginate } = require('../../../lib/paginate')
 
 const MAX_RECORDS = 5000
 
@@ -8,5 +9,5 @@ module.exports = async (_, args, { pgdb, user: me }) => {
 
   const records = await pgdb.public.mailLog.findAll({ orderBy: { createdAt: 'DESC' }, limit: MAX_RECORDS })
 
-  return paginator({ first: 100, ...args }, a => a, () => records)
+  return paginate(records, args)
 }

--- a/packages/maillog/graphql/schema-types.js
+++ b/packages/maillog/graphql/schema-types.js
@@ -1,7 +1,7 @@
 module.exports = `
 
 input MaiLogFiltersInput {
-  errornous: Boolean
+  hasError: Boolean
 }
 
 type MailLogConnection {

--- a/packages/maillog/graphql/schema-types.js
+++ b/packages/maillog/graphql/schema-types.js
@@ -1,5 +1,9 @@
 module.exports = `
 
+input MaiLogFiltersInput {
+  errornous: Boolean
+}
+
 type MailLogConnection {
   totalCount: Int!
   pageInfo: MailLogPageInfo!
@@ -38,6 +42,7 @@ extend type User {
     last: Int
     before: String
     after: String
+    filters: MaiLogFiltersInput
   ): MailLogConnection
 }
 

--- a/packages/maillog/graphql/schema.js
+++ b/packages/maillog/graphql/schema.js
@@ -10,6 +10,7 @@ type queries {
     last: Int
     before: String
     after: String
+    filters: MaiLogFiltersInput
   ): MailLogConnection
 }
 

--- a/packages/maillog/lib/paginate.js
+++ b/packages/maillog/lib/paginate.js
@@ -20,7 +20,11 @@ const paginate = (records, args) => paginator(
   ({ filters = {} }) => {
     const filterFns = getFilterFns(filters)
 
-    return records.filter(record => filterFns.every(filterFn => filterFn(record)))
+    if (filterFns.length) {
+      return records.filter(record => filterFns.every(filterFn => filterFn(record)))
+    }
+
+    return records
   }
 )
 

--- a/packages/maillog/lib/paginate.js
+++ b/packages/maillog/lib/paginate.js
@@ -2,12 +2,12 @@ const { paginate: { paginator } } = require('@orbiting/backend-modules-utils')
 
 const { getError } = require('./record')
 
-const getFilterFns = ({ errornous }) => {
+const getFilterFns = ({ hasError }) => {
   const stack = []
 
-  if (errornous === true) {
+  if (hasError === true) {
     stack.push(record => !!getError(record))
-  } else if (errornous === false) {
+  } else if (hasError === false) {
     stack.push(record => !getError(record))
   }
 

--- a/packages/maillog/lib/paginate.js
+++ b/packages/maillog/lib/paginate.js
@@ -1,0 +1,29 @@
+const { paginate: { paginator } } = require('@orbiting/backend-modules-utils')
+
+const { getError } = require('./record')
+
+const getFilterFns = ({ errornous }) => {
+  const stack = []
+
+  if (errornous === true) {
+    stack.push(record => !!getError(record))
+  } else if (errornous === false) {
+    stack.push(record => !getError(record))
+  }
+
+  return stack
+}
+
+const paginate = (records, args) => paginator(
+  { first: 100, ...args },
+  a => a,
+  ({ filters = {} }) => {
+    const filterFns = getFilterFns(filters)
+
+    return records.filter(record => filterFns.every(filterFn => filterFn(record)))
+  }
+)
+
+module.exports = {
+  paginate
+}

--- a/packages/maillog/lib/record.js
+++ b/packages/maillog/lib/record.js
@@ -1,0 +1,24 @@
+const getTemplate = record => record.info && record.info.template
+
+const getSubject = record => record.info && record.info.message && record.info.message.subject
+
+const getStatus = record =>
+  (record.mandrillLastEvent && record.mandrillLastEvent.msg.state) ||
+  (record.result && record.result.status) ||
+  record.status.toLowerCase()
+
+const getError = record =>
+  (record.mandrillLastEvent && record.mandrillLastEvent.msg && record.mandrillLastEvent.msg.diag) ||
+  (record.mandrillLastEvent && record.mandrillLastEvent.msg && record.mandrillLastEvent.msg.bounce_description) ||
+  (record.result && record.result.reject_reason) ||
+  (record.result && record.result.error) ||
+  (record.error && record.error.message) ||
+  (record.error && record.error.meta && record.error.meta.error && record.error.meta.error.type) ||
+  (record.error && record.error.meta && record.error.meta.response)
+
+module.exports = {
+  getTemplate,
+  getSubject,
+  getStatus,
+  getError
+}


### PR DESCRIPTION
This Pull Request adds `filters: { errornous: TRUE|FALSE }` to mail log queries.

```gql
{
  mailLog(filters: {errornous: true}) {
    totalCount
    nodes {
      email
      error
    }
  }
  me {
    mailLog(filters: {errornous: false}) {
      totalCount
      nodes {
        error
      }
    }
  }
}
```

Code is slightly refactored and extended, moving pagination (including filtering) into a lib-file as well as record props conditionals (error, status, template).