### PR TITLE
fix(auth): Filter User.roles

### DIFF
--- a/packages/auth/graphql/resolvers/User.js
+++ b/packages/auth/graphql/resolvers/User.js
@@ -32,8 +32,7 @@ module.exports = {
   },
   roles(user, args, { user: me }) {
     if (Roles.userIsMeOrInRoles(user, me, ['admin', 'supporter'])) {
-      const roles = user.roles ?? []
-      return roles.filter((role) => Roles.exposableRoles.includes(role))
+      return user.roles.filter((role) => Roles.exposableRoles.includes(role))
     }
     return []
   },

--- a/packages/auth/graphql/resolvers/User.js
+++ b/packages/auth/graphql/resolvers/User.js
@@ -32,7 +32,8 @@ module.exports = {
   },
   roles(user, args, { user: me }) {
     if (Roles.userIsMeOrInRoles(user, me, ['admin', 'supporter'])) {
-      return user.roles
+      const roles = user.roles ?? []
+      return roles.filter((role) => Roles.exposableRoles.includes(role))
     }
     return []
   },

--- a/packages/auth/lib/Roles.js
+++ b/packages/auth/lib/Roles.js
@@ -2,6 +2,18 @@ const t = require('./t')
 
 const roles = ['editor']
 const specialRoles = ['accountant', 'admin', 'editor', 'supporter']
+const exposableRoles = [
+  'accomplice',
+  'accountant',
+  'admin',
+  'associate',
+  'debater',
+  'editor',
+  'member',
+  'producer',
+  'supporter',
+  'tester',
+]
 
 const userHasRole = (user, role) => {
   return user && user.roles && user.roles.indexOf(role) > -1
@@ -107,6 +119,7 @@ const isRoleClaimableByMe = (role, me) =>
 module.exports = {
   roles,
   specialRoles,
+  exposableRoles,
   userHasRole,
   ensureUserHasRole,
   userIsInRoles,


### PR DESCRIPTION
Returns only exposable roles as defined in [lib/Roles](https://github.com/orbiting/backends/compare/pae/fix-filtered-user-roles?expand=1#diff-92181c7cbf69ecc6d962e11749cbfd07b2ba631beb5e5797b5e319fe3d21bd8dR5-R16). This omits undefined roles like "foobar".