### PR TITLE
Engagement Metrics w/ Scheduler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,6 +231,7 @@ GITHUB_INSTALLATION_ID=
 # enable schedulers:
 #PUBLICATION_SCHEDULER=true
 #ACCESS_SCHEDULER=true
+#REPUBLIK_SCHEDULER=true
 #MEMBERSHIP_SCHEDULER=true
 
 # Disable User related cache

--- a/servers/republik/graphql/resolvers/MembershipStats/countRange.js
+++ b/servers/republik/graphql/resolvers/MembershipStats/countRange.js
@@ -1,7 +1,7 @@
 const moment = require('moment')
 
 const createCache = require('../../../modules/crowdfundings/lib/cache')
-const QUERY_CACHE_TTL_SECONDS = 60 * 5 // 5 min
+const QUERY_CACHE_TTL_SECONDS = 60 * 60 * 24 // 24 hours
 
 const getCount = (min, max, pgdb) => () => pgdb.queryOneField(`
   SELECT

--- a/servers/republik/graphql/resolvers/RevenueStats/surplus.js
+++ b/servers/republik/graphql/resolvers/RevenueStats/surplus.js
@@ -3,7 +3,7 @@ const debug = require('debug')('republik:resolvers:RevenueStats:surplus')
 const Promise = require('bluebird')
 
 const createCache = require('../../../modules/crowdfundings/lib/cache')
-const QUERY_CACHE_TTL_SECONDS = 60 * 5 // 5 min
+const QUERY_CACHE_TTL_SECONDS = 60 * 60 * 24 // 24 hours
 
 const query = `
 WITH "totals" AS (

--- a/servers/republik/lib/scheduler.js
+++ b/servers/republik/lib/scheduler.js
@@ -1,0 +1,68 @@
+const debug = require('debug')('republik:lib:scheduler')
+const Promise = require('bluebird')
+
+const { intervalScheduler } = require('@orbiting/backend-modules-schedulers')
+
+const { stats: { evolution: { populate: poplateCollectionsStatsEvolution } } } = require('@orbiting/backend-modules-collections')
+const { stats: { evolution: { populate: populateDiscussionsStatsEvolution } } } = require('@orbiting/backend-modules-discussions')
+
+const { populate: populateMembershipStatsEvolution } = require('./MembershipStats/evolution')
+const { populate: populateMembershipStatsLastSeen } = require('./MembershipStats/lastSeen')
+
+const countRange = require('../graphql/resolvers/MembershipStats/countRange')
+const surplus = require('../graphql/resolvers/RevenueStats/surplus')
+
+const DEFAULT_LOCK_TTL_SECS = 60 * 10 // 10 minutes
+
+const init = async (context) => {
+  debug('init')
+
+  const schedulers = [
+    await intervalScheduler.init({
+      name: 'republik-scheduler-cache-collection-stats',
+      context,
+      runFunc: (args, context) => poplateCollectionsStatsEvolution(context),
+      lockTtlSecs: DEFAULT_LOCK_TTL_SECS,
+      runIntervalSecs: 60 * 60 * 8 // each 8 hours
+    }),
+    await intervalScheduler.init({
+      name: 'republik-scheduler-cache-discussion-stats',
+      context,
+      runFunc: (args, context) => populateDiscussionsStatsEvolution(context),
+      lockTtlSecs: DEFAULT_LOCK_TTL_SECS,
+      runIntervalSecs: 60 * 60 * 8 // each 8 hours
+    }),
+    await intervalScheduler.init({
+      name: 'republik-scheduler-cache-membership-stats',
+      context,
+      runFunc: (args, context) => Promise.all([
+        populateMembershipStatsEvolution(context),
+        populateMembershipStatsLastSeen(context)
+      ]),
+      lockTtlSecs: DEFAULT_LOCK_TTL_SECS,
+      runIntervalSecs: 60 * 60 // each hour
+    }),
+    await intervalScheduler.init({
+      name: 'republik-scheduler-cache-misc',
+      context,
+      runFunc: (args, context) => Promise.all([
+        countRange(null, { min: '2020-02-29T23:00:00Z', max: '2020-03-31T23:00:00Z', forceRecache: true }, context),
+        surplus(null, { min: '2019-12-01', forceRecache: true }, context)
+      ]),
+      lockTtlSecs: 10,
+      runIntervalSecs: 60
+    })
+  ]
+
+  const close = async () => {
+    await Promise.each(schedulers, scheduler => scheduler.close())
+  }
+
+  return {
+    close
+  }
+}
+
+module.exports = {
+  init
+}

--- a/servers/republik/modules/crowdfundings/lib/scheduler/index.js
+++ b/servers/republik/modules/crowdfundings/lib/scheduler/index.js
@@ -15,17 +15,13 @@ const { run: membershipsOwnersHandler } = require('./owners')
 const { deactivate } = require('./deactivate')
 const { changeover } = require('./changeover')
 
-const surplus = require('../../../../graphql/resolvers/RevenueStats/surplus')
-const { populate: populateMembershipStatsEvolution } = require('../../../../lib/MembershipStats/evolution')
-const countRange = require('../../../../graphql/resolvers/MembershipStats/countRange')
-
 const init = async (context) => {
   debug('init')
 
   const schedulers = []
 
   schedulers.push(
-    timeScheduler.init({
+    await timeScheduler.init({
       name: 'memberships-givers',
       context,
       runFunc: informGivers,
@@ -36,7 +32,7 @@ const init = async (context) => {
   )
 
   schedulers.push(
-    intervalScheduler.init({
+    await intervalScheduler.init({
       name: 'memberships-owners',
       context,
       runFunc: membershipsOwnersHandler,
@@ -46,7 +42,7 @@ const init = async (context) => {
   )
 
   schedulers.push(
-    timeScheduler.init({
+    await timeScheduler.init({
       name: 'winback',
       context,
       runFunc: informCancellers,
@@ -58,7 +54,7 @@ const init = async (context) => {
   )
 
   schedulers.push(
-    intervalScheduler.init({
+    await intervalScheduler.init({
       name: 'changeover-deactivate',
       context,
       runFunc: async (args, context) => {
@@ -67,21 +63,6 @@ const init = async (context) => {
       },
       lockTtlSecs,
       runIntervalSecs: 60 * 10
-    })
-  )
-
-  schedulers.push(
-    intervalScheduler.init({
-      name: 'stats-cache',
-      context,
-      runFunc: (args, context) =>
-        Promise.all([
-          surplus(null, { min: '2019-12-01', forceRecache: true }, context),
-          populateMembershipStatsEvolution(context),
-          countRange(null, { min: '2020-02-29T23:00:00Z', max: '2020-03-31T23:00:00Z', forceRecache: true }, context)
-        ]),
-      lockTtlSecs: 10,
-      runIntervalSecs: 60
     })
   )
 

--- a/servers/republik/server.js
+++ b/servers/republik/server.js
@@ -37,6 +37,7 @@ const loaderBuilders = {
 
 const { AccessScheduler, graphql: access } = require('@orbiting/backend-modules-access')
 
+const RepublikScheduler = require('.//lib/scheduler')
 const MembershipScheduler = require('./modules/crowdfundings/lib/scheduler')
 const mail = require('./modules/crowdfundings/lib/Mail')
 
@@ -46,6 +47,7 @@ const {
   SEARCH_PG_LISTENER,
   NODE_ENV,
   ACCESS_SCHEDULER,
+  REPUBLIK_SCHEDULER,
   MEMBERSHIP_SCHEDULER,
   SERVER = 'republik',
   DYNO
@@ -203,6 +205,15 @@ const runOnce = async (...args) => {
     accessScheduler = await AccessScheduler.init(context)
   }
 
+  let republikScheduler
+  if (REPUBLIK_SCHEDULER === 'false' || (DEV && REPUBLIK_SCHEDULER !== 'true')) {
+    console.log('REPUBLIK_SCHEDULER prevented scheduler from begin started',
+      { MEMBERSHIP_SCHEDULER, DEV }
+    )
+  } else {
+    republikScheduler = await RepublikScheduler.init(context)
+  }
+
   let membershipScheduler
   if (MEMBERSHIP_SCHEDULER === 'false' || (DEV && MEMBERSHIP_SCHEDULER !== 'true')) {
     console.log('MEMBERSHIP_SCHEDULER prevented scheduler from begin started',
@@ -217,6 +228,7 @@ const runOnce = async (...args) => {
       slackGreeter && slackGreeter.close(),
       searchNotifyListener && searchNotifyListener.close(),
       accessScheduler && accessScheduler.close(),
+      republikScheduler && republikScheduler.close(),
       membershipScheduler && membershipScheduler.close()
     ].filter(Boolean))
     await ConnectionContext.close(context)


### PR DESCRIPTION
This Pull Request is updating data for engagement metrics with a scheduler. It is a variation on https://github.com/orbiting/backends/pull/433.

While developing, I ran into a pickle, wondering if updating pre-populated data via a cronjob is a better, leaner solution:

- Updating engagement data is not required within minutes
- Scheduler consumes credits (memory, CPU) on each instance