### PR TITLE
fix: stripe customer without sources

### DIFF
--- a/packages/republik/modules/crowdfundings/lib/payments/stripe/addSource.js
+++ b/packages/republik/modules/crowdfundings/lib/payments/stripe/addSource.js
@@ -33,7 +33,7 @@ module.exports = async ({
       throw new Error('three_d_secure sources cannot be attached like this!')
     }
 
-    existingSource = stripeCustomer.sources.data.find(s =>
+    existingSource = stripeCustomer.sources?.data.find(s =>
       s.card &&
       s.card.fingerprint === source.card.fingerprint &&
       s.card.exp_month === source.card.exp_month &&


### PR DESCRIPTION
resolves an error if a stripe customer has no sources (because they were deleted in the stripe dashboard for example)
```
2020-08-20T09:59:22.385619+00:00 app[web.1]: graphql error in undefined (undefined): [GraphQLError [Object]: Cannot read property 'data' of undefined] {
2020-08-20T09:59:22.385620+00:00 app[web.1]: locations: [ { line: 2, column: 3 } ],
2020-08-20T09:59:22.385620+00:00 app[web.1]: path: [ 'addPaymentSource' ],
2020-08-20T09:59:22.385621+00:00 app[web.1]: extensions: {
2020-08-20T09:59:22.385621+00:00 app[web.1]: code: 'INTERNAL_SERVER_ERROR',
2020-08-20T09:59:22.385621+00:00 app[web.1]: exception: {
2020-08-20T09:59:22.385621+00:00 app[web.1]: stacktrace: [
2020-08-20T09:59:22.385622+00:00 app[web.1]: "TypeError: Cannot read property 'data' of undefined",
2020-08-20T09:59:22.385622+00:00 app[web.1]: '    at module.exports (/app/packages/republik/modules/crowdfundings/lib/payments/stripe/addSource.js:36:45)',
2020-08-20T09:59:22.385622+00:00 app[web.1]: '    at runMicrotasks (<anonymous>)',
2020-08-20T09:59:22.385623+00:00 app[web.1]: '    at processTicksAndRejections (internal/process/task_queues.js:93:5)',
2020-08-20T09:59:22.385623+00:00 app[web.1]: '    at async module.exports (/app/packages/republik/modules/crowdfundings/graphql/resolvers/_mutations/addPaymentSource.js:26:7)'
2020-08-20T09:59:22.385624+00:00 app[web.1]: ]
2020-08-20T09:59:22.385624+00:00 app[web.1]: }
2020-08-20T09:59:22.385624+00:00 app[web.1]: }
2020-08-20T09:59:22.385624+00:00 app[web.1]: }
```