### PR TITLE
feat(publikator): Configure MailChimp campaign segment, envelope via configs ENV var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,6 +132,7 @@ DEFAULT_MAIL_FROM_NAME="Republik"
 #  - republik to set interests based on belongings of a user
 #MAILCHIMP_URL=https://us9.api.mailchimp.com
 #MAILCHIMP_API_KEY=
+#MAILCHIMP_CAMPAIGN_CONFIGS='[{"key":"org/some-format","from_name":"Republik"}]'
 
 #############
 # assets

--- a/.env.example
+++ b/.env.example
@@ -132,7 +132,6 @@ DEFAULT_MAIL_FROM_NAME="Republik"
 #  - republik to set interests based on belongings of a user
 #MAILCHIMP_URL=https://us9.api.mailchimp.com
 #MAILCHIMP_API_KEY=
-#MAILCHIMP_CAMPAIGN_CONFIGS='[{"key":"org/some-format","from_name":"Republik"}]'
 
 #############
 # assets

--- a/app.json
+++ b/app.json
@@ -70,9 +70,6 @@
     },
     "LOGDNA_KEY": "",
     "MAILCHIMP_API_KEY": "",
-    "MAILCHIMP_FROM_NAME": {
-      "required": true
-    },
     "MAILCHIMP_INTEREST_MEMBER": {
       "required": true
     },
@@ -92,9 +89,6 @@
       "required": true
     },
     "MAILCHIMP_MAIN_LIST_ID": {
-      "required": true
-    },
-    "MAILCHIMP_REPLY_TO": {
       "required": true
     },
     "MAILCHIMP_URL": {

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-03-23T20:34:06.306Z",
+  "updated": "2020-05-24T13:10:16.770Z",
   "title": "live",
   "data": [
     {
@@ -1693,6 +1693,18 @@
     {
       "key": "api/publish/disabled",
       "value": "Artikel können im Moment weder veröffentlicht noch zurückgezogen werden. Bitte versuche es in ein paar Minuten noch einmal, ansonsten kontaktiere bitte die IT."
+    },
+    {
+      "key": "api/publish/error/createCampaign",
+      "value": "Kampagne auf MailChimp konnte nicht angelegt werden."
+    },
+    {
+      "key": "api/publish/error/updateCampaign",
+      "value": "Kampagne auf MailChimp konnte nicht aktualisiert werden."
+    },
+    {
+      "key": "api/publish/error/updateCampaignContent",
+      "value": "Kampagne auf MailChimp konnte nicht aktualisiert werden."
     },
     {
       "key": "api/archive/error/published",

--- a/servers/publikator/.env.example
+++ b/servers/publikator/.env.example
@@ -6,7 +6,19 @@ CORS_WHITELIST_URL=http://localhost:3005
 # analytics with apollo's engine
 #ENGINE_API_KEY=
 
-# default settings for mailchimp campaign creation
+# MAILCHIMP_CAMPAIGN_CONFIGS is a way to default MailChimp settings when pushed
+# to MailChimp like a segment or sender address.
+#
+# It is expected to be Array<Object> and each Object may contain:
+#
+# {
+#   "key": "<Repo ID to a format>",
+#   "from_name": "Republik",
+#   "reply_to": "<Sender email address>",
+#   "list_id": "<MailChimp List ID>",
+#   "saved_segment_id": <MailChimp Segment ID in List ID>
+# }
+#
 #MAILCHIMP_CAMPAIGN_CONFIGS='[{"key":"org/some-format","from_name":"Republik"}]'
 
 # filter repos by their names

--- a/servers/publikator/.env.example
+++ b/servers/publikator/.env.example
@@ -7,8 +7,7 @@ CORS_WHITELIST_URL=http://localhost:3005
 #ENGINE_API_KEY=
 
 # default settings for mailchimp campaign creation
-MAILCHIMP_FROM_NAME=Republik
-MAILCHIMP_REPLY_TO=kontakt@republik.ch
+#MAILCHIMP_CAMPAIGN_CONFIGS='[{"key":"org/some-format","from_name":"Republik"}]'
 
 # filter repos by their names
 #REPOS_NAME_FILTER=newsletter-,article-

--- a/servers/publikator/lib/mailchimp/createCampaign.js
+++ b/servers/publikator/lib/mailchimp/createCampaign.js
@@ -1,27 +1,18 @@
 const fetch = require('isomorphic-unfetch')
 
-const {
-  MAILCHIMP_URL,
-  MAILCHIMP_API_KEY,
-  MAILCHIMP_FROM_NAME,
-  MAILCHIMP_REPLY_TO
-} = process.env
+const { MAILCHIMP_URL, MAILCHIMP_API_KEY } = process.env
 
-module.exports = async ({ title, subject }) => {
+module.exports = async () => {
   return fetch(`${MAILCHIMP_URL}/campaigns`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Basic ${Buffer.from('anystring:' + MAILCHIMP_API_KEY).toString('base64')}`
+      Authorization: `Basic ${Buffer.from('anystring:' + MAILCHIMP_API_KEY).toString('base64')}`
     },
     body: JSON.stringify({
       type: 'regular',
       settings: {
-        title,
-        subject_line: subject,
-        content_type: 'html',
-        from_name: MAILCHIMP_FROM_NAME,
-        reply_to: MAILCHIMP_REPLY_TO
+        content_type: 'html'
       },
       tracking: {
         opens: false,
@@ -30,6 +21,10 @@ module.exports = async ({ title, subject }) => {
       }
     })
   })
-    .then(response => response.json())
-    .catch(error => console.error('updateMailchimp failed', { error }))
+    .then(response => {
+      if (!response.ok) {
+        throw Error(response.statusText)
+      }
+      return response
+    })
 }

--- a/servers/publikator/lib/mailchimp/index.js
+++ b/servers/publikator/lib/mailchimp/index.js
@@ -1,9 +1,11 @@
 const createCampaign = require('./createCampaign')
+const updateCampaign = require('./updateCampaign')
 const updateCampaignContent = require('./updateCampaignContent')
 const getCampaign = require('./getCampaign')
 
 module.exports = {
   createCampaign,
+  updateCampaign,
   updateCampaignContent,
   getCampaign
 }

--- a/servers/publikator/lib/mailchimp/updateCampaign.js
+++ b/servers/publikator/lib/mailchimp/updateCampaign.js
@@ -1,0 +1,54 @@
+const fetch = require('isomorphic-unfetch')
+const debug = require('debug')('publikator:lib:mailchimp:updateCampaign')
+
+const {
+  MAILCHIMP_URL,
+  MAILCHIMP_API_KEY,
+  MAILCHIMP_CAMPAIGN_CONFIGS,
+  DEFAULT_MAIL_FROM_NAME,
+  DEFAULT_MAIL_FROM_ADDRESS
+} = process.env
+
+const mailchimpCampaignConfigs = MAILCHIMP_CAMPAIGN_CONFIGS
+  ? JSON.parse(MAILCHIMP_CAMPAIGN_CONFIGS)
+  : []
+
+module.exports = async ({ campaignId, campaignConfig = {} }) => {
+  const config = {
+    ...mailchimpCampaignConfigs.find(c => c.key === campaignConfig.key),
+    ...campaignConfig
+  }
+
+  const body = {
+    recipients: {
+      ...config.list_id && { list_id: config.list_id },
+      segment_opts: {
+        ...config.saved_segment_id && { saved_segment_id: Number(config.saved_segment_id) }
+      }
+    },
+    settings: {
+      ...config.subject_line && { subject_line: config.subject_line },
+      ...config.title && { title: config.title },
+      ...config.to_name && { to_name: config.to_name },
+      from_name: config.from_name || DEFAULT_MAIL_FROM_NAME,
+      reply_to: config.reply_to || DEFAULT_MAIL_FROM_ADDRESS
+    }
+  }
+
+  debug('%o', { campaignId, campaignConfig, config, body })
+
+  return fetch(`${MAILCHIMP_URL}/campaigns/${campaignId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${Buffer.from('anystring:' + MAILCHIMP_API_KEY).toString('base64')}`
+    },
+    body: JSON.stringify(body)
+  })
+    .then(response => {
+      if (!response.ok) {
+        throw Error(response.statusText)
+      }
+      return response
+    })
+}

--- a/servers/publikator/lib/mailchimp/updateCampaignContent.js
+++ b/servers/publikator/lib/mailchimp/updateCampaignContent.js
@@ -10,12 +10,16 @@ module.exports = async ({ campaignId, html }) => {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Basic ${Buffer.from('anystring:' + MAILCHIMP_API_KEY).toString('base64')}`
+      Authorization: `Basic ${Buffer.from('anystring:' + MAILCHIMP_API_KEY).toString('base64')}`
     },
     body: JSON.stringify({
       html
     })
   })
-    .then(response => response.json())
-    .catch(error => console.error('updateMailchimp failed', { error }))
+    .then(response => {
+      if (!response.ok) {
+        throw Error(response.statusText)
+      }
+      return response
+    })
 }


### PR DESCRIPTION
Use `MAILCHIMP_CAMPAIGN_CONFIGS` to set configurations, containing array with objects.

Each object may contain:
- key, currently format.meta.repoId)
- list_id, MailChimp List ID
- saved_segment_id, MailChimp Segment ID
- to_name, MailChimp Merge Vars as To: name
- from_name, sender From: name
- reply_to, sender email

Publish mutation checks if key matches format.meta.repoId and merges configuration.

This includes fixes:
* Neater error handling if MailChimp fetch request fails or returns errorneous status
* Updated subject line or title will be pushed to MailChimp which it did before only when creating
* From: defaults to DEFAULT_MAIL_FROM_NAME and DEFAULT_MAIL_ADDRESS

Example value in `MAILCHIMP_CAMPAIGN_CONFIGS`

```json
[
  {
    "key": "republik-dev/format-newsletter-um-7",
    "from_name": "Republik (Staging)",
    "reply_to": "kontakt@republik.love",
    "list_id": "xxx",
    "saved_segment_id": 1234
  },
  {
    "key": "republik-dev/format-wochenende-newsletter",
    "from_name": "Republik (Staging)",
    "reply_to": "kontakt@republik.love",
    "list_id": "xxx",
    "saved_segment_id": 2345
  },
  {
    "key": "republik-dev/format-covid-19-uhr-newsletter",
    "from_name": "Republik (Staging)",
    "reply_to": "covid19@republik.love",
    "list_id": "95ae41fe21",
    "saved_segment_id": 3456
  }
]
```