### PR TITLE
fix: quotes in notification titles

### DIFF
--- a/packages/discussions/lib/Notifications.js
+++ b/packages/discussions/lib/Notifications.js
@@ -2,7 +2,7 @@ const htmlToText = require('html-to-text')
 const { renderEmail } = require('mdast-react-render/lib/email')
 
 const { transformUser } = require('@orbiting/backend-modules-auth')
-const { commentSchema } = require('@orbiting/backend-modules-styleguide')
+const { commentSchema, inQuotes } = require('@orbiting/backend-modules-styleguide')
 const {
   Subscriptions: {
     getSubscriptionsForUserAndObjects,
@@ -74,7 +74,7 @@ const getCommentInfo = async (comment, displayAuthor, discussion, context) => {
     muteUrl: `${discussionUrl}${discussionUrl.indexOf('?') === -1 ? '?' : '&'}mute=1`,
     subjectParams: {
       authorName: displayAuthor.name,
-      discussionName: discussion.title
+      discussionName: inQuotes(discussion.title)
     },
     isTopLevelComment: !parentIds || parentIds.length === 0,
     icon: displayAuthor.profilePicture || t('api/comment/notification/new/app/icon')

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -720,11 +720,11 @@
     },
     {
       "key": "api/comment/notification/new/email/subject",
-      "value": "Neuer Beitrag von {authorName} in «{discussionName}»"
+      "value": "Neuer Beitrag von {authorName} in {discussionName}"
     },
     {
       "key": "api/comment/notification/answer/email/subject",
-      "value": "Neue Antwort von {authorName} in «{discussionName}»"
+      "value": "Neue Antwort von {authorName} in {discussionName}"
     },
     {
       "key": "api/comment/notification/new/app/icon",
@@ -732,11 +732,11 @@
     },
     {
       "key": "api/comment/notification/new/app/subject",
-      "value": "Neuer Beitrag in «{discussionName}»"
+      "value": "Neuer Beitrag in {discussionName}"
     },
     {
       "key": "api/comment/notification/answer/app/subject",
-      "value": "Neue Antwort in «{discussionName}»"
+      "value": "Neue Antwort in {discussionName}"
     },
     {
       "key": "api/comment/tagRequired",


### PR DESCRIPTION
Fixes double quotes in notification titles, e.g.
![CED3027B-7887-4592-A087-B49080A3473C](https://user-images.githubusercontent.com/3500621/90637364-2e36c080-e22c-11ea-90dc-d147f97d876b.jpg)
