### PR TITLE
feat(notifications): filter for EventObjectType

### DIFF
--- a/packages/subscriptions/graphql/resolvers/_queries/notifications.js
+++ b/packages/subscriptions/graphql/resolvers/_queries/notifications.js
@@ -9,9 +9,9 @@ module.exports = async (_, args, context) => {
 
   const nodes = await pgdb.public.notifications.find(
     {
-      userId: me.id,
       ...(args.onlyUnread ? { readAt: null } : {}),
       ...(args.filter ? { eventObjectType: args.filter } : {}),
+      userId: me.id,
     },
     {
       orderBy: { createdAt: 'DESC' },

--- a/packages/subscriptions/graphql/resolvers/_queries/notifications.js
+++ b/packages/subscriptions/graphql/resolvers/_queries/notifications.js
@@ -11,6 +11,7 @@ module.exports = async (_, args, context) => {
     {
       userId: me.id,
       ...(args.onlyUnread ? { readAt: null } : {}),
+      ...(args.filter ? { eventObjectType: args.filter } : {}),
     },
     {
       orderBy: { createdAt: 'DESC' },

--- a/packages/subscriptions/graphql/schema.js
+++ b/packages/subscriptions/graphql/schema.js
@@ -9,6 +9,7 @@ schema {
 type queries {
   notifications(
     onlyUnread: Boolean
+    filter: EventObjectType
     first: Int
     last: Int
     before: String


### PR DESCRIPTION
Allow to query for notifications for a specific type.

```gql
{
  notifications(first: 2, filter: Document) {
    totalCount
    nodes {
      object {
        ... on Document {
          id
          meta {
            title
          }
        }
      }
    }
  }
}
```