### PR TITLE
refactor: schedulers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: yarn run start
+scheduler: yarn run startScheduler

--- a/Procfile-dev
+++ b/Procfile-dev
@@ -1,3 +1,5 @@
 republik: cd servers/republik && PORT=5000 yarn run dev
+republik-scheduler: cd servers/republik && PORT=5000 yarn run devScheduler
 publikator: cd servers/publikator && PORT=5010 yarn run dev
+publikator-scheduler: cd servers/publikator && PORT=5010 yarn run devScheduler
 assets: cd servers/assets && PORT=5020 yarn run dev

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "start": "if [ -z \"$SERVER\" ]; then >&2 echo \"Missing ENV var: SERVER. Possible values are: republik, publikator, assets.\" && exit 1; else cd servers/$SERVER && yarn run start; fi",
+    "startScheduler": "if [ -z \"$SERVER\" ]; then >&2 echo \"Missing ENV var: SERVER. Possible values are: republik, publikator.\" && exit 1; else cd servers/$SERVER && yarn run startScheduler; fi",
     "dev": "nf --procfile Procfile-dev start",
     "cloc": "find . -name '*.js' -not -path \"*/node_modules*\" -not -path \"./node_modules*\" | xargs wc -l",
     "commit": "git-cz",

--- a/servers/assets/nodemon.json
+++ b/servers/assets/nodemon.json
@@ -1,0 +1,4 @@
+{
+  "watch": ["../../packages", "./"],
+  "ext": "js,json,env"
+}

--- a/servers/assets/package.json
+++ b/servers/assets/package.json
@@ -13,7 +13,7 @@
     "regiment": "^0.0.5"
   },
   "scripts": {
-    "dev": "NODE_ENV=development nodemon $NODE_DEBUG_OPTION --trace-warnings -w ../../packages -w .env -w package.jsoan -w ../yarn.lock -w server.js -w index.js index.js",
+    "dev": "NODE_ENV=development nodemon $NODE_DEBUG_OPTION --trace-warnings index.js",
     "inspect": "NODE_DEBUG_OPTION=--inspect yarn run dev",
     "start": "node index.js"
   },

--- a/servers/publikator/index.js
+++ b/servers/publikator/index.js
@@ -11,9 +11,8 @@ if (CLUSTER) {
   throng({
     workers: WEB_CONCURRENCY,
     grace: 30 * 1000,
-    master: server.runOnce,
     start: server.run
   })
 } else {
-  server.start()
+  server.run()
 }

--- a/servers/publikator/nodemon.json
+++ b/servers/publikator/nodemon.json
@@ -1,0 +1,4 @@
+{
+  "watch": ["../../packages", "./"],
+  "ext": "js,json,env"
+}

--- a/servers/publikator/package.json
+++ b/servers/publikator/package.json
@@ -42,9 +42,11 @@
     "yargs": "^15.3.1"
   },
   "scripts": {
-    "dev": "NODE_ENV=development nodemon $NODE_DEBUG_OPTION --trace-warnings -w ../../packages -w graphql -w lib -w express -w .env -w package.json -w ../yarn.lock -w server.js -w index.js index.js",
+    "dev": "NODE_ENV=development nodemon $NODE_DEBUG_OPTION --trace-warnings index.js",
+    "devScheduler": "NODE_ENV=development nodemon $NODE_DEBUG_OPTION --trace-warnings scheduler.js",
     "inspect": "NODE_DEBUG_OPTION=--inspect yarn run dev",
-    "start": "node index.js"
+    "start": "node index.js",
+    "startScheduler": "node scheduler.js"
   },
   "devDependencies": {
     "gsheets": "^2.0.0",

--- a/servers/publikator/scheduler.js
+++ b/servers/publikator/scheduler.js
@@ -1,0 +1,3 @@
+require('@orbiting/backend-modules-env').config()
+const server = require('./server')
+server.runOnce()

--- a/servers/publikator/server.js
+++ b/servers/publikator/server.js
@@ -35,9 +35,10 @@ const {
 
 const DEV = NODE_ENV && NODE_ENV !== 'production'
 
+// only used by tests, needs to run server and schedulers
 const start = async () => {
   const server = await run()
-  const _runOnce = await runOnce({ clusterMode: false })
+  const _runOnce = await runOnce()
 
   const close = async () => {
     await server.close()
@@ -127,7 +128,7 @@ const run = async (workerId, config) => {
 }
 
 // in cluster mode, this runs before run otherwise after
-const runOnce = async (...args) => {
+const runOnce = async () => {
   if (cluster.isWorker) {
     throw new Error('runOnce must only be called on cluster.isMaster')
   }

--- a/servers/republik/index.js
+++ b/servers/republik/index.js
@@ -11,9 +11,8 @@ if (CLUSTER) {
   throng({
     workers: WEB_CONCURRENCY,
     grace: 30 * 1000,
-    master: server.runOnce,
     start: server.run
   })
 } else {
-  server.start()
+  server.run()
 }

--- a/servers/republik/nodemon.json
+++ b/servers/republik/nodemon.json
@@ -1,0 +1,4 @@
+{
+  "watch": ["../../packages", "./"],
+  "ext": "js,json,env"
+}

--- a/servers/republik/package.json
+++ b/servers/republik/package.json
@@ -32,9 +32,11 @@
     "yargs": "^15.3.1"
   },
   "scripts": {
-    "dev": "NODE_ENV=development nodemon $NODE_DEBUG_OPTION -w ../../packages -w express -w graphql -w lib -w modules -w .env -w package.json -w ../yarn.lock -w server.js -w index.js index.js",
+    "dev": "NODE_ENV=development nodemon $NODE_DEBUG_OPTION --trace-warnings index.js",
+    "devScheduler": "NODE_ENV=development nodemon $NODE_DEBUG_OPTION --trace-warnings scheduler.js",
     "inspect": "NODE_DEBUG_OPTION=--inspect yarn run dev",
     "start": "node index.js",
+    "startScheduler": "node scheduler.js",
     "db:seed:redirections": "cat ../../packages/redirections/seeds/seeds.example.json | node ../../packages/redirections/seeds/seed.js",
     "db:seed:users": "cat ../../packages/auth/seeds/seeds.example.json | node ../../packages/auth/seeds/seed.js --truncate",
     "db:seed:crowdfundings": "seeds/script/seed.js"

--- a/servers/republik/scheduler.js
+++ b/servers/republik/scheduler.js
@@ -1,0 +1,3 @@
+require('@orbiting/backend-modules-env').config()
+const server = require('./server')
+server.runOnce()

--- a/servers/republik/server.js
+++ b/servers/republik/server.js
@@ -55,9 +55,10 @@ const {
 
 const DEV = NODE_ENV && NODE_ENV !== 'production'
 
+// only used by tests, needs to run server and schedulers
 const start = async () => {
   const server = await run()
-  const _runOnce = await runOnce({ clusterMode: false })
+  const _runOnce = await runOnce()
 
   const close = async () => {
     await server.close()
@@ -70,7 +71,6 @@ const start = async () => {
   }
 }
 
-// in cluster mode, this runs after runOnce otherwise before
 const run = async (workerId, config) => {
   const localModule = require('./graphql')
   const graphqlSchema = merge(
@@ -172,12 +172,7 @@ const run = async (workerId, config) => {
   }
 }
 
-// in cluster mode, this runs before run otherwise after
-const runOnce = async (...args) => {
-  if (cluster.isWorker) {
-    throw new Error('runOnce must only be called on cluster.isMaster')
-  }
-
+const runOnce = async () => {
   const applicationName = [
     'backends',
     SERVER,


### PR DESCRIPTION
Untagles running schedulers from the webserver.
For prod: `server/xxx/index.js` doesn't exec `server.js`'s `runOnce` anymore. A `Procfile` was added which specifies the `web` and `scheduler` task. `web` starts `Server.run`, `scheduler` starts `Server.runOnce`
For dev: As a `Procfile-dev` already exists, only the addition of the new scripts was needed. 
