### PR TITLE
Collection Items

### DIFF
--- a/packages/collections/graphql/resolvers/User.js
+++ b/packages/collections/graphql/resolvers/User.js
@@ -5,32 +5,28 @@ const { paginate } = require('@orbiting/backend-modules-utils')
 const accessRoles = ['member']
 const adminRoles = ['admin', 'supporter']
 
+const canAccess = (user, context) => {
+  const { user: me } = context
+  return (
+    (Roles.userIsMe(user, me) && Roles.userIsInRoles(user, accessRoles)) ||
+    Roles.userIsInRoles(me, adminRoles)
+  )
+}
+
 module.exports = {
   collections (user, args, context) {
-    const { user: me } = context
-    if (
-      (Roles.userIsMe(user, me) && Roles.userIsInRoles(user, accessRoles)) ||
-      Roles.userIsInRoles(me, adminRoles)
-    ) {
+    if (canAccess(user, context)) {
       return Collection.findForUser(user.id, context)
     }
     return []
   },
   collection (user, { name }, context) {
-    const { user: me } = context
-    if (
-      (Roles.userIsMe(user, me) && Roles.userIsInRoles(user, accessRoles)) ||
-      Roles.userIsInRoles(me, adminRoles)
-    ) {
+    if (canAccess(user, context)) {
       return Collection.byNameForUser(name, user.id, context)
     }
   },
   async collectionItems (user, args, context) {
-    const { user: me } = context
-    if (
-      (Roles.userIsMe(user, me) && Roles.userIsInRoles(user, accessRoles)) ||
-      Roles.userIsInRoles(me, adminRoles)
-    ) {
+    if (canAccess(user, context)) {
       const collections = await Promise.all(args.names.map(name => Collection.byNameForUser(name, user.id, context)))
       const items = await Collection.findDocumentItems(
         {

--- a/packages/collections/graphql/resolvers/User.js
+++ b/packages/collections/graphql/resolvers/User.js
@@ -1,5 +1,6 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
 const Collection = require('../../lib/Collection')
+const { paginate } = require('@orbiting/backend-modules-utils')
 
 const accessRoles = ['member']
 const adminRoles = ['admin', 'supporter']
@@ -22,6 +23,23 @@ module.exports = {
       Roles.userIsInRoles(me, adminRoles)
     ) {
       return Collection.byNameForUser(name, user.id, context)
+    }
+  },
+  async collectionItems (user, args, context) {
+    const { user: me } = context
+    if (
+      (Roles.userIsMe(user, me) && Roles.userIsInRoles(user, accessRoles)) ||
+      Roles.userIsInRoles(me, adminRoles)
+    ) {
+      const collections = await Promise.all(args.names.map(name => Collection.byNameForUser(name, user.id, context)))
+      const items = await Collection.findDocumentItems(
+        {
+          collectionId: collections.map(collection => collection.id),
+          userId: user.id
+        },
+        context
+      )
+      return paginate(args, items)
     }
   }
 }

--- a/packages/collections/graphql/resolvers/User.js
+++ b/packages/collections/graphql/resolvers/User.js
@@ -37,5 +37,6 @@ module.exports = {
       )
       return paginate(args, items)
     }
+    return paginate(args, [])
   }
 }

--- a/packages/collections/graphql/schema-types.js
+++ b/packages/collections/graphql/schema-types.js
@@ -48,6 +48,13 @@ extend type Document {
 extend type User {
   collections: [Collection!]!
   collection(name: String!): Collection
+  collectionItems(
+    names: [String!]!
+    first: Int
+    last: Int
+    before: String
+    after: String
+  ): CollectionItemConnection!
 }
 
 type DocumentProgress implements CollectionItemInterface {

--- a/packages/collections/lib/Collection.js
+++ b/packages/collections/lib/Collection.js
@@ -45,7 +45,7 @@ const byIdForUser = (id, userId, { loaders }) =>
 const findDocumentItems = (args, { pgdb }) =>
   pgdb.public.collectionDocumentItems.find(
     args,
-    { orderBy: ['createdAt desc'] }
+    { orderBy: ['updatedAt desc'] }
   )
     .then(items => items
       .map(spreadItemData)


### PR DESCRIPTION
Allowing to query `collectionItems` from multiple collections at the same time.

Example query:
```
{
  me {
    collectionItems(names: ["bookmarks", "progress"], first: 10) {
      totalCount
      nodes {
        id
        collection {
          name
        }
        document {
          meta {
            title
          }
        }
      }
    }
  }
}
```