### PR TITLE
feat: github downtime resilience

### DIFF
--- a/packages/search/lib/inserts/document.js
+++ b/packages/search/lib/inserts/document.js
@@ -124,13 +124,13 @@ const iterateRepos = async (context, callback) => {
     const allLatestPublications = await Promise.all(
       repos.nodes
         .filter(repo => !repo.isArchived)
-        .map(repo => getLatestPublications(repo))
+        .map(repo => getLatestPublications(repo, null, context))
     )
       .then(arr => arr.filter(arr2 => arr2.length > 0))
 
     for (const publications of allLatestPublications) {
       const repo = repos.nodes.find(r => r.id === publications[0].repo.id)
-      const repoMeta = await getRepoMeta(repo)
+      const repoMeta = await getRepoMeta(repo, null, context)
       await callback(repo, repoMeta, publications)
     }
   } while (pageInfo && pageInfo.hasNextPage)

--- a/packages/search/lib/inserts/repo.js
+++ b/packages/search/lib/inserts/repo.js
@@ -28,7 +28,7 @@ const iterateRepos = async (context, callback) => {
     for (let repo of repos.nodes) {
       await callback(
         repo,
-        await getLatestPublications(repo)
+        await getLatestPublications(repo, null, context)
       )
     }
   } while (pageInfo && pageInfo.hasNextPage)

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1801,6 +1801,10 @@
     {
       "key": "api/notifications/doc/title",
       "value": "{title} jetzt online"
+    },
+    {
+      "key": "api/github/unavailable",
+      "value": "GitHub scheint zur Zeit nicht verfügbar zu sein. Bitte versuchen Sie es später nochmals."
     }
   ]
 }

--- a/servers/publikator/graphql/resolvers/_mutations/archive.js
+++ b/servers/publikator/graphql/resolvers/_mutations/archive.js
@@ -16,7 +16,7 @@ module.exports = async (
   ensureUserHasRole(user, 'editor')
 
   await Promise.each(repoIds, async repoId => {
-    const publications = await getLatestPublications({ id: repoId })
+    const publications = await getLatestPublications({ id: repoId }, null, context)
 
     if (publications.length > 0) {
       if (!unpublish) {

--- a/servers/publikator/graphql/resolvers/_mutations/commit.js
+++ b/servers/publikator/graphql/resolvers/_mutations/commit.js
@@ -237,7 +237,7 @@ module.exports = async (_, args, context) => {
   await repoCacheUpsert(cacheUpsert, context)
 
   // load heads
-  const heads = await getHeads(repoId)
+  const heads = await getHeads(repoId, context)
 
   // check if parent is (still) a head
   // pick master for new repos initated by github

--- a/servers/publikator/graphql/resolvers/_mutations/editRepoMeta.js
+++ b/servers/publikator/graphql/resolvers/_mutations/editRepoMeta.js
@@ -29,7 +29,8 @@ module.exports = async (_, args, context) => {
 
   const tag = await getAnnotatedTag(
     repoId,
-    TAG_NAME
+    TAG_NAME,
+    context
   )
 
   const meta = {

--- a/servers/publikator/graphql/resolvers/_mutations/publish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/publish.js
@@ -121,7 +121,7 @@ module.exports = async (
   if (doc.content.meta.template !== 'front' && !doc.content.meta.slug) {
     throw new Error(t('api/publish/document/slug/404'))
   }
-  const repoMeta = await getRepoMeta({ id: repoId })
+  const repoMeta = await getRepoMeta({ id: repoId }, null, context)
 
   const indexType = 'Document'
 
@@ -414,7 +414,7 @@ module.exports = async (
   await repoCacheUpsert({
     id: repoId,
     meta: repoMeta,
-    publications: await getLatestPublications({ id: repoId })
+    publications: await getLatestPublications({ id: repoId }, null, context)
   }, context)
 
   // release for nice view on github

--- a/servers/publikator/graphql/resolvers/_mutations/publish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/publish.js
@@ -286,7 +286,7 @@ module.exports = async (
   }
 
   // calc version number
-  const latestPublicationVersion = await getAnnotatedTags(repoId)
+  const latestPublicationVersion = await getAnnotatedTags(repoId, context)
     .then(tags => tags
       .filter(tag => publicationVersionRegex.test(tag.name))
       .map(tag => parseInt(publicationVersionRegex.exec(tag.name)[1]))

--- a/servers/publikator/graphql/resolvers/_mutations/unpublish.js
+++ b/servers/publikator/graphql/resolvers/_mutations/unpublish.js
@@ -46,8 +46,8 @@ module.exports = async (
 
   await repoCacheUpsert({
     id: repoId,
-    meta: await getRepoMeta({ id: repoId }),
-    publications: await getLatestPublications({ id: repoId })
+    meta: await getRepoMeta({ id: repoId }, null, context),
+    publications: await getLatestPublications({ id: repoId }, null, context)
   }, context)
 
   await pubsub.publish('repoUpdate', {

--- a/servers/publikator/graphql/resolvers/_queries/repo.js
+++ b/servers/publikator/graphql/resolvers/_queries/repo.js
@@ -13,6 +13,9 @@ module.exports = async (_, args, context) => {
 
   const cachedRepo = body.hits.hits[0]
   if (cachedRepo) {
+    // repo.latestPublications must always be fresh
+    // otherwise resolvers/Repo latestPublications uses stale information after publishing a new doc
+    delete cachedRepo.latestPublications
     return client.mapHit(cachedRepo)
   }
 

--- a/servers/publikator/graphql/resolvers/_queries/repo.js
+++ b/servers/publikator/graphql/resolvers/_queries/repo.js
@@ -1,7 +1,20 @@
 const { Roles: { ensureUserHasRole } } = require('@orbiting/backend-modules-auth')
 
-module.exports = async (_, args, { user }) => {
+const client = require('../../../lib/cache/search')
+
+module.exports = async (_, args, context) => {
+  const { user } = context
   ensureUserHasRole(user, 'editor')
+
+  const { body } = await client.find({
+    first: 1,
+    id: args.id
+  }, context)
+
+  const cachedRepo = body.hits.hits[0]
+  if (cachedRepo) {
+    return client.mapHit(cachedRepo)
+  }
 
   return {
     id: args.id

--- a/servers/publikator/graphql/resolvers/_queries/reposSearch.js
+++ b/servers/publikator/graphql/resolvers/_queries/reposSearch.js
@@ -8,14 +8,6 @@ const { graphql: { resolvers: { queries: { documents: getDocuments } } } } =
 
 const client = require('../../../lib/cache/search')
 
-const mapHit = ({ _source }) => {
-  _source.latestCommit.repo = {
-    id: _source.id
-  }
-
-  return _source
-}
-
 const encodeCursor = (payload) => {
   return Buffer.from(JSON.stringify(payload)).toString('base64')
 }
@@ -113,7 +105,7 @@ module.exports = async (__, args, context) => {
   const hasPreviousPage = from > 0
 
   const data = {
-    nodes: body.hits.hits.map(mapHit),
+    nodes: body.hits.hits.map(client.mapHit),
     totalCount: body.hits.total,
     pageInfo: {
       hasNextPage,

--- a/servers/publikator/lib/PublicationScheduler.js
+++ b/servers/publikator/lib/PublicationScheduler.js
@@ -112,8 +112,8 @@ const init = async (context) => {
 
         await repoCacheUpsert({
           id: repoId,
-          meta: await getRepoMeta({ id: repoId }),
-          publications: await getLatestPublications({ id: repoId })
+          meta: await getRepoMeta({ id: repoId }, null, context),
+          publications: await getLatestPublications({ id: repoId }, null, context)
         }, context)
 
         await upsertDiscussion(doc.meta, context)

--- a/servers/publikator/lib/cache/search.js
+++ b/servers/publikator/lib/cache/search.js
@@ -104,6 +104,12 @@ const find = async (args, { elastic }) => {
     }
   }
 
+  if (args.id) {
+    query.bool.must.push(
+      { term: { _id: args.id } }
+    )
+  }
+
   if (args.search) {
     query.bool.must.push({
       simple_query_string: {
@@ -132,6 +138,16 @@ const find = async (args, { elastic }) => {
   })
 }
 
+const mapHit = ({ _source }) => {
+  _source.latestCommit.repo = {
+    id: _source.id
+  }
+
+  return _source
+}
+
+
 module.exports = {
-  find
+  find,
+  mapHit
 }

--- a/servers/publikator/lib/github/index.js
+++ b/servers/publikator/lib/github/index.js
@@ -365,7 +365,7 @@ module.exports = {
       .then(tags =>
         uniqWith(tags, (a, b) => a.name === b.name)
       )
-      .catch(e => {})
+      .catch(e => {console.error(e)})
 
     // github downtime resilience
     const redisKey = `repos:${repoId}/tags:first=${first}`

--- a/servers/publikator/lib/github/index.js
+++ b/servers/publikator/lib/github/index.js
@@ -90,18 +90,10 @@ module.exports = {
     })
     return repo
   },
-  getHeads: async (repoId) => {
+  getHeads: async (repoId, { t }) => {
     const { githubApolloFetch } = await createGithubClients()
     const [login, repoName] = repoId.split('/')
-    const {
-      data: {
-        repository: {
-          refs: {
-            nodes: heads
-          }
-        }
-      }
-    } = await githubApolloFetch({
+    const result = await githubApolloFetch({
       query: `
         query repository(
           $login: String!,
@@ -134,6 +126,10 @@ module.exports = {
         first: 100
       }
     })
+    const heads = result?.data?.repository?.refs?.nodes
+    if (!heads) {
+      throw new Error(t('api/github/unavailable'))
+    }
     return heads
   },
   getCommit: async (repo, { id: sha }, { redis }) => {
@@ -148,13 +144,7 @@ module.exports = {
 
     const { githubApolloFetch } = await createGithubClients()
     const [login, repoName] = repo.id.split('/')
-    const {
-      data: {
-        repository: {
-          object: rawCommit
-        }
-      }
-    } = await githubApolloFetch({
+    const result = await githubApolloFetch({
       query: `
         query repository(
           $login: String!,
@@ -190,25 +180,18 @@ module.exports = {
         sha
       }
     })
+    const rawCommit = result?.data?.repository?.object
     if (!rawCommit) {
-      return null
+      throw new Error(t('api/github/unavailable'))
     }
     const commit = normalizeGQLCommit(repo, rawCommit)
     await redis.setAsync(redisKey, JSON.stringify(commit), 'EX', redis.__defaultExpireSeconds)
     return commit
   },
-  getCommits: async (repo, { first = 15, after, before }) => {
+  getCommits: async (repo, { first = 15, after, before }, { redis, t }) => {
     const { githubApolloFetch } = await createGithubClients()
     const [login, repoName] = repo.id.split('/')
-    const {
-      data: {
-        repository: {
-          refs: {
-            nodes: heads
-          }
-        }
-      }
-    } = await githubApolloFetch({
+    const result = await githubApolloFetch({
       query: `
         query repository(
           $login: String!,
@@ -269,6 +252,22 @@ module.exports = {
         commitsUntil: after
       }
     })
+
+
+    // github downtime resilience
+    let heads = result?.data?.repository?.refs?.nodes
+    const redisKey = `repos:${repo.id}/heads`
+    if (heads) {
+      redis.setAsync(redisKey, JSON.stringify(heads))
+    } else {
+      const redisHeads = await redis.getAsync(redisKey)
+        .then( r => r && JSON.parse(r) )
+      if (!redisHeads) {
+        throw new Error(t('api/github/unavailable'))
+      }
+      heads = redisHeads
+    }
+
     const hasNextPage = heads.some(({ target }) => target.history.pageInfo.hasNextPage)
     const totalCount = heads.reduce((total, { target }) => total + target.history.totalCount, 0)
 
@@ -296,7 +295,8 @@ module.exports = {
       nodes: commits
     }
   },
-  getAnnotatedTags: async (repoId, first = 100) => {
+  getAnnotatedTags: async (repoId, { redis, t }) => {
+    const first = 100
     const { githubApolloFetch } = await createGithubClients()
     const [login, repoName] = repoId.split('/')
 
@@ -354,10 +354,9 @@ module.exports = {
           }
           return nextNodes
         })
-        .catch(errors => { console.log(errors) })
     }
 
-    return getAll()
+    const result = await getAll()
       .then(tags => tags
         .map(tag => tag.target)
         .filter(tag => Object.keys(tag).length > 0) // only annotated
@@ -366,17 +365,26 @@ module.exports = {
       .then(tags =>
         uniqWith(tags, (a, b) => a.name === b.name)
       )
+      .catch(e => {})
+
+    // github downtime resilience
+    const redisKey = `repos:${repoId}/tags:first=${first}`
+    if (result) {
+      redis.setAsync(redisKey, JSON.stringify(result))
+      return result
+    } else {
+      const redisResult = await redis.getAsync(redisKey)
+        .then( r => r && JSON.parse(r) )
+      if (redisResult) {
+        return redisResult
+      }
+      throw new Error(t('api/github/unavailable'))
+    }
   },
-  getAnnotatedTag: async (repoId, tagName) => {
+  getAnnotatedTag: async (repoId, tagName, { redis, t }) => {
     const { githubApolloFetch } = await createGithubClients()
     const [login, repoName] = repoId.split('/')
-    const {
-      data: {
-        repository: {
-          ref
-        }
-      }
-    } = await githubApolloFetch({
+    const result = await githubApolloFetch({
       query: `
         query repository(
           $login: String!,
@@ -413,6 +421,20 @@ module.exports = {
         ref: `refs/tags/${tagName}`
       }
     })
+    let ref = result?.data?.repository?.ref
+
+    // github downtime resilience
+    const redisKey = `repos:${repoId}/tags:name=${tagName}`
+    if (ref) {
+      redis.setAsync(redisKey, JSON.stringify(ref))
+    } else {
+      const redisResult = await redis.getAsync(redisKey)
+        .then( r => r && JSON.parse(r) )
+      if (redisResult) {
+        ref = redisResult
+      }
+    }
+
     if (!ref || !ref.target) {
       return null
     }

--- a/servers/publikator/lib/github/index.js
+++ b/servers/publikator/lib/github/index.js
@@ -423,17 +423,9 @@ module.exports = {
     })
     let ref = result?.data?.repository?.ref
 
-    // github downtime resilience
-    const redisKey = `repos:${repoId}/tags:name=${tagName}`
-    if (ref) {
-      redis.setAsync(redisKey, JSON.stringify(ref))
-    } else {
-      const redisResult = await redis.getAsync(redisKey)
-        .then( r => r && JSON.parse(r) )
-      if (redisResult) {
-        ref = redisResult
-      }
-    }
+    // github downtime resilience:
+    // annotatedTag can not be cached, because they must dissapear when a doc
+    // is unpublished or a scheduled publication is overwritten by a publish.
 
     if (!ref || !ref.target) {
       return null


### PR DESCRIPTION
make repo overview, commits tree and milestones available even if github is unavailable

new redis cache, which is only used if github doesn't answer
- commits (heads)
- annotatedTags

use repo cache for single repo lookup (repo query)

throw error if github is not accessible and cache not available