### PR TITLE
handle unpublished notification objects

### DIFF
--- a/packages/subscriptions/graphql/schema-types.js
+++ b/packages/subscriptions/graphql/schema-types.js
@@ -121,9 +121,7 @@ type Notification {
 
 type NotificationContent {
   title: String!
-  body: String!
   url: String!
-  icon: String
 }
 
 type WebNotification {

--- a/packages/subscriptions/graphql/schema-types.js
+++ b/packages/subscriptions/graphql/schema-types.js
@@ -75,7 +75,7 @@ extend type Discussion {
 
 type Subscription {
   id: ID!
-  object: SubscriptionObject!
+  object: SubscriptionObject
   subject: User!
   filters: [EventObjectType!]
   active: Boolean!


### PR DESCRIPTION
- fix: allow empty Subscription.object (unpublished)
- fix: hide notificationContent.body and url
- cleanup discussion notifications

The majority of changed lines are attributed to the last point.