### PR TITLE
fix(crowdfundings): List UNCERTAIN_FUTURE when showMore flag is truthy

### DIFF
--- a/servers/republik/modules/crowdfundings/graphql/resolvers/_queries/cancellationCategories.js
+++ b/servers/republik/modules/crowdfundings/graphql/resolvers/_queries/cancellationCategories.js
@@ -1,8 +1,20 @@
 const { parse, Source } = require('graphql')
 const Schema = require('../../schema-types')
 
-const HIDDEN_CATEGORIES = ['SYSTEM']
-const MORE_CATEGORIES = ['EDITORAL_NARCISSISTIC', 'LOGIN_TECH', 'PAPER', 'EXPECTIONS', 'RARELY_READ', 'TOO_MUCH_TO_READ', 'CROWFUNDING_ONLY', 'SEVERAL_REASONS']
+const HIDDEN_CATEGORIES = [
+  'SYSTEM'
+]
+const MORE_CATEGORIES = [
+  'EDITORAL_NARCISSISTIC',
+  'LOGIN_TECH',
+  'PAPER',
+  'EXPECTIONS',
+  'RARELY_READ',
+  'TOO_MUCH_TO_READ',
+  'CROWFUNDING_ONLY',
+  'SEVERAL_REASONS',
+  'UNCERTAIN_FUTURE'
+]
 
 const cancellationCategories = parse(new Source(Schema))
   .definitions.find(


### PR DESCRIPTION
This Pull Request hides cancellation category `UNCERTAIN_FUTURE` in `query cancellationCategories` per default.

It is listed when `showMore` argument is truthy (for Admin-Tool and book keeping reasons).