### PR TITLE
feat(republik): Extend MembershipStats.evolution

### DIFF
--- a/servers/republik/graphql/schema-types.js
+++ b/servers/republik/graphql/schema-types.js
@@ -256,12 +256,22 @@ type MembershipStatsEvolutionBucket {
 
   "Amount of memberships ending during month"
   ending: Int!
-  "Amount of memberships ending during month but still prolongable"
-  prolongable: Int!
-  "Amount of memberships ended during month due to expiration"
+
+  "Amount of memberships which ended as of now"
+  ended: Int!
+  "Amount of memberships which expired as of now"
   expired: Int!
-  "Amount of memberships ended during month due to cancellation"
+  "Amount of memberships which ended and were cancelled as of now"
   cancelled: Int!
+  "Amount of memberships which are active (periods)"
+  active: Int!
+
+  "Amount of memberships ended during month"
+  endedEndOfMonth: Int!
+  "Amount of memberships ended during month due to expiration"
+  expiredEndOfMonth: Int!
+  "Amount of memberships ended during month due to cancellation"
+  cancelledEndOfMonth: Int!
 
   "Amount of active memberships at end of month"
   activeEndOfMonth: Int!
@@ -270,6 +280,8 @@ type MembershipStatsEvolutionBucket {
   "Amount of active memberships at end of month without a donation"
   activeEndOfMonthWithoutDonation: Int!
 
+  "Amount of memberships ending during month but still prolongable"
+  prolongable: Int!
   "Amount of all memberships pending at end of month (ending but still prolongable)"
   pending: Int!
   "Amount of all subscriptions (e.g. MONTHLY_ABO) pending at end of month (ending but still prolongable)"

--- a/servers/republik/graphql/schema-types.js
+++ b/servers/republik/graphql/schema-types.js
@@ -265,6 +265,8 @@ type MembershipStatsEvolutionBucket {
   cancelled: Int!
   "Amount of memberships which are active (periods)"
   active: Int!
+  "Amount of memberships which are overdue"
+  overdue: Int!
 
   "Amount of memberships ended during month"
   endedEndOfMonth: Int!

--- a/servers/republik/lib/MembershipStats/evolution.js
+++ b/servers/republik/lib/MembershipStats/evolution.js
@@ -78,27 +78,48 @@ SELECT
 
   ) "ending",
 
+  -- Data up until now
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "first"
+    AND "maxEndDate" <= LEAST(NOW(), "last")
+  ) "ended",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "first"
+    AND "maxEndDate" <= LEAST(NOW(), "last")
+    AND renew = TRUE
+  ) "expired",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "first"
+    AND "maxEndDate" <= LEAST(NOW(), "last")
+    AND renew = FALSE
+  ) "cancelled",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= LEAST(NOW(), "last")
+    AND "minBeginDate" < LEAST(NOW(), "last")
+  ) "active",
+
+  -- Data to end of month
+
   COUNT(*) FILTER (
     WHERE "maxEndDate" >= "first"
     AND "maxEndDate" <= "last"
-    AND (
-      active = TRUE
-      AND renew = TRUE
-    )
-  ) "prolongable",
+  ) "endedEndOfMonth",
 
   COUNT(*) FILTER (
     WHERE "maxEndDate" >= "first"
     AND "maxEndDate" <= "last"
     AND renew = TRUE
-    AND active = FALSE
-  ) "expired",
+  ) "expiredEndOfMonth",
 
   COUNT(*) FILTER (
     WHERE "maxEndDate" >= "first"
     AND "maxEndDate" <= "last"
     AND renew = FALSE
-  ) "cancelled",
+  ) "cancelledEndOfMonth",
 
   COUNT(*) FILTER (
     WHERE "maxEndDate" >= "last"
@@ -117,22 +138,27 @@ SELECT
     AND "membershipDonation"."membershipId" IS NULL
   ) "activeEndOfMonthWithoutDonation",
 
+  -- Data based on membership active state
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= "first"
+    AND "maxEndDate" <= "last"
+    AND active = TRUE
+    AND renew = TRUE
+  ) "prolongable",
+
   COUNT(*) FILTER (
     WHERE "maxEndDate" >= :min::timestamp
     AND "maxEndDate" <= "last"
-    AND (
-      active = TRUE
-      AND renew = TRUE
-    )
+    AND active = TRUE
+    AND renew = TRUE
   ) "pending",
 
   COUNT(*) FILTER (
     WHERE "maxEndDate" >= :min::timestamp
     AND "maxEndDate" <= "last"
-    AND (
-      active = TRUE
-      AND renew = TRUE
-    )
+    AND active = TRUE
+    AND renew = TRUE
     AND "membershipTypeName" IN ('MONTHLY_ABO')
   ) "pendingSubscriptionsOnly"
 
@@ -155,7 +181,7 @@ const createCache = (context) => create(
   context
 )
 
-const populate = async (context) => {
+const populate = async (context, resultFn) => {
   debug('populate')
 
   const { pgdb } = context
@@ -174,6 +200,10 @@ const populate = async (context) => {
 
   // Generate date for range
   const result = await pgdb.query(query, { min, max, TZ: process.env.TZ || 'Europe/Zurich' })
+
+  if (resultFn) {
+    return resultFn(result)
+  }
 
   // Cache said data.
   await createCache(context).set({ result, updatedAt: new Date() })

--- a/servers/republik/lib/MembershipStats/evolution.js
+++ b/servers/republik/lib/MembershipStats/evolution.js
@@ -83,17 +83,20 @@ SELECT
   COUNT(*) FILTER (
     WHERE "maxEndDate" >= "first"
     AND "maxEndDate" <= LEAST(NOW(), "last")
+    AND active = FALSE
   ) "ended",
 
   COUNT(*) FILTER (
     WHERE "maxEndDate" >= "first"
     AND "maxEndDate" <= LEAST(NOW(), "last")
+    AND active = FALSE
     AND renew = TRUE
   ) "expired",
 
   COUNT(*) FILTER (
     WHERE "maxEndDate" >= "first"
     AND "maxEndDate" <= LEAST(NOW(), "last")
+    AND active = FALSE
     AND renew = FALSE
   ) "cancelled",
 
@@ -101,6 +104,13 @@ SELECT
     WHERE "maxEndDate" >= LEAST(NOW(), "last")
     AND "minBeginDate" < LEAST(NOW(), "last")
   ) "active",
+
+  COUNT(*) FILTER (
+    WHERE "maxEndDate" >= :min::timestamp
+    AND "maxEndDate" <= LEAST(NOW(), "last")
+    AND active = TRUE
+    AND renew = TRUE
+  ) "overdue",
 
   -- Data to end of month
 

--- a/servers/republik/script/MembershipStats/evolution/evaluate.js
+++ b/servers/republik/script/MembershipStats/evolution/evaluate.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * Script will evaluate data for MembershipStats.evolution and print result.
+ *
+ * No options or arguments available.
+ */
+require('@orbiting/backend-modules-env').config()
+const { lib: { ConnectionContext } } = require('@orbiting/backend-modules-base')
+
+const { populate } = require('../../../lib/MembershipStats/evolution')
+
+const applicationName = 'backends republik script MembershipStats evolution evaluate'
+
+ConnectionContext.create(applicationName).then(async context => {
+  console.log('Begin...')
+  await populate(
+    context,
+    result => console.log(result)
+  )
+  console.log('Done.')
+
+  return context
+})
+  .then(context => ConnectionContext.close(context))


### PR DESCRIPTION
* ended, expired, cancelled, active returning up-to-now in current month,
end of month of past months
* endedEndOfMonth, expiredEndOfMonth, cancelledEndOfMonth returning presumable state at end of month

Also add script to evaluate data without popuplating cache