### PR TITLE
fix(publikator): Split content into multiple strings and query them

### DIFF
--- a/servers/publikator/lib/cache/search.js
+++ b/servers/publikator/lib/cache/search.js
@@ -52,6 +52,7 @@ const getSourceFilter = () => ({
     excludes: [
       'contentMeta',
       'contentString',
+      'contentStrings',
       'createdAt',
       'name',
       'updatedAt'
@@ -79,13 +80,19 @@ const find = async (args, { elastic }) => {
     'contentMeta.seriesMaster.episodes.label',
     'contentMeta.seriesMaster.episodes.title',
     'contentMeta.seriesMaster.title',
+    'contentMeta.shortTitle',
     'contentMeta.slug',
     'contentMeta.subject',
     'contentMeta.template',
-    'contentMeta.title^2',
+    'contentMeta.title',
     'contentMeta.twitterDescription',
     'contentMeta.twitterTitle',
     'contentString',
+    'contentStrings.credits',
+    'contentStrings.lead',
+    'contentStrings.subject',
+    'contentStrings.text',
+    'contentStrings.title',
     'name'
   ]
 

--- a/servers/publikator/lib/cache/upsert.js
+++ b/servers/publikator/lib/cache/upsert.js
@@ -1,6 +1,9 @@
 const debug = require('debug')('publikator:cache:upsert')
 
-const utils = require('@orbiting/backend-modules-search/lib/utils')
+const visit = require('unist-util-visit')
+
+const { getIndexAlias, mdastContentToString } = require('@orbiting/backend-modules-search/lib/utils')
+const { mdastToString } = require('@orbiting/backend-modules-utils')
 
 /**
  * Builds ElasticSearch routing object, to find documents in an {index} of a
@@ -10,19 +13,68 @@ const utils = require('@orbiting/backend-modules-search/lib/utils')
  * @return {Object}    Routing object to pass ElacsticSearch client
  */
 const getPath = (id) => ({
-  index: utils.getIndexAlias('repo', 'write'),
+  index: getIndexAlias('repo', 'write'),
   type: 'Repo',
   id
 })
 
+/**
+ * Get stringified version of mdast object.
+ *
+ * @deprecated Use getContentStrings instead.
+ *
+ * @param {Object} mdast A MDAST object
+ * @return {(Object|null)} Returns { contentString } or null
+ */
 const getContentString = (mdast) => {
-  const contentString = mdast && utils.mdastContentToString(mdast)
+  const contentString = mdast && mdastContentToString(mdast)
 
   if (!contentString) {
     return
   }
 
   return { contentString }
+}
+
+const getContentStrings = (mdast) => {
+  const contentStrings = {}
+
+  const text = mdast && mdastContentToString(mdast)
+  if (text) {
+    contentStrings.text = text
+  }
+
+  visit(mdast, 'zone', node => {
+    if (node.identifier === 'TITLE') {
+      const title = mdastToString({
+        children: node.children.filter(n => n.type === 'heading' && n.depth === 1)
+      }).trim()
+
+      const subject = mdastToString({
+        children: node.children.filter(n => n.type === 'heading' && n.depth === 2)
+      }).trim()
+
+      const lead = mdastToString({
+        children: [node.children.filter(n => n.type === 'paragraph')[0]]
+      }).trim()
+
+      const credits = mdastToString({
+        children: [node.children.filter(n => n.type === 'paragraph')[1]]
+      }).trim()
+
+      Object.assign(
+        contentStrings,
+        {
+          title,
+          subject,
+          lead,
+          credits
+        }
+      )
+    }
+  })
+
+  return { contentStrings }
 }
 
 const getContentMeta = ({ meta = false } = {}) => {
@@ -155,6 +207,7 @@ const upsert = async ({
     updatedAt,
     isArchived,
     ...getContentString(content),
+    ...getContentStrings(content),
     ...getContentMeta(content),
     ...getLatestCommit(commit),
     ...getLatestPublications(publications),


### PR DESCRIPTION
`doc.content` (Markdown MDAST) is split into title, subject, lead, credits and text.

`mdastContentToString` began excluding TITLE identifiers in ab4d1d5 and thus removed e. g. credit line from stringified content and started hindered searching for terms in credit line.

Also search in `shortTitle` and remove weighting on `contentMeta.title`.