### PR TITLE
Fix User.mailLog and mergeUser mutation

### DIFF
--- a/packages/maillog/graphql/resolvers/User.js
+++ b/packages/maillog/graphql/resolvers/User.js
@@ -10,7 +10,10 @@ module.exports = {
 
     const records = await pgdb.public.mailLog.find(
       {
-        or: [{ userId: user.id }, { email: user.email }],
+        or: [
+          { userId: user.id },
+          { userId: null, email: user.email }
+        ],
       },
       { orderBy: { createdAt: 'DESC' } },
     )

--- a/packages/maillog/graphql/resolvers/User.js
+++ b/packages/maillog/graphql/resolvers/User.js
@@ -10,7 +10,7 @@ module.exports = {
 
     const records = await pgdb.public.mailLog.find(
       {
-        or: [{ id: user.id }, { email: user.email }],
+        or: [{ userId: user.id }, { email: user.email }],
       },
       { orderBy: { createdAt: 'DESC' } },
     )

--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
@@ -218,6 +218,11 @@ module.exports = async (_, args, context) => {
       () => transaction.public.electionCandidacies.update(from, to),
       () => transaction.public.eventLog.update(from, to),
       () => transaction.public.mailLog.update(from, to),
+      () =>
+        transaction.public.mailLog.update(
+          { userId: null, email: sourceUser.email },
+          to
+        ),
       () => transaction.public.notifications.update(from, to),
       () => transaction.public.previewRequests.update(from, to),
       () => transaction.public.questionnaireSubmissions.update(from, to),

--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
@@ -224,7 +224,9 @@ module.exports = async (_, args, context) => {
           to
         ),
       () => transaction.public.notifications.update(from, to),
-      () => transaction.public.previewRequests.update(from, to),
+      () =>
+        transaction.public.previewRequests &&
+        transaction.public.previewRequests.update(from, to),
       () => transaction.public.questionnaireSubmissions.update(from, to),
       () =>
         transaction.public.accessGrants.update(


### PR DESCRIPTION
Merges mail log of source user to target user more diligently. It also fixes a bug on `User.mailLog` which did not return mail log records with only a matching `userId`.

This Pull Request fixes:
- Mutation `mergeUser` sets `mailLog` records with `email` but no `userId` to target user ID thus transferring mail log records (without user ID) to target user.
- `User.mailLog` will return `mailLog` records either linked via `userId` or lacks `userId` but matches current user email address.
- Prevent error if previewRequests table is not available is it was removed a while ago and running migrations on an empty database won't create that table.

Relates to https://github.com/orbiting/backends/issues/506