### PR TITLE
Fix plain text mail template generator

### DIFF
--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -24,7 +24,8 @@
     "bluebird": "^3.7.2",
     "check-env": "^1.3.0",
     "debug": "^4.1.1",
-    "html-to-text": "^5.1.1",
+    "he": "^1.2.0",
+    "html-to-text": "^6.0.0",
     "isomorphic-unfetch": "^3.0.0",
     "nodemailer": "^6.4.8",
     "recursive-readdir": "^2.2.2"

--- a/packages/mail/script/generateTextTemplates.js
+++ b/packages/mail/script/generateTextTemplates.js
@@ -159,15 +159,6 @@ const run = async () => {
         ,
       { encoding: 'utf8', flag: 'w' },
     )
-  }).then(() => {
-    const custom = 'cf_comment_notification_new.txt signin.txt signin_code.txt newsletter_request_COVID19.txt'
-      .split(' ')
-      .filter((t) => !argv.templates || argv.templates.includes(t))
-    if (custom.length) {
-      console.log(
-        'Make sure to restore plain text customizations: ' + custom.join(', '),
-      )
-    }
   })
 }
 

--- a/packages/mail/script/generateTextTemplates.js
+++ b/packages/mail/script/generateTextTemplates.js
@@ -2,19 +2,125 @@
 const { promises: fs } = require('fs')
 const htmlToText = require('html-to-text')
 const defaultFormat = require('html-to-text/lib/formatter')
+const he = require('he')
 const path = require('path')
 const Promise = require('bluebird')
 const recursive = require('recursive-readdir')
 const yargs = require('yargs')
 
-const argv = yargs.options('templates', {
-  alias: ['template', 't'],
-  type: 'array',
-}).argv
+const argv = yargs
+  .options('templates', {
+    alias: ['template', 't'],
+    type: 'array',
+  })
+  .options('domain', {
+    alias: 'd',
+    type: 'string',
+    default: 'republik.ch'
+  })
+  .argv
 
 const filterNonHtml = (file) => path.extname(file) !== '.html'
 const filterUnspecifiedTemplates = (file) =>
   !argv.templates.includes(path.basename(file, '.html'))
+
+/**
+ * Process an anchor
+ * 
+ * @see https://github.com/html-to-text/node-html-to-text/blob/6.0.0/lib/formatter.js#L151-L193
+ *
+ * Customized to:
+ * - append a space after a URL
+ * - print href only whenver deemed best, see useHrefOnly()
+ *
+ */
+const formatAnchorRepublik = (elem, walk, builder, formatOptions) => {
+  function getHref () {
+    if (formatOptions.ignoreHref) { return ''; }
+    if (!elem.attribs || !elem.attribs.href) { return '' }
+    let href = elem.attribs.href.replace(/^mailto:/, '')
+    if (formatOptions.noAnchorUrl && href[0] === '#') { return '' }
+    href = (formatOptions.baseUrl && href[0] === '/')
+      ? formatOptions.baseUrl + href
+      : href;
+    return he.decode(href, builder.options.decodeOptions);
+  }
+  const href = getHref()
+  if (!href) {
+    walk(elem.children, builder)
+  } else {
+    const text = elem.children
+      .filter(elem => elem.type === 'text' && !elem.children)
+      .map(elem => elem.data.split(' ').map(string => string.trim()).filter(Boolean).join(' '))
+      .join(' ')
+
+    if (useHrefOnly(text, href)) {
+      builder.addInline(href + ' ', true)
+    } else if (formatOptions.hideLinkHrefIfSameAsText) {
+      builder.addInline(text, true)
+      builder.addInline(
+        formatOptions.noLinkBrackets
+          ? ' ' + href + ' '
+          : ' [' + href + ' ]',
+        true
+      )
+    }
+  }
+}
+
+/**
+ * Compares an achor text and href link. Returns true if href string
+ * is deemd enough to represent anchor.
+ *
+ * @param {string} text 
+ * @param {string} href 
+ */
+const useHrefOnly = (text, href) => {
+  // Return true if text and href are the same
+  if (text === href) {
+    return true
+  }
+
+  const handlebarTag = /^{{.+}}$/
+
+  /**
+   * Returns true if text and href are handlebar tags
+   *
+   * Example:
+   *   text: {{link_account}}
+   *   href: {{link_account_something}}
+   *
+   */
+  if (text.match(handlebarTag) && href.match(handlebarTag)) {
+    return true
+  }
+
+  /**
+   * Returns true if text contains domain and href is a handlebar tag
+   * 
+   * Example:
+   *   text: www.republik.ch/merci
+   *   href: {{link_merci}}
+   *
+   */
+  if (text.match(new RegExp(argv.domain)) && href.match(handlebarTag)) {
+    return true
+  }
+
+  /**
+   * Returns true if text is part of href
+   * 
+   * Example:
+   *   text: republik.ch/foobar
+   *   href: https://www.republik.ch/foobar
+   *
+   */
+  if (href.search(text) !== -1) {
+    return true
+  }
+
+  return false
+}
 
 const run = async () => {
   const files = await recursive(
@@ -31,51 +137,26 @@ const run = async () => {
       file.replace(/\.html$/gi, '.txt'),
       htmlToText
         .fromString(html, {
-          ignoreImage: true,
-          format: {
-            anchor: (elem, fn, options) => {
-              // based on https://github.com/werk85/node-html-to-text/blob/7894809a57e9066501b954dbd9c16fd34c3bcebf/lib/formatter.js#L148-L176
-              // backed in noLinkBrackets: true and hideLinkHrefIfSameAsText: true
-              // custom
-              // - add extra space after urls
-              // - add normalizeUrl for toHideSameLink
-              function getHref() {
-                if (!elem.attribs || !elem.attribs.href) {
-                  return undefined
-                }
-                const href = elem.attribs.href.replace(/^mailto:/, '')
-                if (options.noAnchorUrl && href[0] === '#') {
-                  return undefined
-                }
-                return options.linkHrefBaseUrl && href[0] === '/'
-                  ? options.linkHrefBaseUrl + href
-                  : href
-              }
-              function getText() {
-                return fn(elem.children, options) || ''
-              }
-
-              const storedCharCount = options.lineCharCount
-              const text = getText()
-              const href = getHref()
-              function normalizeUrl(url = '') {
-                return url
-                  .replace(/\s+/g, '')
-                  .replace(/^(https?:\/\/)?(www\.)?/, '')
-                  .replace('{{frontend_base_url}}', 'republik.ch')
-              }
-              const toHideSameLink =
-                href && normalizeUrl(href) === normalizeUrl(text)
-
-              const result =
-                toHideSameLink || !text ? href + ' ' : text + ' ' + href + ' '
-
-              options.lineCharCount = storedCharCount
-              return defaultFormat.text({ data: result, type: 'text' }, options)
-            },
+          decodeOptions: {
+            strict: true,
           },
+          formatters: {
+            formatAnchorRepublik
+          },
+          tags: {
+            img: {
+              format: 'skip'
+            },
+            a: {
+              format: 'formatAnchorRepublik',
+              options: {
+                noLinkBrackets: true,
+                hideLinkHrefIfSameAsText: true
+              }
+            }
+          }
         })
-        .replace(/^ /gm, ''),
+        ,
       { encoding: 'utf8', flag: 'w' },
     )
   }).then(() => {

--- a/packages/mail/templates/access_granter_claim_notice.txt
+++ b/packages/mail/templates/access_granter_claim_notice.txt
@@ -1,6 +1,6 @@
 Guten Tag
 
-Der von Ihnen vermittelte Republik-Testzugang wurde soeben von 
+Der von Ihnen vermittelte Republik-Testzugang wurde soeben von
 {{recipient_name}} eingelöst.
 
 Herzlichen Dank für Ihre Vermittlungsarbeit!
@@ -15,9 +15,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/access_granter_claim_notice_gifted_membership.txt
+++ b/packages/mail/templates/access_granter_claim_notice_gifted_membership.txt
@@ -16,9 +16,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/access_recipient_expired.txt
+++ b/packages/mail/templates/access_recipient_expired.txt
@@ -1,10 +1,13 @@
 Guten Tag
 
-{{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}} Seit dem {{GRANT_BEGIN}} durften wir
-Sie dank einer Empfehlung von {{GRANTER_NAME}} probeweise als Leserin oder Leser
-an Bord der Republik haben.
+{{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}}
 
-{{/if}} Hat Ihnen unser Magazin gefallen?
+Seit dem {{GRANT_BEGIN}} durften wir Sie dank einer Empfehlung von
+{{GRANTER_NAME}} probeweise als Leserin oder Leser an Bord der Republik haben.
+
+{{/if}}
+
+Hat Ihnen unser Magazin gefallen?
 
 Finden Sie unsere Idee eines unabhängigen und werbefreien digitalen Magazins für
 Politik, Wirtschaft, Gesellschaft und Kultur auch unterstützenswert?
@@ -32,35 +35,34 @@ besten einfach ein (unbegrenztes) Monatsabo ab.
 
 Die Republik-Abonnemente/-Mitgliedschaften in der Übersicht:
 
-1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat Verlängert sich
-   automatisch, kann aber jederzeit und ohne Frist gekündigt werden. Mit diesem
-   Abo erhalten Sie viel Kontext und Vertiefung – ohne dass Sie Teil unserer
-   Genossenschaft werden.
-   
-   
-2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr Verlängert sich nicht
-   automatisch, wir erinnern Sie aber immer rechtzeitig daran, die
-   Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten Sie
-   unabhängigen und werbefreien Qualitätsjournalismus und sind gleichzeitig
-   Teil der Republik-Community und der Project R Genossenschaft.
-   
-   
-3. Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr Verlängert
-   sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran, die
-   Gönnerschaft zu erneuern. Mit der Gönnerschaft erhalten Sie Zugang zum
-   vollständigen Republik-Angebot, ein Extra-Dankeschön in Form eines Buches
-   und die Sicherheit, etwas sehr Wichtiges zur Erhaltung einer wirklich freien
-   Demokratie beigetragen zu haben. Zudem sind Sie Teil der Republik-Community
-   und der Project R Genossenschaft.
-   
-   
-4. Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} CHF 140.–/Jahr 
-   Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
-   die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten alle
-   Auszubildenden und Studierenden Zugang zum vollständigen Republik-Angebot
-   inklusive Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
-   
-   
+ 1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat
+    
+    Verlängert sich automatisch, kann aber jederzeit und ohne Frist gekündigt
+    werden. Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass
+    Sie Teil unserer Genossenschaft werden.
+
+ 2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr
+    
+    Verlängert sich nicht automatisch, wir erinnern Sie aber immer rechtzeitig
+    daran, die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten
+    Sie unabhängigen und werbefreien Qualitätsjournalismus und sind gleichzeitig
+    Teil der Republik-Community und der Project R Genossenschaft.
+
+ 3. Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr
+    
+    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
+    die Gönnerschaft zu erneuern. Mit der Gönnerschaft erhalten Sie Zugang zum
+    vollständigen Republik-Angebot, ein Extra-Dankeschön in Form eines Buches
+    und die Sicherheit, etwas sehr Wichtiges zur Erhaltung einer wirklich freien
+    Demokratie beigetragen zu haben. Zudem sind Sie Teil der Republik-Community
+    und der Project R Genossenschaft.
+
+ 4. Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} CHF 140.–/Jahr
+    
+    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
+    die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten alle
+    Auszubildenden und Studierenden Zugang zum vollständigen Republik-Angebot
+    inklusive Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
 
 Haben Sie Fragen oder brauchen Sie Hilfe? Unter kontakt@republik.ch helfen wir
 Ihnen gerne weiter.
@@ -76,9 +78,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/access_recipient_expired_winback.txt
+++ b/packages/mail/templates/access_recipient_expired_winback.txt
@@ -1,7 +1,7 @@
 Guten Tag
 
 Seit dem {{GRANT_BEGIN}} durften wir Sie für ein weiteres Mal als Leserin oder
-Leser an Bord der Republik haben. 
+Leser an Bord der Republik haben.
 
 Hat Ihnen unser Magazin gefallen?
 
@@ -35,7 +35,7 @@ wollen, sondern nur Zugriff aufs Magazin haben möchten, schliessen Sie am beste
 einfach ein (unbegrenztes) Monatsabo ab.
 
 Hier finden Sie die Abonnemente und Mitgliedschaften in der Übersicht
-{{link_offers_overview}} . 
+{{link_offers_overview}} .
 
 Wir freuen uns auf Sie!
 
@@ -50,9 +50,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/access_recipient_followup.txt
+++ b/packages/mail/templates/access_recipient_followup.txt
@@ -1,10 +1,14 @@
 Guten Tag
 
-{{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}} Am {{GRANT_BEGIN}} hat
-{{GRANTER_NAME}} mit Ihnen das Republik-Abonnement geteilt.
+{{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}}
 
-{{/if}} Für einen Einblick in unser unabhängiges, werbefreies digitales Magazin
-für Politik, Wirtschaft, Gesellschaft und Kultur. Und in unser Projekt gegen den
+Am {{GRANT_BEGIN}} hat {{GRANTER_NAME}} mit Ihnen das Republik-Abonnement
+geteilt.
+
+{{/if}}
+
+Für einen Einblick in unser unabhängiges, werbefreies digitales Magazin für
+Politik, Wirtschaft, Gesellschaft und Kultur. Und in unser Projekt gegen den
 Zynismus, den Vormarsch der Autoritären und gegen die Diktatur der Angst.
 
 Die Republik bietet Einordnung und Vertiefung anstelle einer Flut von
@@ -30,37 +34,36 @@ besten einfach ein (unbegrenztes) Monatsabo ab.
 
 Die Republik-Abonnemente/-Mitgliedschaften in der Übersicht:
 
-1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat Verlängert sich
-   automatisch, kann aber jederzeit und ohne Frist gekündigt werden. Mit diesem
-   Abo erhalten Sie viel Kontext und Vertiefung – ohne dass Sie Teil unserer
-   Genossenschaft werden.
-   
-   
-2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr Verlängert sich nicht
-   automatisch, wir erinnern Sie aber immer rechtzeitig daran, die
-   Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten Sie
-   unabhängigen und werbefreien Qualitätsjournalismus und sind gleichzeitig
-   Teil der Republik-Community und der Project R Genossenschaft.
-   
-   
-3. Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr Verlängert
-   sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran, die
-   Gönnerschaft zu erneuern. Mit der Gönnerschaft erhalten Sie Zugang zum
-   vollständigen Republik-Angebot, ein Extra-Dankeschön in Form eines Buches
-   und die Sicherheit, etwas sehr Wichtiges zur Erhaltung einer wirklich freien
-   Demokratie beigetragen zu haben. Zudem sind Sie Teil der Republik-Community
-   und der Project R Genossenschaft.
-   
-   
-4. Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} CHF 140.–/Jahr 
-   Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
-   die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten alle
-   Auszubildenden und Studierenden Zugang zum vollständigen Republik-Angebot
-   inklusive Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
-   
-   
+ 1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat
+    
+    Verlängert sich automatisch, kann aber jederzeit und ohne Frist gekündigt
+    werden. Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass
+    Sie Teil unserer Genossenschaft werden.
 
-Ob Sie dazugehören wollen, ist nun Ihre Entscheidung. {{link_offers_overview}} 
+ 2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr
+    
+    Verlängert sich nicht automatisch, wir erinnern Sie aber immer rechtzeitig
+    daran, die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten
+    Sie unabhängigen und werbefreien Qualitätsjournalismus und sind gleichzeitig
+    Teil der Republik-Community und der Project R Genossenschaft.
+
+ 3. Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr
+    
+    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
+    die Gönnerschaft zu erneuern. Mit der Gönnerschaft erhalten Sie Zugang zum
+    vollständigen Republik-Angebot, ein Extra-Dankeschön in Form eines Buches
+    und die Sicherheit, etwas sehr Wichtiges zur Erhaltung einer wirklich freien
+    Demokratie beigetragen zu haben. Zudem sind Sie Teil der Republik-Community
+    und der Project R Genossenschaft.
+
+ 4. Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} CHF 140.–/Jahr
+    
+    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
+    die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten alle
+    Auszubildenden und Studierenden Zugang zum vollständigen Republik-Angebot
+    inklusive Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
+
+Ob Sie dazugehören wollen, ist nun Ihre Entscheidung. {{link_offers_overview}}
 
 Haben Sie noch Fragen? kontakt@republik.ch .
 
@@ -76,9 +79,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/access_recipient_followup_winback.txt
+++ b/packages/mail/templates/access_recipient_followup_winback.txt
@@ -13,7 +13,7 @@ Die Republik ist aber viel mehr als nur ein Magazin.
 Bei uns sind inhaltliche Debatten mit Expertinnen, Lesern und Journalistinnen
 nicht nur ein demokratischer Traum. Mit verschiedenen Veranstaltungen zu
 Politik, Gesellschaft und Kultur und mit unserer Genossenschaft sind wir und
-schaffen wir Gemeinschaft, ermöglichen wir Austausch und Verbindungen. 
+schaffen wir Gemeinschaft, ermöglichen wir Austausch und Verbindungen.
 
 Wir sind ein Projekt gegen den Zynismus, den Vormarsch der Autoritären und gegen
 die Diktatur der Angst. Und wir stehen für die Verteidigung der demokratischen
@@ -36,10 +36,10 @@ Uns würde es sehr freuen. Es dauert auch nicht länger als fünf Minuten:
 Lieber nicht?
 Schade!
 Vielleicht teilen Sie uns in einer E-Mail den Grund dafür mit? Als junges Medium
-und Unternehmen können wir noch einiges lernen und schätzen Ihre Kritik sehr! 
+und Unternehmen können wir noch einiges lernen und schätzen Ihre Kritik sehr!
 
-Auch bei weiteren Fragen und Anliegen stehen wir Ihnen gerne zur Verfügung: 
-kontakt@republik.ch 
+Auch bei weiteren Fragen und Anliegen stehen wir Ihnen gerne zur Verfügung:
+kontakt@republik.ch
 
 Herzlich
 
@@ -53,9 +53,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/access_recipient_invitation.html
+++ b/packages/mail/templates/access_recipient_invitation.html
@@ -68,6 +68,39 @@
                     </p>
                     {{/if}}
 
+                    <table
+                      width="100%"
+                      border="0"
+                      cellspacing="0"
+                      cellpadding="0"
+                    >
+                      <tr>
+                        <td>
+                          <table border="0" cellspacing="0" cellpadding="0">
+                            <tr>
+                              <td align="center" bgcolor="#3CAD00">
+                                <a
+                                  href="{{LINK_CLAIM_PREFILLED}}"
+                                  style="font-size:20px;{{sg_font_style_sans_serif_regular}}color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;"
+                                  >Jetzt anmelden</a
+                                >
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+                    <p>
+                      Falls dieser Button nicht funktioniert: Öffnen Sie bitte
+                      <a href="{{LINK_CLAIM_PREFILLED}}"
+                        >{{LINK_CLAIM_CONTEXTLESS}}</a
+                      >, und geben Sie dann Ihren Namen, Ihre E-Mail-Adresse und
+                      den folgenden Gutscheincode ein:
+                      <span style="font-family: monospace"
+                        >{{GRANT_VOUCHER_CODE}}</span
+                      >. Der Gutscheincode ist gültig bis zum {{GRANT_BEGIN_BEFORE}}.
+                    </p>
+
                     <p>
                       Die Republik erscheint von Montag bis Samstag mit täglich
                       ein bis drei neuen Beiträgen.
@@ -99,43 +132,6 @@
                       Lösungen von Fall zu Fall, für Offenheit gegenüber Kritik,
                       für Respektlosigkeit gegenüber der Macht und Respekt vor
                       dem Menschen.
-                    </p>
-
-                    <p>
-                      Um die Republik näher kennenzulernen, melden Sie sich
-                      einfach vor dem {{GRANT_BEGIN_BEFORE}} hier an:
-                    </p>
-                    <table
-                      width="100%"
-                      border="0"
-                      cellspacing="0"
-                      cellpadding="0"
-                    >
-                      <tr>
-                        <td>
-                          <table border="0" cellspacing="0" cellpadding="0">
-                            <tr>
-                              <td align="center" bgcolor="#3CAD00">
-                                <a
-                                  href="{{LINK_CLAIM_PREFILLED}}"
-                                  style="font-size:20px;{{sg_font_style_sans_serif_regular}}color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;"
-                                  >Jetzt anmelden</a
-                                >
-                              </td>
-                            </tr>
-                          </table>
-                        </td>
-                      </tr>
-                    </table>
-                    <p>
-                      Falls dieser Button nicht funktioniert: Öffnen Sie bitte
-                      <a href="{{LINK_CLAIM_PREFILLED}}"
-                        >{{LINK_CLAIM_CONTEXTLESS}}</a
-                      >, und geben Sie dann Ihren Namen, Ihre E-Mail-Adresse und
-                      den folgenden Gutscheincode ein:
-                      <span style="font-family: monospace"
-                        >{{GRANT_VOUCHER_CODE}}</span
-                      >
                     </p>
                     {{/unless}} {{#if RECIPIENT_HAS_MEMBERSHIPS}}
                     <p>

--- a/packages/mail/templates/access_recipient_invitation.txt
+++ b/packages/mail/templates/access_recipient_invitation.txt
@@ -1,20 +1,27 @@
 Guten Tag
 
-{{#unless RECIPIENT_HAS_MEMBERSHIPS}} {{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}} 
+{{#unless RECIPIENT_HAS_MEMBERSHIPS}} {{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}}
+
 {{GRANTER_NAME}} ({{GRANTER_EMAIL}} ) hat die Republik – ein neues, unabhängiges
 und werbefreies digitales Magazin für Politik, Wirtschaft, Gesellschaft und
-Kultur – mit Ihnen geteilt. 
+Kultur – mit Ihnen geteilt.
 
-{{#if GRANTER_MESSAGE}} Und uns eine Nachricht für Sie mitgegeben:
+{{#if GRANTER_MESSAGE}}
+
+Und uns eine Nachricht für Sie mitgegeben:
 
 > {{{GRANTER_MESSAGE}}}
-{{/if}} {{/if}} {{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}} Für
-{{CAMPAIGN_PERIOD}} sind Sie jetzt Gast an Bord der Republik. Und können unser
-Magazin entdecken, es lesen, sehen und hören.
 
-{{/if}} Die Republik erscheint von Montag bis Samstag mit täglich ein bis drei
-neuen Beiträgen. In der Republik-App {{link_manual}} , auf der Website
-{{link_signin}} und als Newsletter.
+{{/if}} {{/if}} {{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}}
+
+Für {{CAMPAIGN_PERIOD}} sind Sie jetzt Gast an Bord der Republik. Und können
+unser Magazin entdecken, es lesen, sehen und hören.
+
+{{/if}}
+
+Die Republik erscheint von Montag bis Samstag mit täglich ein bis drei neuen
+Beiträgen. In der Republik-App {{link_manual}} , auf der Website {{link_signin}}
+und als Newsletter.
 
 Als Magazin bieten wir Einordnung und Vertiefung anstelle einer Flut von
 Nachrichten. Wir recherchieren, um Missstände aufzudecken, oft monatelang. Und
@@ -35,25 +42,37 @@ der Macht und Respekt vor dem Menschen.
 Um die Republik näher kennenzulernen, melden Sie sich einfach vor dem
 {{GRANT_BEGIN_BEFORE}} hier an:
 
-Jetzt anmelden {{LINK_CLAIM_PREFILLED}} Falls dieser Button nicht funktioniert:
-Öffnen Sie bitte {{LINK_CLAIM_CONTEXTLESS}} {{LINK_CLAIM_PREFILLED}} , und geben
-Sie dann Ihren Namen, Ihre E-Mail-Adresse und den folgenden Gutscheincode ein: 
-{{GRANT_VOUCHER_CODE}} 
+Jetzt anmelden {{LINK_CLAIM_PREFILLED}}
 
-{{/unless}} {{#if RECIPIENT_HAS_MEMBERSHIPS}} Sie erhalten diese E-Mail im
-Rahmen unserer Aktion «{{CAMPAIGN_TITLE}}».
+Falls dieser Button nicht funktioniert: Öffnen Sie bitte
+{{LINK_CLAIM_PREFILLED}} , und geben Sie dann Ihren Namen, Ihre E-Mail-Adresse
+und den folgenden Gutscheincode ein: {{GRANT_VOUCHER_CODE}}
 
-{{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}} {{GRANTER_NAME}} geht davon aus, dass
-Sie noch kein Republik-Abo besitzen. Dabei befinden Sie sich als Besitzerin oder
-Besitzer eines Abos bereits an Bord – vielen Dank dafür!
+{{/unless}} {{#if RECIPIENT_HAS_MEMBERSHIPS}}
 
-{{else}} Sie haben aber bereits ein gültiges Abo – vielen Dank dafür!
+Sie erhalten diese E-Mail im Rahmen unserer Aktion «{{CAMPAIGN_TITLE}}».
 
-{{/if}} {{#if RECIPIENT_HAS_CAMPAIGNS}} Sie können Ihr Abo auch mit anderen Personen teilen {{LINK_ACCOUNT_SHARE}} . Die
+{{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}}
+
+{{GRANTER_NAME}} geht davon aus, dass Sie noch kein Republik-Abo besitzen. Dabei
+befinden Sie sich als Besitzerin oder Besitzer eines Abos bereits an Bord –
+vielen Dank dafür!
+
+{{else}}
+
+Sie haben aber bereits ein gültiges Abo – vielen Dank dafür!
+
+{{/if}} {{#if RECIPIENT_HAS_CAMPAIGNS}}
+
+Sie können Ihr Abo auch mit anderen Personen teilen {{LINK_ACCOUNT_SHARE}} . Die
 Empfänger erhalten eine persönliche Einladung per E-Mail.
 
-Zugriff teilen {{LINK_ACCOUNT_SHARE}} {{/if}} {{/if}} Bei Fragen und Anliegen
-stehen wir Ihnen gerne unter kontakt@republik.ch zur Verfügung.
+Zugriff teilen {{LINK_ACCOUNT_SHARE}}
+
+{{/if}} {{/if}}
+
+Bei Fragen und Anliegen stehen wir Ihnen gerne unter kontakt@republik.ch zur
+Verfügung.
 
 Wir wünschen Ihnen viel Freude beim Lesen und Ausprobieren!
 
@@ -67,9 +86,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/access_recipient_invitation.txt
+++ b/packages/mail/templates/access_recipient_invitation.txt
@@ -19,6 +19,13 @@ unser Magazin entdecken, es lesen, sehen und hören.
 
 {{/if}}
 
+Jetzt anmelden {{LINK_CLAIM_PREFILLED}}
+
+Falls dieser Button nicht funktioniert: Öffnen Sie bitte
+{{LINK_CLAIM_PREFILLED}} , und geben Sie dann Ihren Namen, Ihre E-Mail-Adresse
+und den folgenden Gutscheincode ein: {{GRANT_VOUCHER_CODE}}. Der Gutscheincode
+ist gültig bis zum {{GRANT_BEGIN_BEFORE}}.
+
 Die Republik erscheint von Montag bis Samstag mit täglich ein bis drei neuen
 Beiträgen. In der Republik-App {{link_manual}} , auf der Website {{link_signin}}
 und als Newsletter.
@@ -38,15 +45,6 @@ die Diktatur der Angst. Wir stehen für die Verteidigung der demokratischen
 Institutionen und die Werte der Aufklärung: für Treue zu Fakten, für Lösungen
 von Fall zu Fall, für Offenheit gegenüber Kritik, für Respektlosigkeit gegenüber
 der Macht und Respekt vor dem Menschen.
-
-Um die Republik näher kennenzulernen, melden Sie sich einfach vor dem
-{{GRANT_BEGIN_BEFORE}} hier an:
-
-Jetzt anmelden {{LINK_CLAIM_PREFILLED}}
-
-Falls dieser Button nicht funktioniert: Öffnen Sie bitte
-{{LINK_CLAIM_PREFILLED}} , und geben Sie dann Ihren Namen, Ihre E-Mail-Adresse
-und den folgenden Gutscheincode ein: {{GRANT_VOUCHER_CODE}}
 
 {{/unless}} {{#if RECIPIENT_HAS_MEMBERSHIPS}}
 

--- a/packages/mail/templates/access_recipient_invitation_gifted_membership.txt
+++ b/packages/mail/templates/access_recipient_invitation_gifted_membership.txt
@@ -12,17 +12,22 @@ Wachstum beiträgt.
 Sie wurden von {{GRANTER_NAME}} ausgewählt und erhalten damit eine
 Jahresmitgliedschaft, im Wert von 240 Franken, geschenkt!
 
-{{#if GRANTER_MESSAGE}} {{GRANTER_NAME}} hat uns eine Nachricht für Sie
-mitgegeben:
+{{#if GRANTER_MESSAGE}}
+
+{{GRANTER_NAME}} hat uns eine Nachricht für Sie mitgegeben:
 
 > {{{GRANTER_MESSAGE}}}
-{{/if}} Um Ihre Jahresmitgliedschaft in Empfang zu nehmen, melden Sie sich
-einfach vor dem {{GRANT_BEGIN_BEFORE}} hier an:
 
-Jetzt aktivieren {{LINK_CLAIM_PREFILLED}} Falls dieser Button nicht
-funktioniert: Öffnen Sie bitte {{LINK_CLAIM_CONTEXTLESS}}
+{{/if}}
+
+Um Ihre Jahresmitgliedschaft in Empfang zu nehmen, melden Sie sich einfach vor
+dem {{GRANT_BEGIN_BEFORE}} hier an:
+
+Jetzt aktivieren {{LINK_CLAIM_PREFILLED}}
+
+Falls dieser Button nicht funktioniert: Öffnen Sie bitte
 {{LINK_CLAIM_PREFILLED}} , und geben Sie dann Ihren Namen, Ihre E-Mail-Adresse
-und den folgenden Gutscheincode ein: {{GRANT_VOUCHER_CODE}} 
+und den folgenden Gutscheincode ein: {{GRANT_VOUCHER_CODE}}
 
 Sollten Sie schon in den nächsten Tagen oder Monaten so überzeugt sein, dass Sie
 der Republik-Community etwas zurückgeben wollen: Sie können jederzeit eine
@@ -42,9 +47,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/access_recipient_onboarding.txt
+++ b/packages/mail/templates/access_recipient_onboarding.txt
@@ -3,11 +3,14 @@ Guten Tag
 Und willkommen an Bord!
 Wir freuen uns sehr, Sie bei der Republik begrüssen zu dürfen.
 
-{{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}} Für {{CAMPAIGN_PERIOD}} sind Sie
-jetzt Gast an Bord der Republik. Und können unser Magazin entdecken, es lesen,
-sehen, hören und mitdiskutieren.
+{{#if `RECIPIENT_EMAIL != GRANTER_EMAIL`}}
 
-{{/if}} Nachfolgend finden Sie die wichtigsten Informationen zur Republik:
+Für {{CAMPAIGN_PERIOD}} sind Sie jetzt Gast an Bord der Republik. Und können
+unser Magazin entdecken, es lesen, sehen, hören und mitdiskutieren.
+
+{{/if}}
+
+Nachfolgend finden Sie die wichtigsten Informationen zur Republik:
 
 Die Republik erscheint von Montag bis Samstag mit täglich ein bis drei neuen
 Beiträgen. In der Republik-App {{link_app}} , auf der Website
@@ -44,35 +47,34 @@ besten einfach ein (unbegrenztes) Monatsabo ab.
 
 Die Republik-Abonnemente/-Mitgliedschaften in der Übersicht:
 
-1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat Verlängert sich
-   automatisch, kann aber jederzeit und ohne Frist gekündigt werden. Mit diesem
-   Abo erhalten Sie viel Kontext und Vertiefung – ohne dass Sie Teil unserer
-   Genossenschaft werden.
-   
-   
-2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr Verlängert sich nicht
-   automatisch, wir erinnern Sie aber immer rechtzeitig daran, die
-   Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten Sie
-   unabhängigen und werbefreien Qualitätsjournalismus und sind gleichzeitig
-   Teil der Republik-Community und der Project R Genossenschaft.
-   
-   
-3. Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr Verlängert
-   sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran, die
-   Gönnerschaft zu erneuern. Mit der Gönnerschaft erhalten Sie Zugang zum
-   vollständigen Republik-Angebot, ein Extra-Dankeschön in Form eines Buches
-   und die Sicherheit, etwas sehr Wichtiges zur Erhaltung einer wirklich freien
-   Demokratie beigetragen zu haben. Zudem sind Sie Teil der Republik-Community
-   und der Project R Genossenschaft.
-   
-   
-4. Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} CHF 140.–/Jahr 
-   Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
-   die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten alle
-   Auszubildenden und Studierenden Zugang zum vollständigen Republik-Angebot
-   inklusive Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
-   
-   
+ 1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat
+    
+    Verlängert sich automatisch, kann aber jederzeit und ohne Frist gekündigt
+    werden. Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass
+    Sie Teil unserer Genossenschaft werden.
+
+ 2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr
+    
+    Verlängert sich nicht automatisch, wir erinnern Sie aber immer rechtzeitig
+    daran, die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten
+    Sie unabhängigen und werbefreien Qualitätsjournalismus und sind gleichzeitig
+    Teil der Republik-Community und der Project R Genossenschaft.
+
+ 3. Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr
+    
+    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
+    die Gönnerschaft zu erneuern. Mit der Gönnerschaft erhalten Sie Zugang zum
+    vollständigen Republik-Angebot, ein Extra-Dankeschön in Form eines Buches
+    und die Sicherheit, etwas sehr Wichtiges zur Erhaltung einer wirklich freien
+    Demokratie beigetragen zu haben. Zudem sind Sie Teil der Republik-Community
+    und der Project R Genossenschaft.
+
+ 4. Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} CHF 140.–/Jahr
+    
+    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
+    die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten alle
+    Auszubildenden und Studierenden Zugang zum vollständigen Republik-Angebot
+    inklusive Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
 
 Haben Sie Fragen oder brauchen Sie Hilfe? Unter kontakt@republik.ch helfen wir
 Ihnen gerne weiter.
@@ -89,9 +91,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/access_recipient_onboarding_gifted_membership.txt
+++ b/packages/mail/templates/access_recipient_onboarding_gifted_membership.txt
@@ -7,16 +7,21 @@ Ihre Mitgliedschaft wurde von unseren Verlegerinnen finanziert in der Hoffnung,
 dass Sie die Republik kennen und schätzen lernen und hoffentlich zu einem treuen
 Mitglied der Republik werden.
 
-{{#if pledger_name}} {{#unless message_to_claimer}} Die grosszügige Person, die
-Ihnen die Mitgliedschaft geschenkt hat, heisst {{pledger_name}}.
+{{#if pledger_name}} {{#unless message_to_claimer}}
 
-{{/unless}} {{#if message_to_claimer}} Die grosszügige Person, die Ihnen die
-Mitgliedschaft geschenkt hat, heisst {{pledger_name}} und hat Ihnen folgende
-Nachricht hinterlassen:
+Die grosszügige Person, die Ihnen die Mitgliedschaft geschenkt hat, heisst
+{{pledger_name}}.
+
+{{/unless}} {{#if message_to_claimer}}
+
+Die grosszügige Person, die Ihnen die Mitgliedschaft geschenkt hat, heisst
+{{pledger_name}} und hat Ihnen folgende Nachricht hinterlassen:
 
 > {{{message_to_claimer}}}
-{{/if}} {{/if}} Nachfolgend finden Sie die wichtigsten Informationen zur
-Republik:
+
+{{/if}} {{/if}}
+
+Nachfolgend finden Sie die wichtigsten Informationen zur Republik:
 
 Die Republik erscheint von Montag bis Samstag mit täglich ein bis drei neuen
 Beiträgen. In der Republik-App {{link_app}} , auf der Website
@@ -46,9 +51,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/cf_comment_notification_new.txt
+++ b/packages/mail/templates/cf_comment_notification_new.txt
@@ -1,38 +1,29 @@
 {{COMMENTER_NAME}} schreibt:
 
----
+{{{CONTENT_HTML}}}
 
-{{CONTENT_PLAIN}}
-
----
-
-Den Beitrag im Kontext auf republik.ch anzeigen: 
-{{URL}} 
-
-Dort können Sie antworten und weiter debattieren.
+{{URL}} . Dort können Sie antworten und weiter debattieren.
 
 
-Sie erhalten diese E-Mail, weil Sie an der Debatte «{{DISCUSSION_TITLE}}» {{DISCUSSION_URL}} teilgenommen haben und/oder Benachrichtigungen für diese
-abonniert haben. 
+Sie erhalten diese E-Mail, weil Sie an der Debatte «{{DISCUSSION_URL}} »
+teilgenommen haben und/oder Benachrichtigungen für diese abonniert haben.
 
-Hier können Sie die Benachrichtigungen zu dieser Debatte deaktivieren:
-{{DISCUSSION_MUTE_URL}}
-
-Und falls Sie gar keine Benachrichtigungen per E-Mail
-mehr erhalten möchten, können Sie dies in Ihrem Konto festlegen:
-{{link_account_notifications}}
+Hier können Sie die Benachrichtigungen zu dieser Debatte deaktivieren
+{{DISCUSSION_MUTE_URL}} . Und falls Sie gar keine Benachrichtigungen per E-Mail
+mehr erhalten möchten, können Sie dies in Ihrem Konto festlegen
+{{link_account_notifications}} .
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/cf_email_change_new_address.txt
+++ b/packages/mail/templates/cf_email_change_new_address.txt
@@ -12,14 +12,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/cf_email_change_old_address.txt
+++ b/packages/mail/templates/cf_email_change_old_address.txt
@@ -2,8 +2,8 @@ Guten Tag
 
 Ihre E-Mail-Adresse wurde geändert und lautet nun: {{EMAIL}}
 
-Falls dies nicht in Ihrem Sinn ist, melden Sie sich bitte umgehend bei uns: 
-kontakt@republik.ch 
+Falls dies nicht in Ihrem Sinn ist, melden Sie sich bitte umgehend bei uns:
+kontakt@republik.ch
 
 Herzlich
 
@@ -12,14 +12,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/cf_faq.txt
+++ b/packages/mail/templates/cf_faq.txt
@@ -2,8 +2,10 @@ Guten Tag
 
 Herzlichen Dank für die folgende Frage:
 
-{{QUESTION}} Wir kümmern uns umgehend darum. Eine Antwort finden Sie schon bald
-in Ihrer Mailbox!
+{{QUESTION}}
+
+Wir kümmern uns umgehend darum. Eine Antwort finden Sie schon bald in Ihrer
+Mailbox!
 
 Herzlich
 
@@ -12,14 +14,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/cf_payment_reminder.txt
+++ b/packages/mail/templates/cf_payment_reminder.txt
@@ -21,29 +21,35 @@ Dürfen wir Sie freundlich bitten, den Betrag in den nächsten Tagen zu
 Bitte geben Sie bei der Zahlung Ihren Namen und den folgenden Code als
 Zahlungszweck an (so können wir Ihre Zahlung zuordnen): {{HRID}}
 
-{{#if `COMPANY_NAME == "REPUBLIK"`}} PC 61-229215-3
+{{#if `COMPANY_NAME == "REPUBLIK"`}}
+
+PC 61-229215-3
 IBAN: CH23 0900 0000 6122 9215 3
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
 lautend auf:
 
 Republik AG
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
-{{/if}} {{#if `COMPANY_NAME == "PROJECT_R"`}} PC 61-11760-6
+{{/if}} {{#if `COMPANY_NAME == "PROJECT_R"`}}
+
+PC 61-11760-6
 IBAN: CH50 0900 0000 6101 1760 6
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
 lautend auf:
 
 Project R Genossenschaft
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
-{{/if}} Sollte sich Ihre Überweisung mit dieser Zahlungserinnerung kreuzen,
-erachten Sie unsere E-Mail als gegenstandslos. Haben Sie sonst Fragen, melden
-Sie sich jederzeit unter kontakt@republik.ch .
+{{/if}}
+
+Sollte sich Ihre Überweisung mit dieser Zahlungserinnerung kreuzen, erachten Sie
+unsere E-Mail als gegenstandslos. Haben Sie sonst Fragen, melden Sie sich
+jederzeit unter kontakt@republik.ch .
 
 Herzlich
 Ihre Crew der Republik
@@ -51,14 +57,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/cf_payment_reminder_last.txt
+++ b/packages/mail/templates/cf_payment_reminder_last.txt
@@ -10,28 +10,34 @@ Dürfen wir Sie freundlich bitten, den Betrag in den nächsten Tagen zu
 Bitte geben Sie bei der Zahlung Ihren Namen und den folgenden Code als
 Zahlungszweck an (so können wir Ihre Zahlung zuordnen): {{HRID}}
 
-{{#if `COMPANY_NAME == "REPUBLIK"`}} PC 61-229215-3
+{{#if `COMPANY_NAME == "REPUBLIK"`}}
+
+PC 61-229215-3
 IBAN: CH23 0900 0000 6122 9215 3
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
 lautend auf:
 
 Republik AG
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
-{{/if}} {{#if `COMPANY_NAME == "PROJECT_R"`}} PC 61-11760-6
+{{/if}} {{#if `COMPANY_NAME == "PROJECT_R"`}}
+
+PC 61-11760-6
 IBAN: CH50 0900 0000 6101 1760 6
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
 lautend auf:
 
 Project R Genossenschaft
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
-{{/if}} Sollte sich Ihre Zahlung mit dieser Zahlungserinnerung kreuzen, erachten
-Sie unsere E-Mail als gegenstandslos. Haben Sie sonst Fragen, melden Sie sich
+{{/if}}
+
+Sollte sich Ihre Zahlung mit dieser Zahlungserinnerung kreuzen, erachten Sie
+unsere E-Mail als gegenstandslos. Haben Sie sonst Fragen, melden Sie sich
 jederzeit unter kontakt@republik.ch .
 
 Wenn wir Ihre Zahlung in den nächsten 30 Tagen nicht erhalten, gehen wir davon
@@ -44,14 +50,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/cf_successful_payment.txt
+++ b/packages/mail/templates/cf_successful_payment.txt
@@ -4,10 +4,12 @@ Ihre Zahlung ist erfolgreich bei uns eingegangen.
 
 Herzlichen Dank! Lang lebe die Republik!
 
-Hier finden Sie die Details: https://www.republik.ch/merci 
+Hier finden Sie die Details: https://www.republik.ch/merci
 
-{{#if VOUCHER_CODES}} Gratulation für Ihre Grossherzigkeit: Sie verschenken die
-Republik. Sie erhalten pro Geschenk-Abonnement einen Sechs-Zeichen-Code. Hier:
+{{#if VOUCHER_CODES}}
+
+Gratulation für Ihre Grossherzigkeit: Sie verschenken die Republik. Sie erhalten
+pro Geschenk-Abonnement einen Sechs-Zeichen-Code. Hier:
 
 {{VOUCHER_CODES}}
 
@@ -15,16 +17,22 @@ Sie können diesen der Person Ihrer Wahl mit einem Mittel Ihrer Wahl überreiche
 sofort per Mail, traditionell per Briefpost, originell als Schrift auf einem
 Kuchen oder mit einem Spezialflugzeug an den Himmel geschrieben.
 
-{{#if NOTEBOOK_OR_TOADBAG}} Wie der Zufall spielt, eignen sich auch das
-Republik-Notizbuch oder die Republik-Tasche perfekt für die Code-Übergabe. Sie
-werden diese per Post zugeschickt bekommen. Stellen Sie dafür bitte sicher, dass
-Sie Ihre Adresse unter https://www.republik.ch/merci korrekt eingetragen haben.
+{{#if NOTEBOOK_OR_TOADBAG}}
 
-{{/if}} Um das Geschenk einzulösen, muss der neue Besitzer, die neue Besitzerin
-des Codes auf die Seite https://www.republik.ch/claim gehen. Und die sechs
-Zeichen dort eintippen.
+Wie der Zufall spielt, eignen sich auch das Republik-Notizbuch oder die
+Republik-Tasche perfekt für die Code-Übergabe. Sie werden diese per Post
+zugeschickt bekommen. Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
+unter https://www.republik.ch/merci korrekt eingetragen haben.
 
-{{/if}} Mit freundlichen Grüssen,
+{{/if}}
+
+Um das Geschenk einzulösen, muss der neue Besitzer, die neue Besitzerin des
+Codes auf die Seite https://www.republik.ch/claim gehen. Und die sechs Zeichen
+dort eintippen.
+
+{{/if}}
+
+Mit freundlichen Grüssen,
 
 Ihre Crew von Project R und Republik
 

--- a/packages/mail/templates/membership_cancel_notice.txt
+++ b/packages/mail/templates/membership_cancel_notice.txt
@@ -8,11 +8,14 @@ Wir haben Ihre Kündigung erfasst: Ihr Abonnement läuft noch theoretisch bis zu
 
 Herzlichen Dank für Ihr Interesse und Ihre Unterstützung bis hierhin!
 
-{{#if reason_given}} Auch für Ihre Kündigungs­begründung, aus der wir lernen
-können.
+{{#if reason_given}}
 
-{{/if}} Wir würden uns sehr freuen, wenn Sie zu einem späteren Zeitpunkt wieder
-bei uns vorbeischauten. Sie sind jederzeit willkommen.
+Auch für Ihre Kündigungs­begründung, aus der wir lernen können.
+
+{{/if}}
+
+Wir würden uns sehr freuen, wenn Sie zu einem späteren Zeitpunkt wieder bei uns
+vorbeischauten. Sie sind jederzeit willkommen.
 
 Herzlich
 
@@ -21,14 +24,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_deactivated_abo_uncancelled.txt
+++ b/packages/mail/templates/membership_deactivated_abo_uncancelled.txt
@@ -1,4 +1,5 @@
-Mitgliedschaft jetzt reaktivieren {{prolong_url}} 
+Mitgliedschaft jetzt reaktivieren {{prolong_url}}
+
 
 --------------------------------------------------------------------------------
 
@@ -30,7 +31,7 @@ kritischen Journalismus, die vierte Gewalt und unser Projekt gegen den Zynismus
 und die Diktatur der Angst. Einfach ohne dass Sie Teil unserer Genossenschaft
 sind.
 
-Und wenn Sie einen finanziellen Engpass haben, schreiben Sie uns auf 
+Und wenn Sie einen finanziellen Engpass haben, schreiben Sie uns auf
 kontakt@republik.ch . Wir finden eine Lösung!
 
 Sollte uns hingegen ein Fehler unterlaufen sein, nehmen Sie bitte ebenfalls so
@@ -43,14 +44,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_deactivated_benefactor_abo_uncancelled.txt
+++ b/packages/mail/templates/membership_deactivated_benefactor_abo_uncancelled.txt
@@ -1,4 +1,5 @@
-Mitgliedschaft jetzt reaktivieren {{prolong_url}} 
+Mitgliedschaft jetzt reaktivieren {{prolong_url}}
+
 
 --------------------------------------------------------------------------------
 
@@ -30,7 +31,7 @@ kritischen Journalismus, die vierte Gewalt und unser Projekt gegen den Zynismus
 und die Diktatur der Angst. Einfach ohne dass Sie Teil unserer Genossenschaft
 sind.
 
-Und wenn Sie einen finanziellen Engpass haben, schreiben Sie uns auf 
+Und wenn Sie einen finanziellen Engpass haben, schreiben Sie uns auf
 kontakt@republik.ch . Wir finden eine Lösung!
 
 Sollte uns hingegen ein Fehler unterlaufen sein, nehmen Sie bitte ebenfalls so
@@ -43,14 +44,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_giver_claim_notice.txt
+++ b/packages/mail/templates/membership_giver_claim_notice.txt
@@ -1,28 +1,33 @@
 Guten Tag
 
-{{#if `membership_type_interval == "month"`}} Das von Ihnen finanzierte
-Monats-Abo als Geschenk wurde soeben eingelöst: Dank Ihnen hat 
-{{recipient_name}} Zugang zur Republik.
+{{#if `membership_type_interval == "month"`}}
 
-{{else}} Die von Ihnen finanzierte Mitgliedschaft als Geschenk wurde soeben
-eingelöst: Dank Ihnen ist {{recipient_name}} nun ein Mitglied bei der Project R
+Das von Ihnen finanzierte Monats-Abo als Geschenk wurde soeben eingelöst: Dank
+Ihnen hat {{recipient_name}} Zugang zur Republik.
+
+{{else}}
+
+Die von Ihnen finanzierte Mitgliedschaft als Geschenk wurde soeben eingelöst:
+Dank Ihnen ist {{recipient_name}} nun ein Mitglied bei der Project R
 Genossenschaft und hat Zugang zur Republik.
 
-{{/if}} Herzlich
+{{/if}}
+
+Herzlich
 
 Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_giver_prolong_notice.txt
+++ b/packages/mail/templates/membership_giver_prolong_notice.txt
@@ -5,12 +5,18 @@ Herzlichen Dank für Ihre Grosszügigkeit und Ihr Vertrauen.
 Sie haben {{#if `gifted_memberships_count == 1`}}eine Mitgliedschaft{{elseif
 `gifted_memberships_count > 1`}}mehrere Mitgliedschaften{{/if}} verschenkt.
 
-{{#if `gifted_memberships_count == 1`}} Diese Mitgliedschaft endet bald.
+{{#if `gifted_memberships_count == 1`}}
 
-{{elseif `gifted_memberships_count > 1`}} Diese Mitgliedschaften enden bald.
+Diese Mitgliedschaft endet bald.
 
-{{/if}} Schenken Sie noch ein weiteres Jahr unabhängige und werbefreie
-Einordnung und Vertiefung anstelle einer Flut von Nachrichten?
+{{elseif `gifted_memberships_count > 1`}}
+
+Diese Mitgliedschaften enden bald.
+
+{{/if}}
+
+Schenken Sie noch ein weiteres Jahr unabhängige und werbefreie Einordnung und
+Vertiefung anstelle einer Flut von Nachrichten?
 
 Jede Mitgliedschaft unterstützt die Republik und die Idee hinter unserem Projekt
 einer wirklich unabhängigen vierten Gewalt und zentralen demokratischen
@@ -21,9 +27,9 @@ Folgende{{#if `gifted_memberships_count == 1`}} Mitgliedschaft steht{{elseif
 `gifted_memberships_count > 1`}} Mitgliedschaften stehen{{/if}} zur Verlängerung
 an:
 
-* 
-* {{this.olabel}}
-* 
+   {{#options}}
+ * {{this.olabel}}
+   {{/options}}
 
 Klicken Sie hier, um {{#if `gifted_memberships_count == 1`}}die
 Geschenkmitgliedschaft{{elseif `gifted_memberships_count > 1`}}die
@@ -44,14 +50,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_autopay_failed.txt
+++ b/packages/mail/templates/membership_owner_autopay_failed.txt
@@ -1,10 +1,12 @@
 Sehr geehrte Dame
-Sehr geehrter Herr 
+Sehr geehrter Herr
 
-{{#if `attempt_number == 3`}} Ihre Mitgliedschaft erneuerte sich am {{end_date}}
-um ein weiteres Jahr. Bedauerlicherweise konnten wir erneut den Jahresbeitrag
-von {{autopay_total}} Ihrer hinterlegten {{autopay_card_brand}}-Kreditkarte mit
-den Endziffern {{autopay_card_last4}} nicht belasten.
+{{#if `attempt_number == 3`}}
+
+Ihre Mitgliedschaft erneuerte sich am {{end_date}} um ein weiteres Jahr.
+Bedauerlicherweise konnten wir erneut den Jahresbeitrag von {{autopay_total}}
+Ihrer hinterlegten {{autopay_card_brand}}-Kreditkarte mit den Endziffern
+{{autopay_card_last4}} nicht belasten.
 
 Wir unternehmen am {{attempt_next_at}} einen letzten Versuch und bitten Sie, bis
 dahin Ihre Kreditkartendaten hier gegebenenfalls zu aktualisieren
@@ -16,11 +18,12 @@ wenn es für {{autopay_total}} nicht reicht, wollen Sie aber nicht verlieren. Si
 haben die Möglichkeit, die Höhe Ihres Mitgliederbeitrags selbst zu bestimmen
 {{prolong_url_reduced}} .
 
-{{elseif `attempt_number == 4`}} Ihre Mitgliedschaft erneuerte sich am
-{{end_date}} um ein weiteres Jahr. Trotz mehrfachen Versuchen konnten wir den
-Jahresbeitrag von {{autopay_total}} Ihrer hinterlegten
-{{autopay_card_brand}}-Kreditkarte mit den Endziffern {{autopay_card_last4}}
-nicht belasten.
+{{elseif `attempt_number == 4`}}
+
+Ihre Mitgliedschaft erneuerte sich am {{end_date}} um ein weiteres Jahr. Trotz
+mehrfachen Versuchen konnten wir den Jahresbeitrag von {{autopay_total}} Ihrer
+hinterlegten {{autopay_card_brand}}-Kreditkarte mit den Endziffern
+{{autopay_card_last4}} nicht belasten.
 
 Wir sehen uns daher zu unserem grossen Bedauern gezwungen, Ihre Mitgliedschaft
 am {{grace_end_date}} zu deaktivieren.
@@ -28,41 +31,53 @@ am {{grace_end_date}} zu deaktivieren.
 Wollen Sie dies verhindern, können Sie den ausstehenden Jahresbeitrag begleichen
 {{prolong_url}} , wenn Sie möchten, auch mit einer anderen Zahlungsart.
 
-{{else}} Ihre Mitgliedschaft erneuerte sich am {{end_date}} um ein weiteres
-Jahr. Bei Ihrem letzten Kauf haben Sie angegeben, dass Sie uns erlauben, Ihre
-hinterlegte Kreditkarte automatisch zu belasten. Bedauerlicherweise konnten wir
-den Jahresbeitrag von {{autopay_total}} von Ihrer hinterlegten
+{{else}}
+
+Ihre Mitgliedschaft erneuerte sich am {{end_date}} um ein weiteres Jahr. Bei
+Ihrem letzten Kauf haben Sie angegeben, dass Sie uns erlauben, Ihre hinterlegte
+Kreditkarte automatisch zu belasten. Bedauerlicherweise konnten wir den
+Jahresbeitrag von {{autopay_total}} von Ihrer hinterlegten
 {{autopay_card_brand}}-Kreditkarte mit den Endziffern {{autopay_card_last4}}
 nicht abbuchen.
 
-{{#if attempt_is_last}} Wir sehen uns daher zu unserem grossen Bedauern
-gezwungen, Ihre Mitgliedschaft am {{grace_end_date}} zu deaktivieren.
+{{#if attempt_is_last}}
 
-{{elseif attempt_next_is_last}} Wir unternehmen am {{attempt_next_at}} einen
-letzten Versuch und bitten Sie, bis dahin Ihre Kreditkartendaten hier
-gegebenenfalls zu aktualisieren {{prolong_url}} .
+Wir sehen uns daher zu unserem grossen Bedauern gezwungen, Ihre Mitgliedschaft
+am {{grace_end_date}} zu deaktivieren.
 
-{{else}} Wir unternehmen am {{attempt_next_at}} erneut einen Versuch und bitten
-Sie, bis dahin nötigenfalls eine neue Kreditkarte zu erfassen {{prolong_url}} .
+{{elseif attempt_next_is_last}}
 
-{{/if}} Vielleicht ziehen Sie inzwischen auch eine andere Zahlungsart vor? Sie können
+Wir unternehmen am {{attempt_next_at}} einen letzten Versuch und bitten Sie, bis
+dahin Ihre Kreditkartendaten hier gegebenenfalls zu aktualisieren
+{{prolong_url}} .
+
+{{else}}
+
+Wir unternehmen am {{attempt_next_at}} erneut einen Versuch und bitten Sie, bis
+dahin nötigenfalls eine neue Kreditkarte zu erfassen {{prolong_url}} .
+
+{{/if}}
+
+Vielleicht ziehen Sie inzwischen auch eine andere Zahlungsart vor? Sie können
 auch eine andere Zahlungsart angeben {{prolong_url}} .
 
-{{/if}} Herzlich
+{{/if}}
+
+Herzlich
 
 Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_autopay_notice.txt
+++ b/packages/mail/templates/membership_owner_autopay_notice.txt
@@ -1,5 +1,5 @@
 Sehr geehrte Dame
-Sehr geehrter Herr 
+Sehr geehrter Herr
 
 Am {{end_date}} erneuert sich Ihre Mitgliedschaft um ein weiteres Jahr.
 Herzlichen Dank für Ihre Unterstützung. Wir sind sehr froh, Sie an Bord zu
@@ -14,16 +14,20 @@ mit den Endziffern {{autopay_card_last4}} belasten wir am {{end_date}} mit
 {{autopay_total}}.
 
 {{#if `autopay_membership_type == "BENEFACTOR_ABO"`}} {{#if
-autopay_with_donation}} Dieser Beitrag kommt zustande, weil Sie die Republik im
-letzten Jahr grosszügigerweise mit einer Gönner-Mitgliedschaft und einer
-zusätzlichen Spende unterstützt haben. Durch Sie ist unsere Unabhängigkeit,
-unsere Werbefreiheit, ja unsere Existenz erst möglich. Wir bedanken uns von
-ganzem Herzen und hoffen, dass Sie sich und uns treu bleiben und weiterhin in
-kompromisslosen Journalismus investieren. Sollten Sie es sich anders überlegen,
-können Sie Ihre Mitgliedschaft beziehungsweise die Höhe Ihres Spendenbeitrags
-vor der Abbuchung noch anpassen {{prolong_url}} .
+autopay_with_donation}}
 
-{{else}} Dieser Beitrag kommt zustande, weil Sie die Republik im letzten Jahr
+Dieser Beitrag kommt zustande, weil Sie die Republik im letzten Jahr
+grosszügigerweise mit einer Gönner-Mitgliedschaft und einer zusätzlichen Spende
+unterstützt haben. Durch Sie ist unsere Unabhängigkeit, unsere Werbefreiheit, ja
+unsere Existenz erst möglich. Wir bedanken uns von ganzem Herzen und hoffen,
+dass Sie sich und uns treu bleiben und weiterhin in kompromisslosen Journalismus
+investieren. Sollten Sie es sich anders überlegen, können Sie Ihre
+Mitgliedschaft beziehungsweise die Höhe Ihres Spendenbeitrags vor der Abbuchung
+noch anpassen {{prolong_url}} .
+
+{{else}}
+
+Dieser Beitrag kommt zustande, weil Sie die Republik im letzten Jahr
 grosszügigerweise mit einer Gönner-Mitgliedschaft unterstützt haben. Durch Sie
 ist unsere Unabhängigkeit, unsere Werbefreiheit, ja unsere Existenz erst
 möglich. Wir bedanken uns von ganzem Herzen und hoffen, dass Sie sich und uns
@@ -31,29 +35,35 @@ treu bleiben und weiterhin in kompromisslosen Journalismus investieren. Sollten
 Sie es sich anders überlegen, können Sie Ihre Mitgliedschaft beziehungsweise die
 Höhe Ihres Spendenbeitrags vor der Abbuchung noch anpassen {{prolong_url}} .
 
-{{/if}} {{else}} {{#if autopay_with_discount}} Sie haben im letzten Jahr einen
-reduzierten Beitrag für Ihre Mitgliedschaft bezahlt. Da unsere Unabhängigkeit
-und Werbefreiheit, ja unsere Existenz von der Unterstützung unserer
-Verlegerinnen abhängt, wäre es grandios, wenn Sie Ihre Mitgliedschaft auf den
-regulären Beitrag von {{autopay_default_price}} anpassen {{prolong_url}} 
-könnten.
+{{/if}} {{else}} {{#if autopay_with_discount}}
 
-{{elseif autopay_with_donation}} Dieser Beitrag kommt zustande, weil Sie die
-Republik im letzten Jahr grosszügigerweise mit einer zusätzlichen Spende
-unterstützt haben. Durch Sie ist unsere Unabhängigkeit, unsere Werbefreiheit, ja
-unsere Existenz erst möglich. Wir bedanken uns von ganzem Herzen und hoffen,
-dass Sie sich und uns treu bleiben und weiterhin in kompromisslosen Journalismus
-investieren. Sollten Sie es sich anders überlegen, können Sie Ihre
-Mitgliedschaft beziehungsweise die Höhe Ihres Spendenbeitrags vor der Abbuchung
-noch anpassen {{prolong_url}} . 
+Sie haben im letzten Jahr einen reduzierten Beitrag für Ihre Mitgliedschaft
+bezahlt. Da unsere Unabhängigkeit und Werbefreiheit, ja unsere Existenz von der
+Unterstützung unserer Verlegerinnen abhängt, wäre es grandios, wenn Sie Ihre
+Mitgliedschaft auf den regulären Beitrag von {{autopay_default_price}} anpassen
+{{prolong_url}} könnten.
 
-{{else}} Sie haben sich im letzten Jahr für eine reguläre Mitgliedschaft
-entschieden. Sollten Sie dieses Mal noch mehr in kompromisslosen, unabhängigen
-und werbefreien Journalismus investieren wollen und können, passen Sie doch 
-Ihren Mitgliedsbeitrag vor der Abbuchung noch an {{prolong_url}} . Jede Spende
-macht einen Unterschied.
+{{elseif autopay_with_donation}}
 
-{{/if}} {{/if}} Ausserdem können Sie bis zur Abbuchung falls gewünscht eine andere Kreditkarte
+Dieser Beitrag kommt zustande, weil Sie die Republik im letzten Jahr
+grosszügigerweise mit einer zusätzlichen Spende unterstützt haben. Durch Sie ist
+unsere Unabhängigkeit, unsere Werbefreiheit, ja unsere Existenz erst möglich.
+Wir bedanken uns von ganzem Herzen und hoffen, dass Sie sich und uns treu
+bleiben und weiterhin in kompromisslosen Journalismus investieren. Sollten Sie
+es sich anders überlegen, können Sie Ihre Mitgliedschaft beziehungsweise die
+Höhe Ihres Spendenbeitrags vor der Abbuchung noch anpassen {{prolong_url}} .
+
+{{else}}
+
+Sie haben sich im letzten Jahr für eine reguläre Mitgliedschaft entschieden.
+Sollten Sie dieses Mal noch mehr in kompromisslosen, unabhängigen und
+werbefreien Journalismus investieren wollen und können, passen Sie doch Ihren
+Mitgliedsbeitrag vor der Abbuchung noch an {{prolong_url}} . Jede Spende macht
+einen Unterschied.
+
+{{/if}} {{/if}}
+
+Ausserdem können Sie bis zur Abbuchung falls gewünscht eine andere Kreditkarte
 hinterlegen, eine andere Zahlungsart wählen {{prolong_url}} oder Ihre
 Mitgliedschaft kündigen {{cancel_url}} .
 
@@ -67,14 +77,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_autopay_successful.txt
+++ b/packages/mail/templates/membership_owner_autopay_successful.txt
@@ -1,5 +1,5 @@
 Sehr geehrte Dame
-Sehr geehrter Herr 
+Sehr geehrter Herr
 
 Wir haben Ihre Mitgliedschaft automatisch um ein weiteres Jahr verlängert und
 dafür Ihre {{autopay_card_brand}}-Kreditkarte mit den Endziffern
@@ -15,14 +15,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_feedback.html
+++ b/packages/mail/templates/membership_owner_feedback.html
@@ -108,7 +108,7 @@
                       >
                       oder
                       <a
-                        href="https://play.google.com/store/apps/details?id=app.republik&hl=de_CH"
+                        href="https://play.google.com/store/apps/details?id=app.republik&amp;hl=de_CH"
                         >Android</a
                       >.
                     </p>

--- a/packages/mail/templates/membership_owner_feedback.txt
+++ b/packages/mail/templates/membership_owner_feedback.txt
@@ -1,9 +1,15 @@
-{{#if name}} Hallo {{name}}
+{{#if name}}
 
-{{else}} Sehr geehrte Dame
-Sehr geehrter Herr 
+Hallo {{name}}
 
-{{/if}} Schön, dass Sie hier sind! Dank Ihnen {{#if memberships_count}}und
+{{else}}
+
+Sehr geehrte Dame
+Sehr geehrter Herr
+
+{{/if}}
+
+Schön, dass Sie hier sind! Dank Ihnen {{#if memberships_count}}und
 {{memberships_count}} weiteren Menschen {{/if}}können wir recherchieren,
 nachfragen, einordnen und aufdecken, ohne von Werbeeinnahmen oder Sponsoren
 abhängig zu sein. Und Ihnen weiterhin Fakten und Zusammenhänge als Grundlage für
@@ -13,11 +19,12 @@ dankbar.
 Sind Sie mit uns zufrieden? Gefällt Ihnen, was Sie in der Republik lesen, sehen
 und hören? Im Dialog {{link_dialog}} können Sie uns Feedback geben oder
 Vorschläge machen, Kritik loswerden und Fragen stellen. Brauchen Sie technische
-Unterstützung oder funktioniert etwas nicht, wenden Sie sich direkt an 
+Unterstützung oder funktioniert etwas nicht, wenden Sie sich direkt an
 kontakt@republik.ch .
 
-{{#unless subscriptions_count}} Möchten Sie mehr lesen, aber Sie wissen nicht,
-was?
+{{#unless subscriptions_count}}
+
+Möchten Sie mehr lesen, aber Sie wissen nicht, was?
 
 Vielleicht gefallen Ihnen als Einstieg unsere regelmässigen Formate: am Montag
 unser Datenbriefing «Auf lange Sicht
@@ -30,28 +37,34 @@ Nachrichtenüberblick «Was diese Woche wichtig war
 Benachrichtigungs-Funktion können Sie sich Push-Meldungen einrichten, die Sie
 informieren, sobald eine neue Folge erscheint {{link_account_notifications}} .
 
-{{/unless}} Sind Sie viel unterwegs, oder lesen Sie ungern mit dem Laptop auf
-dem Schoss? Dann installieren Sie die Republik-App für iOS
+{{/unless}}
+
+Sind Sie viel unterwegs, oder lesen Sie ungern mit dem Laptop auf dem Schoss?
+Dann installieren Sie die Republik-App für iOS
 https://apps.apple.com/ch/app/republik/id1392772910 oder Android
 https://play.google.com/store/apps/details?id=app.republik&hl=de_CH .
 
-{{#unless grants_count}} Oder haben Sie neugierige Freundinnen und Bekannte,
-denen Sie gerne einen Probezugriff auf die Republik ermöglichen würden? Sie
-haben ein Kontingent von fünf 14-Tage-Probeabos, die Sie zu jeder Zeit vergeben
-können {{link_account_share}} .
+{{#unless grants_count}}
 
-{{/unless}} Ausserdem gibt es für jeden Beitrag einige hilfreiche Funktionen,
-die wir Ihnen ans Herz legen wollen:
+Oder haben Sie neugierige Freundinnen und Bekannte, denen Sie gerne einen
+Probezugriff auf die Republik ermöglichen würden? Sie haben ein Kontingent von
+fünf 14-Tage-Probeabos, die Sie zu jeder Zeit vergeben können
+{{link_account_share}} .
 
-* Sie können im Beitrag ein Lesezeichen setzen, um ihn später zu lesen.
-  {{link_bookmarks}} 
-* Sie können Ihre Leseposition pro Beitrag speichern, um später weiterzulesen – 
-  dies müssen Sie zuerst in Ihrem Konto freigeben {{link_account_progress}} .
-* Und Sie können jeden Beitrag als PDF herunterladen.
+{{/unless}}
+
+Ausserdem gibt es für jeden Beitrag einige hilfreiche Funktionen, die wir Ihnen
+ans Herz legen wollen:
+
+ * Sie können im Beitrag ein Lesezeichen setzen, um ihn später zu lesen.
+   {{link_bookmarks}}
+ * Sie können Ihre Leseposition pro Beitrag speichern, um später weiterzulesen –
+   dies müssen Sie zuerst in Ihrem Konto freigeben {{link_account_progress}} .
+ * Und Sie können jeden Beitrag als PDF herunterladen.
 
 Wenn Sie noch mehr über die Republik, die Geschichte und die Leute dahinter
 wissen wollen, finden Sie hier mehr Informationen zu Aufbau und Team
-{{link_about}} , zu Verlag und Genossenschaft {{link_publisher}} und zu unseren 
+{{link_about}} , zu Verlag und Genossenschaft {{link_publisher}} und zu unseren
 Zahlen {{link_cockpit}} .
 
 Wir hoffen, dass wir Ihnen einige hilfreiche Hinweise geben konnten, und würden
@@ -66,14 +79,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_prolong_notice.txt
+++ b/packages/mail/templates/membership_owner_prolong_notice.txt
@@ -9,10 +9,11 @@ Ganz gleich, ob Sie uns einmal pro Woche, einmal pro Monat oder einmal pro Jahr
 lesen – mit Ihrem Beitrag stärken Sie kritischen Journalismus, die vierte Gewalt
 und die Demokratie.
 
-Jetzt erneuern {{prolong_url}} Als Magazin bieten wir Einordnung und Vertiefung
-anstelle einer Flut von Nachrichten. Wir recherchieren, um Missstände
-aufzudecken, oft monatelang. Und diskutieren über drängende Fragen der
-Gegenwart.
+Jetzt erneuern {{prolong_url}}
+
+Als Magazin bieten wir Einordnung und Vertiefung anstelle einer Flut von
+Nachrichten. Wir recherchieren, um Missstände aufzudecken, oft monatelang. Und
+diskutieren über drängende Fragen der Gegenwart.
 
 Die Republik ist aber noch mehr. Wir sind ein Projekt gegen den Zynismus, den
 Vormarsch der Autoritären und gegen die Diktatur der Angst. Und stehen für die
@@ -23,8 +24,8 @@ Magazin über ihre Leserinnen und Leser.
 
 Nun haben Sie die Wahl:
 Sie bleiben an Bord und investieren damit weiter in die Republik und ihre Idee.
-{{prolong_url}} 
-Sie kündigen Ihre Mitgliedschaft bis zum {{cancel_until_date}}. 
+{{prolong_url}}
+Sie kündigen Ihre Mitgliedschaft bis zum {{cancel_until_date}}.
 
 Wie auch immer Sie entscheiden: Wir hoffen, dass wir Sie im vergangenen Jahr
 immer wieder erfolgreich informiert, unterhalten, geärgert und beglückt haben.
@@ -36,14 +37,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_prolong_notice_0.txt
+++ b/packages/mail/templates/membership_owner_prolong_notice_0.txt
@@ -6,16 +6,17 @@ die Diktatur der Angst um ein Jahr.
 
 Ihr Mitgliedsbeitrag ist fällig:
 
-Jetzt bezahlen {{prolong_url}} Hierfür müssen Sie nur noch die Rechnung für das
-nächste Jahr bezahlen, was mit einem Klick in drei Minuten erledigt ist.
-{{prolong_url}} 
+Jetzt bezahlen {{prolong_url}}
+
+Hierfür müssen Sie nur noch die Rechnung für das nächste Jahr bezahlen, was mit
+einem Klick in drei Minuten erledigt ist. {{prolong_url}}
 
 Sollten Sie das nicht tun, verlieren Ihre Zugangsdaten am {{grace_end_date}}
 leider ihre Gültigkeit.
 
 Sie wollen die Republik nicht mehr unterstützen? Jetzt kündigen {{cancel_url}} .
 
-Und sollte uns ein Fehler unterlaufen sein, schreiben Sie uns auf 
+Und sollte uns ein Fehler unterlaufen sein, schreiben Sie uns auf
 kontakt@republik.ch .
 
 Mit grossem Dank für das letzte Jahr!
@@ -26,14 +27,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_prolong_notice_7.txt
+++ b/packages/mail/templates/membership_owner_prolong_notice_7.txt
@@ -6,17 +6,19 @@ weiteres Jahr.
 Wir freuen uns, Sie weiterhin an Bord zu haben, denn die Republik und die Idee
 hinter unserem gemeinsamen Projekt brauchen Sie.
 
-Jetzt erneuern {{prolong_url}} Ganz gleich, ob Sie uns einmal pro Woche, einmal
-pro Monat oder einmal pro Jahr lesen – mit Ihrem Beitrag stärken Sie kritischen
-Journalismus, die vierte Gewalt und die Demokratie. 
+Jetzt erneuern {{prolong_url}}
+
+Ganz gleich, ob Sie uns einmal pro Woche, einmal pro Monat oder einmal pro Jahr
+lesen – mit Ihrem Beitrag stärken Sie kritischen Journalismus, die vierte Gewalt
+und die Demokratie.
 
 Wie Sie wissen, finanziert sich die Republik als unabhängiges und werbefreies
 Magazin über ihre Leserinnen und Leser.
 
 Sie haben die Wahl:
-Sie bleiben an Bord und investieren weiter in die Republik und ihre Idee. 
+Sie bleiben an Bord und investieren weiter in die Republik und ihre Idee.
 Hierfür müssen Sie nur die Rechnung für ein weiteres Jahr Mitgliedschaft
-bezahlen. {{prolong_url}} 
+bezahlen. {{prolong_url}}
 
 Oder: Sie kündigen Ihre Mitgliedschaft {{cancel_url}} bis zum
 {{cancel_until_date}}.
@@ -24,7 +26,7 @@ Oder: Sie kündigen Ihre Mitgliedschaft {{cancel_url}} bis zum
 Wie auch immer Sie entscheiden: Wir hoffen, dass wir Sie im vergangenen Jahr
 immer wieder erfolgreich informiert, unterhalten, geärgert und beglückt haben.
 
-Falls Sie Fragen haben, beantworten wir diese sehr gerne unter 
+Falls Sie Fragen haben, beantworten wir diese sehr gerne unter
 kontakt@republik.ch .
 
 Herzlich
@@ -34,14 +36,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_prolong_winback_7.txt
+++ b/packages/mail/templates/membership_owner_prolong_winback_7.txt
@@ -6,28 +6,28 @@ Gültigkeit, da Ihre Mitgliedschaft ausgelaufen ist.
 Um dies zu verhindern, können Sie einfach die Rechnung für das nächste Jahr
 bezahlen, was mit einem Klick in drei Minuten erledigt ist {{prolong_url}} .
 
-Sollte uns ein Fehler unterlaufen sein, schreiben Sie uns auf 
+Sollte uns ein Fehler unterlaufen sein, schreiben Sie uns auf
 kontakt@republik.ch .
 
-Und sollten Sie einen finanziellen Engpass haben, schreiben Sie uns ebenso auf 
+Und sollten Sie einen finanziellen Engpass haben, schreiben Sie uns ebenso auf
 kontakt@republik.ch . Wir finden eine Lösung.
 
 Mit grossem Dank für das letzte Jahr!
-Und in Vorfreude auf ein neues. 
+Und in Vorfreude auf ein neues.
 
 Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_upgrade_monthly.txt
+++ b/packages/mail/templates/membership_owner_upgrade_monthly.txt
@@ -1,8 +1,14 @@
-{{#if name}} Hallo {{name}}
+{{#if name}}
 
-{{else}} Sehr geehrte Verlegerin, sehr geehrter Verleger
+Hallo {{name}}
 
-{{/if}} Schön, dass Sie dabei sind! Dank Ihnen {{#if memberships_count}}und
+{{else}}
+
+Sehr geehrte Verlegerin, sehr geehrter Verleger
+
+{{/if}}
+
+Schön, dass Sie dabei sind! Dank Ihnen {{#if memberships_count}}und
 {{memberships_count}} weiteren Menschen {{/if}}können wir recherchieren,
 nachfragen, einordnen und aufdecken, ohne von Werbeeinnahmen oder Sponsoren
 abhängig zu sein. Damit ermöglichen Sie uns, in der Schweizer Medienlandschaft
@@ -12,19 +18,20 @@ Wir hoffen, dass auch Sie zufrieden mit unserer Arbeit sind. Wenn ja, haben wir
 eine Bitte an Sie: Gehen Sie noch einen Schritt weiter und wechseln Sie vom
 Monatsabo zu einer Jahresmitgliedschaft.
 
-Zur Jahresmitgliedschaft wechseln {{link_account_abos_goto}} Sie erhöhen dadurch
-unsere Planungssicherheit und sichern die Zukunft der Republik langfristig.
-Ausserdem würden wir uns sehr freuen, Sie auch in einem Jahr noch an unserer
-Seite zu wissen. Zusätzlich profitieren Sie bei einer Jahresmitgliedschaft von
-folgenden Vorteilen:
+Zur Jahresmitgliedschaft wechseln {{link_account_abos_goto}}
 
-* Verschiedene Zahlungsmöglichkeiten: Sie können wählen, ob Sie per
-  Kreditkarte, Paypal, Postkarte oder Banküberweisung zahlen möchten.
-* Tiefere Transaktionsgebühren: Sie zahlen rund 24 Franken weniger im Jahr als
-  beim Monatsabo.
-* Stimmrecht in der Project R Genossenschaft: Sie können an Urabstimmungen und
-  Genossenschaftsrats-Wahlen teilnehmen und damit den Weg der Republik
-  mitbestimmen.
+Sie erhöhen dadurch unsere Planungssicherheit und sichern die Zukunft der
+Republik langfristig. Ausserdem würden wir uns sehr freuen, Sie auch in einem
+Jahr noch an unserer Seite zu wissen. Zusätzlich profitieren Sie bei einer
+Jahresmitgliedschaft von folgenden Vorteilen:
+
+ * Verschiedene Zahlungsmöglichkeiten: Sie können wählen, ob Sie per
+   Kreditkarte, Paypal, Postkarte oder Banküberweisung zahlen möchten.
+ * Tiefere Transaktionsgebühren: Sie zahlen rund 24 Franken weniger im Jahr als
+   beim Monatsabo.
+ * Stimmrecht in der Project R Genossenschaft: Sie können an Urabstimmungen und
+   Genossenschaftsrats-Wahlen teilnehmen und damit den Weg der Republik
+   mitbestimmen.
 
 Sollten Sie nicht zufrieden sein: Im Dialog {{link_dialog}} können Sie uns
 Feedback geben oder Vorschläge machen, Kritik loswerden und Fragen stellen.
@@ -42,14 +49,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_prolong_notice.txt
+++ b/packages/mail/templates/membership_prolong_notice.txt
@@ -5,9 +5,9 @@ Willkommen zu einem weiteren Jahr Republik!
 Sie wurden zum wiederholten Male beschenkt.
 {{#if pledger_name}} {{pledger_name}} hat soeben Ihre Mitgliedschaft um ein Jahr
 verlängert. {{else}} Jemand hat soeben Ihre Mitgliedschaft um ein Jahr
-verlängert. {{/if}} 
+verlängert. {{/if}}
 
-Das neue Ablaufdatum Ihrer Mitgliedschaft: {{end_date}} 
+Das neue Ablaufdatum Ihrer Mitgliedschaft: {{end_date}}
 
 Wir bedanken uns bei {{#if pledger_name}}{{pledger_name}} fürs Verschenken – und
 bei {{/if}}Ihnen fürs Lesen, Teilhaben, Teilen und Mitdiskutieren.
@@ -19,14 +19,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_winback_NO_MONEY.txt
+++ b/packages/mail/templates/membership_winback_NO_MONEY.txt
@@ -2,7 +2,7 @@ Guten Tag
 
 Sie haben sich entschieden, Ihre Mitgliedschaft zu künden.
 Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
-gemeinsamen Projekt! 
+gemeinsamen Projekt!
 
 Bei Ihrer Kündigung haben Sie angegeben, dass Ihre finanzielle Situation es
 derzeit nicht zulässt, die Republik zu unterstützen.
@@ -37,14 +37,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_winback_NO_TIME.txt
+++ b/packages/mail/templates/membership_winback_NO_TIME.txt
@@ -2,7 +2,7 @@ Guten Tag
 
 Sie haben sich entschieden, Ihre Mitgliedschaft zu künden.
 Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
-gemeinsamen Projekt! 
+gemeinsamen Projekt!
 
 Bei Ihrer Kündigung haben Sie angegeben, dass Sie keine Zeit für die Lektüre
 haben.
@@ -19,8 +19,8 @@ Sie einmal in der Woche die besten Artikel der vergangenen Tage ins Postfach.
 Auch wenn Sie wenig zum Lesen kommen, leisten Sie so einen wichtigen Beitrag zur
 Medienvielfalt der Schweiz.
 
-Oder: Vielleicht wollen oder können Sie die Idee hinter diesem Projekt einfach 
-mit einer Spende unterstützen? {{link_offer_donate}} 
+Oder: Vielleicht wollen oder können Sie die Idee hinter diesem Projekt einfach
+mit einer Spende unterstützen? {{link_offer_donate}}
 
 Wir würden uns sehr freuen, Sie weiter bei uns an Bord zu wissen.
 
@@ -34,14 +34,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_winback_PAPER.txt
+++ b/packages/mail/templates/membership_winback_PAPER.txt
@@ -2,7 +2,7 @@ Guten Tag
 
 Sie haben sich entschieden, Ihre Mitgliedschaft zu künden.
 Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
-gemeinsamen Projekt! 
+gemeinsamen Projekt!
 
 Bei Ihrer Kündigung haben Sie angegeben, dass Sie lieber auf Papier lesen
 beziehungsweise nicht gerne am Bildschirm.
@@ -28,14 +28,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_winback_TOO_EXPENSIVE.txt
+++ b/packages/mail/templates/membership_winback_TOO_EXPENSIVE.txt
@@ -2,7 +2,7 @@ Guten Tag
 
 Sie haben sich entschieden, Ihre Mitgliedschaft zu künden.
 Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
-gemeinsamen Projekt! 
+gemeinsamen Projekt!
 
 Bei Ihrer Kündigung haben Sie angegeben, dass Ihnen die Republik zu teuer ist.
 
@@ -38,14 +38,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/newsletter_request_COVID19.txt
+++ b/packages/mail/templates/newsletter_request_COVID19.txt
@@ -2,13 +2,12 @@ Guten Tag
 
 Vielen Dank für Ihr Interesse.
 
-Bestätigen Sie Ihre Newsletter-Anmeldung mit folgendem Link.
+Bestätigen Sie Ihre Newsletter-Anmeldung mit folgendem Link:
 
-Anmeldung bestätigen: 
-{{CONFIRM_LINK}} 
+Anmeldung bestätigen {{CONFIRM_LINK}}
 
-Wenn Sie diese E-Mail öfters unaufgefordert erhalten, 
-wenden Sie sich bitte an kontakt@republik.ch .
+Wenn Sie diese E-Mail öfters unaufgefordert erhalten, wenden Sie sich bitte an
+kontakt@republik.ch .
 
 Wir freuen uns, Ihnen jeden Abend Brauchbares zur Pandemie zu liefern.
 
@@ -17,14 +16,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/payment_successful_abo.txt
+++ b/packages/mail/templates/payment_successful_abo.txt
@@ -3,7 +3,9 @@ Guten Tag
 Ihre Zahlung ist erfolgreich bei uns eingegangen.
 Herzlichen Dank!
 
-{{#if `total > 1000`}} Sie können ab sofort das Magazin lesen {{login_signin}} , an sämtlichen Debatten
+{{#if `total > 1000`}}
+
+Sie können ab sofort das Magazin lesen {{login_signin}} , an sämtlichen Debatten
 teilnehmen {{link_dialog}} , eine öffentliche Profilseite aufschalten
 {{link_profile}} und Beiträge mit Ihren Freunden oder Feinden teilen.
 
@@ -16,48 +18,56 @@ regelmässig Neuigkeiten aus Redaktion und Verlag: zu Vorhaben, Hintergründen,
 Entscheidungen und Fehlern. Sie können Kritik üben und Vorschläge machen. Und
 sich mit Ihren Kolleginnen und Kollegen in der Verlagsetage austauschen.
 
-{{/if}}  * 
-* {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
-  {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
-  {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}} 
-* 
-* Gewünschte Preisreduktion: –{{discount_formatted}}
-* 
-* Spende: {{donation_formatted}}
-* 
-*  Total: {{total_formatted}} 
+{{/if}}
+   {{#options}}
+ * {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
+   {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
+   {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}}
+   {{/options}} {{#if discount}}
+ * Gewünschte Preisreduktion: –{{discount_formatted}}
+   {{/if}} {{#if donation}}
+ * Spende: {{donation_formatted}}
+   {{/if}}
+ * Total: {{total_formatted}}
 
-{{#if goodies_count}} {{#if `goodies_count == 1`}} Sie haben sich zu Ihrer
-Mitgliedschaft noch ein Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}}
-Sie haben sich zu Ihrer Mitgliedschaft noch mehrere Republik-Objekte gegönnt.
-{{/if}} Bücher und Taschen liefern wir innerhalb von 7 Werktagen. 
+{{#if goodies_count}}
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+{{#if `goodies_count == 1`}} Sie haben sich zu Ihrer Mitgliedschaft noch ein
+Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer
+Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Bücher und Taschen
+liefern wir innerhalb von 7 Werktagen.
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{/if}} {{#if `total > 1000`}} Vielen Dank!
+{{/if}} {{#if `total > 1000`}}
+
+Vielen Dank!
 Und viel Vergnügen beim Start mit der Republik.
 
-{{/if}} {{#if `total < 1000`}} Falls Sie Fragen zur Inbetriebnahme des Magazins
-haben:
+{{/if}} {{#if `total < 1000`}}
+
+Falls Sie Fragen zur Inbetriebnahme des Magazins haben:
 Hier finden Sie die Gebrauchsanleitung {{link_manual}} , die die wichtigsten
 davon klärt.
 
 Wir wünschen weiterhin viel Vergnügen mit der Republik.
 
-{{/if}} Ihre Crew der Republik
+{{/if}}
+
+Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/payment_successful_abo_give.txt
+++ b/packages/mail/templates/payment_successful_abo_give.txt
@@ -2,12 +2,14 @@ Guten Tag
 
 Ihre Zahlung ist erfolgreich bei uns eingegangen.
 
-{{#if voucher_codes}} Herzlichen Dank, dass Sie die Republik mit einer
-Geschenk-Mitgliedschaft unterstützen!
+{{#if voucher_codes}}
 
-Für jede Geschenk-Mitgliedschaft erhalten Sie nachfolgend einen 6-Zeichen-Code. 
+Herzlichen Dank, dass Sie die Republik mit einer Geschenk-Mitgliedschaft
+unterstützen!
 
-{{voucher_codes}} 
+Für jede Geschenk-Mitgliedschaft erhalten Sie nachfolgend einen 6-Zeichen-Code.
+
+{{voucher_codes}}
 
 Sie können diesen der beschenkten Person mit einem Mittel Ihrer Wahl
 überreichen: sofort per E-Mail, traditionell per Briefpost oder originell als
@@ -16,52 +18,59 @@ Schrift auf einem Kuchen.
 Um den Geschenkcode einzulösen, muss der neue Besitzer oder die neue Besitzerin
 nur auf die Seite {{link_claim}} gehen. Und ihn dort eingeben.
 
-{{/if}} {{#if goodies_count}} {{#if `goodies_count == 1`}} Auch Ihr bestelltes
-Republik-Objekt eignet sich perfekt für die Code-Übergabe. {{elseif
-`goodies_count > 1`}} Auch Ihre bestellten Republik-Objekte eignen sich perfekt
-für die Code-Übergabe. {{/if}} Bücher und Taschen liefern wir innerhalb von 7
-Werktagen. 
+{{/if}} {{#if goodies_count}}
 
-* 
-* {{this.oamount}} {{this.olabel}} 
-* 
+{{#if `goodies_count == 1`}} Auch Ihr bestelltes Republik-Objekt eignet sich
+perfekt für die Code-Übergabe. {{elseif `goodies_count > 1`}} Auch Ihre
+bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. {{/if}}
+Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+   {{#options}} {{#if `this.otype == "Goodie"`}}
+ * {{this.oamount}} {{this.olabel}}
+   {{/if}} {{/options}}
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
 {{/if}} {{#if `num_access_granted_memberships > 0`}} {{#if
-`num_access_granted_memberships == 1`}} Vielen Dank, dass Sie die Verbreitung
-der Republik {{#if voucher_codes}}zusätzlich {{/if}}mit einer
-Wachstums-Mitgliedschaft unterstützen!
+`num_access_granted_memberships == 1`}}
+
+Vielen Dank, dass Sie die Verbreitung der Republik {{#if
+voucher_codes}}zusätzlich {{/if}}mit einer Wachstums-Mitgliedschaft
+unterstützen!
 
 Wir werden nun, zusammen mit unseren Komplizen, eine passende Empfängerin für
 Ihr Geschenk suchen und Sie informieren, sobald die Mitgliedschaft eingelöst
 wird.
 
-{{/if}} {{#if `num_access_granted_memberships > 1`}} Vielen Dank, dass Sie die
-Verbreitung der Republik {{#if voucher_codes}}zusätzlich {{/if}}mit gleich
-mehreren Wachstums-Mitgliedschaften unterstützen!
+{{/if}} {{#if `num_access_granted_memberships > 1`}}
+
+Vielen Dank, dass Sie die Verbreitung der Republik {{#if
+voucher_codes}}zusätzlich {{/if}}mit gleich mehreren Wachstums-Mitgliedschaften
+unterstützen!
 
 Wir werden nun, zusammen mit unseren Komplizen, passende Empfängerinnen für Ihr
 Geschenk suchen und Sie informieren, wann immer eine Mitgliedschaft eingelöst
 wird.
 
-{{/if}} {{/if}} Vielen Dank! {{#if voucher_codes}} 
-Und viel Freude beim Verschenken der Republik. {{/if}} 
+{{/if}} {{/if}}
+
+Vielen Dank! {{#if voucher_codes}}
+Und viel Freude beim Verschenken der Republik. {{/if}}
 
 Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/payment_successful_abo_give_months.txt
+++ b/packages/mail/templates/payment_successful_abo_give_months.txt
@@ -2,11 +2,11 @@ Guten Tag
 
 Ihre Zahlung ist erfolgreich bei uns eingegangen.
 Herzlichen Dank, dass Sie die Republik mit einem Geschenkabonnement
-unterstützen! 
+unterstützen!
 
-Für jedes Geschenkabonnement erhalten Sie nachfolgend einen 6-Zeichen-Code. 
+Für jedes Geschenkabonnement erhalten Sie nachfolgend einen 6-Zeichen-Code.
 
-{{voucher_codes}} 
+{{voucher_codes}}
 
 Sie können diesen der beschenkten Person mit einem Mittel Ihrer Wahl
 überreichen: sofort per E-Mail, traditionell per Briefpost oder originell als
@@ -15,35 +15,38 @@ Schrift auf einem Kuchen.
 Um den Geschenkcode einzulösen, muss der neue Besitzer oder die neue Besitzerin
 nur auf die Seite {{link_claim}} gehen. Und ihn dort eingeben.
 
-{{#if goodies_count}} {{#if `goodies_count == 1`}} Auch Ihr bestelltes
-Republik-Objekt eignet sich perfekt für die Code-Übergabe. {{elseif
-`goodies_count > 1`}} Auch Ihre bestellten Republik-Objekte eignen sich perfekt
-für die Code-Übergabe. {{/if}} Bücher und Taschen liefern wir innerhalb von 7
-Werktagen. 
+{{#if goodies_count}}
 
-* 
-* {{this.oamount}} {{this.olabel}} 
-* 
+{{#if `goodies_count == 1`}} Auch Ihr bestelltes Republik-Objekt eignet sich
+perfekt für die Code-Übergabe. {{elseif `goodies_count > 1`}} Auch Ihre
+bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. {{/if}}
+Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+   {{#options}} {{#if `this.otype == "Goodie"`}}
+ * {{this.oamount}} {{this.olabel}}
+   {{/if}} {{/options}}
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{/if}} Vielen Dank!
-Und viel Freude beim Verschenken der Republik. 
+{{/if}}
+
+Vielen Dank!
+Und viel Freude beim Verschenken der Republik.
 
 Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/payment_successful_benefactor.txt
+++ b/packages/mail/templates/payment_successful_benefactor.txt
@@ -3,7 +3,9 @@ Guten Tag
 Ihre Zahlung ist erfolgreich bei uns eingegangen.
 Herzlichen Dank!
 
-{{#if `total > 1000`}} Sie können ab sofort das Magazin lesen {{link_signin}} , an sämtlichen Debatten
+{{#if `total > 1000`}}
+
+Sie können ab sofort das Magazin lesen {{link_signin}} , an sämtlichen Debatten
 teilnehmen {{link_dialog}} , eine öffentliche Profilseite aufschalten
 {{link_profile}} und Beiträge mit Ihren Freunden oder Feinden teilen.
 
@@ -16,51 +18,59 @@ regelmässig Neuigkeiten aus Redaktion und Verlag: zu Vorhaben, Hintergründen,
 Entscheidungen und Fehlern. Sie können Kritik üben und Vorschläge machen. Und
 sich mit Ihren Kolleginnen und Kollegen in der Verlagsetage austauschen.
 
-{{/if}} Um uns für Ihre besonders grosse Unterstützung ein kleines bisschen zu
+{{/if}}
+
+Um uns für Ihre besonders grosse Unterstützung ein kleines bisschen zu
 revanchieren, schicken wir Ihnen postwendend das Gönnerpaket mit Manifest, dem
 exklusiven Republik-Anstecker in Gold sowie einer signierten Ausgabe von
 Constantin Seibts Buch «Deadline – Wie man besser schreibt
 https://keinundaber.ch/de/literary-work/deadline/ » zu.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{#if goodies_count}} {{#if `goodies_count == 1`}} Sie haben sich zu Ihrer
-Gönner-Mitgliedschaft noch ein Republik-Objekt gegönnt. {{elseif `goodies_count
-> 1`}} Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch mehrere
-Republik-Objekte gegönnt. {{/if}} Bücher und Taschen liefern wir innerhalb von 7
-Werktagen. 
+{{#if goodies_count}}
 
-* 
-* {{this.oamount}} {{this.olabel}}
-* 
+{{#if `goodies_count == 1`}} Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch
+ein Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu
+Ihrer Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}}
+Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+   {{#options}} {{#if `this.otype == "Goodie"`}}
+ * {{this.oamount}} {{this.olabel}}
+   {{/if}} {{/options}}
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{/if}} {{#if `total > 1000`}} Vielen Dank!
+{{/if}} {{#if `total > 1000`}}
+
+Vielen Dank!
 Und viel Vergnügen beim Start mit der Republik.
 
-{{/if}} {{#if `total < 1000`}} Falls Sie Fragen zur Inbetriebnahme des Magazins
-haben:
+{{/if}} {{#if `total < 1000`}}
+
+Falls Sie Fragen zur Inbetriebnahme des Magazins haben:
 Hier finden Sie die Gebrauchsanleitung {{link_manual}} , die die wichtigsten
 davon klärt.
 
 Wir wünschen weiterhin viel Vergnügen mit der Republik.
 
-{{/if}} Ihre Crew der Republik
+{{/if}}
+
+Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/payment_successful_donate.txt
+++ b/packages/mail/templates/payment_successful_donate.txt
@@ -1,7 +1,7 @@
 Guten Tag
 
 Herzlichen Dank für Ihre Spende von {{total_formatted}}.
-Die Zahlung ist erfolgreich bei uns eingegangen. 
+Die Zahlung ist erfolgreich bei uns eingegangen.
 
 Mit Ihrem Geld fördern Sie die Republik – und damit eine wirklich unabhängige
 vierte Gewalt als zentrale Institution unserer Demokratie.
@@ -11,19 +11,19 @@ Lösungen von Fall zu Fall, für Offenheit gegenüber Kritik, für Respektlosigk
 gegenüber der Macht und Respekt vor dem Menschen.
 
 Herzlich
-Ihre Crew der Republik 
+Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/payment_successful_donate_pot.txt
+++ b/packages/mail/templates/payment_successful_donate_pot.txt
@@ -1,7 +1,7 @@
 Guten Tag
 
 Herzlichen Dank für Ihre Wachstums-Spende von {{total_formatted}}.
-Die Zahlung ist erfolgreich bei uns eingegangen. 
+Die Zahlung ist erfolgreich bei uns eingegangen.
 
 Pro 240 Franken, die so zusammenkommen, schenken wir einer ausgewählten Person
 eine Mitgliedschaft.
@@ -10,19 +10,19 @@ Mit Ihrem Geld fördern Sie das Wachstum der Republik – und damit auch eine
 unabhängige vierte Gewalt als zentrale Institution unserer Demokratie.
 
 Herzlich
-Ihre Crew der Republik 
+Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/payment_successful_prolong.txt
+++ b/packages/mail/templates/payment_successful_prolong.txt
@@ -2,56 +2,66 @@ Guten Tag
 
 Ihre Zahlung in Höhe von {{total_formatted}} ist erfolgreich bei uns
 eingegangen.
-Herzlichen Dank! 
+Herzlichen Dank!
 
-* 
-* {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
-  {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
-  {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}} 
-* 
-* Gewünschte Preisreduktion: –{{discount_formatted}}
-* 
-* Spende: {{donation_formatted}}
-* 
-*  Total: {{total_formatted}} 
+   {{#options}}
+ * {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
+   {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
+   {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}}
+   {{/options}} {{#if discount}}
+ * Gewünschte Preisreduktion: –{{discount_formatted}}
+   {{/if}} {{#if donation}}
+ * Spende: {{donation_formatted}}
+   {{/if}}
+ * Total: {{total_formatted}}
 
-{{#if discount}} Wir haben Ihre Begründung für die Preisreduktion erhalten.
+{{#if discount}}
+
+Wir haben Ihre Begründung für die Preisreduktion erhalten.
 Vielen Dank für Ihre Offenheit. Wir freuen uns, dass Sie an Bord bleiben!
 
-{{/if}} {{#if donation}} Ihnen ist die Republik mehr wert.
-{{donation_formatted}}, um genau zu sein.
-Herzlichen Dank für Ihre grosszügige Spende. 
+{{/if}} {{#if donation}}
 
-{{/if}} {{#if `gifted_memberships_count == 1`}} Schön, dass Sie die Verbreitung
-der Republik noch mehr unterstützen: Sie haben auch die Geschenkmitgliedschaft
-verlängert. Wir haben die Beschenkte darüber per E-Mail informiert.
+Ihnen ist die Republik mehr wert. {{donation_formatted}}, um genau zu sein.
+Herzlichen Dank für Ihre grosszügige Spende.
 
-{{elseif `gifted_memberships_count > 1`}} Schön, dass Sie die Verbreitung der
-Republik noch mehr unterstützen: Sie haben auch Ihre Geschenkmitgliedschaften
-verlängert. Wir haben die Beschenkten darüber per E-Mail informiert.
+{{/if}} {{#if `gifted_memberships_count == 1`}}
 
-{{/if}} {{#if goodies_count}} {{#if `goodies_count == 1`}} Sie haben sich noch
-ein Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich noch
-mehrere Republik-Objekte gegönnt. {{/if}} Bücher und Taschen liefern wir
-innerhalb von 7 Werktagen. 
+Schön, dass Sie die Verbreitung der Republik noch mehr unterstützen: Sie haben
+auch die Geschenkmitgliedschaft verlängert. Wir haben die Beschenkte darüber per
+E-Mail informiert.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+{{elseif `gifted_memberships_count > 1`}}
+
+Schön, dass Sie die Verbreitung der Republik noch mehr unterstützen: Sie haben
+auch Ihre Geschenkmitgliedschaften verlängert. Wir haben die Beschenkten darüber
+per E-Mail informiert.
+
+{{/if}} {{#if goodies_count}}
+
+{{#if `goodies_count == 1`}} Sie haben sich noch ein Republik-Objekt gegönnt.
+{{elseif `goodies_count > 1`}} Sie haben sich noch mehrere Republik-Objekte
+gegönnt. {{/if}} Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{/if}} Herzlich
-Ihre Crew der Republik 
+{{/if}}
+
+Herzlich
+Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/payment_successful_tablebook.txt
+++ b/packages/mail/templates/payment_successful_tablebook.txt
@@ -3,21 +3,21 @@ Sehr geehrter Herr
 
 Ihre Zahlung ist erfolgreich bei uns eingegangen. Vielen Dank!
 
-* 
-* {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
-  {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
-  {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}} 
-* 
-* Gewünschte Preisreduktion: –{{discount_formatted}}
-* 
-* Spende: {{donation_formatted}}
-* 
-*  Total: {{total_formatted}} 
+   {{#options}}
+ * {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
+   {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
+   {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}}
+   {{/options}} {{#if discount}}
+ * Gewünschte Preisreduktion: –{{discount_formatted}}
+   {{/if}} {{#if donation}}
+ * Spende: {{donation_formatted}}
+   {{/if}}
+ * Total: {{total_formatted}}
 
 Bücher liefern wir innerhalb von 7 Werktagen.
 
-Stellen Sie bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
-{{link_account_account}} korrekt eingetragen haben.
+Stellen Sie bitte sicher, dass Sie Ihre Adresse unter {{link_account_account}}
+korrekt eingetragen haben.
 
 Wir wünschen Ihnen anregende Lektüre mit der «Republik bei Stromausfall».
 
@@ -28,14 +28,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/pledge_abo.txt
+++ b/packages/mail/templates/pledge_abo.txt
@@ -3,12 +3,16 @@ Guten Tag
 Und willkommen an Bord!
 Wir freuen uns sehr, Sie bei der Republik begrüssen zu dürfen.
 
-{{#if waiting_for_payment}} Wir sind Ihnen sehr dankbar für Ihren grosszügigen
-Beitrag. Da er CHF 1000.– übersteigt, können Ihre Mitgliedschaft und Ihr Zugang
-erst nach Zahlungseingang aktiviert werden. Sie erhalten eine Bestätigung, wenn
-die Transaktion erfolgreich bei uns angekommen ist.
+{{#if waiting_for_payment}}
 
-{{else}} Sie können ab sofort das Magazin lesen {{link_signin}} , an sämtlichen Debatten
+Wir sind Ihnen sehr dankbar für Ihren grosszügigen Beitrag. Da er CHF 1000.–
+übersteigt, können Ihre Mitgliedschaft und Ihr Zugang erst nach Zahlungseingang
+aktiviert werden. Sie erhalten eine Bestätigung, wenn die Transaktion
+erfolgreich bei uns angekommen ist.
+
+{{else}}
+
+Sie können ab sofort das Magazin lesen {{link_signin}} , an sämtlichen Debatten
 teilnehmen {{link_dialog}} , eine öffentliche Profilseite aufschalten
 {{link_profile}} und Beiträge mit Ihren Freunden oder Feinden teilen.
 
@@ -21,50 +25,58 @@ regelmässig Neuigkeiten aus Redaktion und Verlag: zu Vorhaben, Hintergründen,
 Entscheidungen und Fehlern. Sie können Kritik üben und Vorschläge machen. Und
 sich mit Ihren Kolleginnen und Kollegen in der Verlagsetage austauschen.
 
-{{/if}} Informationen zur Zahlung Ihrer Mitgliedschaft:
+{{/if}}
 
-{{#if `payment_method != "PAYMENTSLIP"`}} Ihre Zahlung ist erfolgreich bei uns
-eingegangen, herzlichen Dank!
+Informationen zur Zahlung Ihrer Mitgliedschaft:
 
-{{/if}} {{#if `payment_method == "PAYMENTSLIP"`}} Sie haben eine Banküberweisung
-als Zahlungsweg gewählt.
+{{#if `payment_method != "PAYMENTSLIP"`}}
+
+Ihre Zahlung ist erfolgreich bei uns eingegangen, herzlichen Dank!
+
+{{/if}} {{#if `payment_method == "PAYMENTSLIP"`}}
+
+Sie haben eine Banküberweisung als Zahlungsweg gewählt.
 
 Bitte überweisen Sie {{total_formatted}} bis spätestens {{due_date}} an:
 
 PC 61-11760-6
 IBAN: CH50 0900 0000 6101 1760 6
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
 lautend auf:
 
 Project R Genossenschaft
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
 Bitte vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins
 zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
-{{/if}}  * 
-* {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
-  {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
-  {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}} 
-* 
-* Gewünschte Preisreduktion: –{{discount_formatted}}
-* 
-* Spende: {{donation_formatted}}
-* 
-*  Total: {{total_formatted}} 
+{{/if}}
+   {{#options}}
+ * {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
+   {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
+   {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}}
+   {{/options}} {{#if discount}}
+ * Gewünschte Preisreduktion: –{{discount_formatted}}
+   {{/if}} {{#if donation}}
+ * Spende: {{donation_formatted}}
+   {{/if}}
+ * Total: {{total_formatted}}
 
-{{#unless waiting_for_payment}} {{#if goodies_count}} {{#if `goodies_count ==
-1`}} Sie haben sich zu Ihrer Mitgliedschaft noch ein Republik-Objekt gegönnt.
-{{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer Mitgliedschaft noch
-mehrere Republik-Objekte gegönnt. {{/if}} Bücher und Taschen liefern wir
-innerhalb von 7 Werktagen. 
+{{#unless waiting_for_payment}} {{#if goodies_count}}
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+{{#if `goodies_count == 1`}} Sie haben sich zu Ihrer Mitgliedschaft noch ein
+Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer
+Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Bücher und Taschen
+liefern wir innerhalb von 7 Werktagen.
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{/if}} {{/unless}} Vielen Dank!
+{{/if}} {{/unless}}
+
+Vielen Dank!
 Und viel Vergnügen beim Start mit der Republik.
 
 Ihre Crew der Republik
@@ -72,14 +84,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/pledge_abo_give.txt
+++ b/packages/mail/templates/pledge_abo_give.txt
@@ -1,13 +1,18 @@
 Guten Tag
 
-{{#if waiting_for_payment}} Vielen Dank, dass Sie die Verbreitung der Republik
-mit einer Geschenk-Mitgliedschaft unterstützen!
+{{#if waiting_for_payment}}
 
-{{/if}} {{#if voucher_codes}} {{#unless waiting_for_payment}} Vielen Dank, dass
-Sie die Verbreitung der Republik mit einer Geschenk-Mitgliedschaft unterstützen!
+Vielen Dank, dass Sie die Verbreitung der Republik mit einer
+Geschenk-Mitgliedschaft unterstützen!
 
-{{/unless}} Für jede Geschenk-Mitgliedschaft erhalten Sie nachfolgend einen
-Gutscheincode.
+{{/if}} {{#if voucher_codes}} {{#unless waiting_for_payment}}
+
+Vielen Dank, dass Sie die Verbreitung der Republik mit einer
+Geschenk-Mitgliedschaft unterstützen!
+
+{{/unless}}
+
+Für jede Geschenk-Mitgliedschaft erhalten Sie nachfolgend einen Gutscheincode.
 
 {{voucher_codes}}
 
@@ -18,65 +23,78 @@ Kuchen.
 Um den Gutscheincode einzulösen, muss der neue Besitzer oder die neue Besitzerin
 nur auf die Seite {{link_claim}} gehen. Und den Code dort eingeben.
 
-{{#if goodies_count}} {{#if `goodies_count == 1`}} Auch Ihr bestelltes
-Republik-Objekt eignet sich perfekt für die Code-Übergabe. {{elseif
-`goodies_count > 1`}} Auch Ihre bestellten Republik-Objekte eignen sich perfekt
-für die Code-Übergabe. {{/if}} Bücher und Taschen liefern wir innerhalb von 7
-Werktagen. 
+{{#if goodies_count}}
 
-* 
-* {{this.oamount}} {{this.olabel}}
-* 
+{{#if `goodies_count == 1`}} Auch Ihr bestelltes Republik-Objekt eignet sich
+perfekt für die Code-Übergabe. {{elseif `goodies_count > 1`}} Auch Ihre
+bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. {{/if}}
+Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+   {{#options}} {{#if `this.otype == "Goodie"`}}
+ * {{this.oamount}} {{this.olabel}}
+   {{/if}} {{/options}}
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
 {{/if}} {{/if}} {{#if `num_access_granted_memberships > 0`}} {{#if
-`num_access_granted_memberships == 1`}} Vielen Dank, dass Sie die Verbreitung
-der Republik {{#if voucher_codes}}zusätzlich {{/if}}mit einer
-Wachstums-Mitgliedschaft unterstützen!
+`num_access_granted_memberships == 1`}}
+
+Vielen Dank, dass Sie die Verbreitung der Republik {{#if
+voucher_codes}}zusätzlich {{/if}}mit einer Wachstums-Mitgliedschaft
+unterstützen!
 
 Wir werden nun, zusammen mit unseren Komplizen, eine passende Empfängerin für
 Ihr Geschenk suchen und Sie informieren, sobald die Mitgliedschaft eingelöst
 wird.
 
-{{/if}} {{#if `num_access_granted_memberships > 1`}} Vielen Dank, dass Sie die
-Verbreitung der Republik {{#if voucher_codes}}zusätzlich {{/if}}mit gleich
-mehreren Wachstums-Mitgliedschaften unterstützen!
+{{/if}} {{#if `num_access_granted_memberships > 1`}}
+
+Vielen Dank, dass Sie die Verbreitung der Republik {{#if
+voucher_codes}}zusätzlich {{/if}}mit gleich mehreren Wachstums-Mitgliedschaften
+unterstützen!
 
 Wir werden nun, zusammen mit unseren Komplizen, passende Empfängerinnen für Ihr
 Geschenk suchen und Sie informieren, wann immer eine Mitgliedschaft eingelöst
 wird.
 
-{{/if}} {{/if}} Informationen zur Zahlung:
+{{/if}} {{/if}}
 
-{{#if `payment_method != "PAYMENTSLIP"`}} Ihre Zahlung ist erfolgreich bei uns
-eingegangen, herzlichen Dank!
+Informationen zur Zahlung:
 
-{{/if}} {{#if `payment_method == "PAYMENTSLIP"`}} Sie haben eine Banküberweisung
-als Zahlungsweg gewählt.
+{{#if `payment_method != "PAYMENTSLIP"`}}
+
+Ihre Zahlung ist erfolgreich bei uns eingegangen, herzlichen Dank!
+
+{{/if}} {{#if `payment_method == "PAYMENTSLIP"`}}
+
+Sie haben eine Banküberweisung als Zahlungsweg gewählt.
 
 Bitte überweisen Sie {{total_formatted}} bis spätestens {{due_date}} an:
 
 PC 61-11760-6
 IBAN: CH50 0900 0000 6101 1760 6
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
-lautend auf: 
+lautend auf:
 
 Project R Genossenschaft
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
 Bitte vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins
 zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
 {{/if}} {{#if waiting_for_payment}}
+
+
 Da der Gesamtbetrag Ihrer Bestellung die magische Grenze von CHF 1000.–
 übersteigt, erhalten Sie die Gutscheincodes erst nach Zahlungseingang.
 
-{{/if}} Vielen Dank! {{#if voucher_codes}} 
-Und viel Freude beim Verschenken der Republik. {{/if}} 
+{{/if}}
+
+Vielen Dank! {{#if voucher_codes}}
+Und viel Freude beim Verschenken der Republik. {{/if}}
 
 Ihre Crew der Republik
 
@@ -88,9 +106,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/pledge_abo_give_months.txt
+++ b/packages/mail/templates/pledge_abo_give_months.txt
@@ -3,8 +3,9 @@ Guten Tag
 Vielen Dank, dass Sie die Verbreitung der Republik mit einem Geschenkabonnement
 unterstützen!
 
-{{#if voucher_codes}} Für jedes Geschenkabonnement erhalten Sie nachfolgend
-einen Gutscheincode.
+{{#if voucher_codes}}
+
+Für jedes Geschenkabonnement erhalten Sie nachfolgend einen Gutscheincode.
 
 {{voucher_codes}}
 
@@ -15,48 +16,57 @@ Kuchen.
 Um den Gutscheincode einzulösen, muss der neue Besitzer oder die neue Besitzerin
 nur auf die Seite {{link_claim}} gehen. Und den Code dort eingeben.
 
-{{#if goodies_count}} {{#if `goodies_count == 1`}} Auch Ihr bestelltes
-Republik-Objekt eignet sich perfekt für die Code-Übergabe. {{elseif
-`goodies_count > 1`}} Auch Ihre bestellten Republik-Objekte eignen sich perfekt
-für die Code-Übergabe. {{/if}} Bücher und Taschen liefern wir innerhalb von 7
-Werktagen. 
+{{#if goodies_count}}
 
-* 
-* {{this.oamount}} {{this.olabel}}
-* 
+{{#if `goodies_count == 1`}} Auch Ihr bestelltes Republik-Objekt eignet sich
+perfekt für die Code-Übergabe. {{elseif `goodies_count > 1`}} Auch Ihre
+bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. {{/if}}
+Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+   {{#options}} {{#if `this.otype == "Goodie"`}}
+ * {{this.oamount}} {{this.olabel}}
+   {{/if}} {{/options}}
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{/if}} {{/if}} Informationen zur Zahlung Ihres Geschenkabonnements:
+{{/if}} {{/if}}
 
-{{#if `payment_method != "PAYMENTSLIP"`}} Ihre Zahlung ist erfolgreich bei uns
-eingegangen, herzlichen Dank!
+Informationen zur Zahlung Ihres Geschenkabonnements:
 
-{{/if}} {{#if `payment_method == "PAYMENTSLIP"`}} Sie haben eine Banküberweisung
-als Zahlungsweg gewählt.
+{{#if `payment_method != "PAYMENTSLIP"`}}
+
+Ihre Zahlung ist erfolgreich bei uns eingegangen, herzlichen Dank!
+
+{{/if}} {{#if `payment_method == "PAYMENTSLIP"`}}
+
+Sie haben eine Banküberweisung als Zahlungsweg gewählt.
 
 Bitte überweisen Sie {{total_formatted}} bis spätestens {{due_date}} an:
 
 PC 61-229215-3
-IBAN: CH23 0900 0000 6122 9215 3 
-BIC: POFICHBEXXX 
+IBAN: CH23 0900 0000 6122 9215 3
+BIC: POFICHBEXXX
 
 lautend auf:
 
 Republik AG
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
 Bitte vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins
 zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
 {{/if}} {{#if waiting_for_payment}}
+
+
 Da der Gesamtbetrag Ihrer Bestellung die magische Grenze von CHF 1000.–
 übersteigt, erhalten Sie die Gutscheincodes erst nach Zahlungseingang.
 
-{{/if}} Vielen Dank!
-Und viel Freude beim Verschenken der Republik. 
+{{/if}}
+
+Vielen Dank!
+Und viel Freude beim Verschenken der Republik.
 
 Ihre Crew der Republik
 
@@ -68,9 +78,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/pledge_benefactor.txt
+++ b/packages/mail/templates/pledge_benefactor.txt
@@ -4,12 +4,16 @@ Und willkommen an Bord!
 Herzlichen Dank für Ihr aussergewöhnliches Investment in unser Magazin und die
 Republik-Idee.
 
-{{#if waiting_for_payment}} Wir sind Ihnen sehr dankbar für Ihren grosszügigen
-Beitrag. Da er CHF 1000.– übersteigt, können Ihre Mitgliedschaft und Ihr Zugang
-erst nach Zahlungseingang aktiviert werden. Sie erhalten eine Bestätigung, wenn
-die Transaktion erfolgreich bei uns angekommen ist.
+{{#if waiting_for_payment}}
 
-{{else}} Sie können ab sofort das Magazin lesen {{link_signin}} , an sämtlichen Debatten
+Wir sind Ihnen sehr dankbar für Ihren grosszügigen Beitrag. Da er CHF 1000.–
+übersteigt, können Ihre Mitgliedschaft und Ihr Zugang erst nach Zahlungseingang
+aktiviert werden. Sie erhalten eine Bestätigung, wenn die Transaktion
+erfolgreich bei uns angekommen ist.
+
+{{else}}
+
+Sie können ab sofort das Magazin lesen {{link_signin}} , an sämtlichen Debatten
 teilnehmen {{link_dialog}} , eine öffentliche Profilseite aufschalten
 {{link_profile}} und Beiträge mit Ihren Freunden oder Feinden teilen.
 
@@ -26,55 +30,63 @@ Um uns für Ihre besonders grosse Unterstützung ein kleines bisschen zu
 revanchieren, schicken wir Ihnen postwendend das Gönner-Paket mit Manifest, dem
 exklusiven Republik-Anstecker in Gold sowie einer signierten Ausgabe von
 Constantin Seibts Buch «Deadline – Wie man besser schreibt
-https://keinundaber.ch/de/literary-work/deadline/ » zu. 
+https://keinundaber.ch/de/literary-work/deadline/ » zu.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{/if}} Informationen zur Zahlung Ihres Abonnements und Ihrer Gönnerschaft:
+{{/if}}
 
-{{#if `payment_method != "PAYMENTSLIP"`}} Ihre Zahlung ist erfolgreich bei uns
-eingegangen, herzlichen Dank!
+Informationen zur Zahlung Ihres Abonnements und Ihrer Gönnerschaft:
 
-{{/if}} {{#if `payment_method == "PAYMENTSLIP"`}} Sie haben eine Banküberweisung
-als Zahlungsweg gewählt.
+{{#if `payment_method != "PAYMENTSLIP"`}}
+
+Ihre Zahlung ist erfolgreich bei uns eingegangen, herzlichen Dank!
+
+{{/if}} {{#if `payment_method == "PAYMENTSLIP"`}}
+
+Sie haben eine Banküberweisung als Zahlungsweg gewählt.
 
 Bitte überweisen Sie {{total_formatted}} bis spätestens {{due_date}} an:
 
 PC 61-11760-6
 IBAN: CH50 0900 0000 6101 1760 6
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
-lautend auf: 
+lautend auf:
 
 Project R Genossenschaft
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
 Bitte vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins
 zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
-{{/if}}  * 
-* {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
-  {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
-  {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}} 
-* 
-* Gewünschte Preisreduktion: –{{discount_formatted}}
-* 
-* Spende: {{donation_formatted}}
-* 
-*  Total: {{total_formatted}} 
+{{/if}}
+   {{#options}}
+ * {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
+   {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
+   {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}}
+   {{/options}} {{#if discount}}
+ * Gewünschte Preisreduktion: –{{discount_formatted}}
+   {{/if}} {{#if donation}}
+ * Spende: {{donation_formatted}}
+   {{/if}}
+ * Total: {{total_formatted}}
 
-{{#unless waiting_for_payment}} {{#if goodies_count}} {{#if `goodies_count ==
-1`}} Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch ein Republik-Objekt
-gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer
-Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Bücher und
-Taschen liefern wir innerhalb von 7 Werktagen. 
+{{#unless waiting_for_payment}} {{#if goodies_count}}
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+{{#if `goodies_count == 1`}} Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch
+ein Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu
+Ihrer Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}}
+Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{/if}} {{/unless}} Vielen Dank!
+{{/if}} {{/unless}}
+
+Vielen Dank!
 Und viel Vergnügen beim Start mit der Republik.
 
 Ihre Crew der Republik
@@ -87,9 +99,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/pledge_donate.txt
+++ b/packages/mail/templates/pledge_donate.txt
@@ -13,26 +13,31 @@ Gewalt als zentrale Institution unserer Demokratie.
 
 Wichtige Informationen zu den Zahlungsformalitäten Ihrer Spende:
 
-{{#if `payment_method == "PAYMENTSLIP"`}} Sie haben den Weg der Banküberweisung
-für Ihre Spende gewählt.
-Bitte überweisen Sie {{total_formatted}} an: 
+{{#if `payment_method == "PAYMENTSLIP"`}}
+
+Sie haben den Weg der Banküberweisung für Ihre Spende gewählt.
+Bitte überweisen Sie {{total_formatted}} an:
 
 PC 61-11760-6
 IBAN: CH50 0900 0000 6101 1760 6
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
 lautend auf:
 Project R Genossenschaft
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
 Bitte vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins
 zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
-{{else}} Ihre Spende von {{total_formatted}} ist erfolgreich bei uns
-eingegangen, vielen Dank!
+{{else}}
 
-{{/if}} Herzlich
+Ihre Spende von {{total_formatted}} ist erfolgreich bei uns eingegangen, vielen
+Dank!
+
+{{/if}}
+
+Herzlich
 
 Ihre Crew der Republik
 
@@ -44,9 +49,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/pledge_donate_pot.txt
+++ b/packages/mail/templates/pledge_donate_pot.txt
@@ -12,26 +12,31 @@ unabhängige vierte Gewalt als zentrale Institution unserer Demokratie.
 
 Wichtige Informationen zu den Zahlungsformalitäten Ihrer Spende:
 
-{{#if `payment_method == "PAYMENTSLIP"`}} Sie haben den Weg der Banküberweisung
-für Ihre Spende gewählt.
-Bitte überweisen Sie {{total_formatted}} an: 
+{{#if `payment_method == "PAYMENTSLIP"`}}
+
+Sie haben den Weg der Banküberweisung für Ihre Spende gewählt.
+Bitte überweisen Sie {{total_formatted}} an:
 
 PC 61-11760-6
 IBAN: CH50 0900 0000 6101 1760 6
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
 lautend auf:
 Project R Genossenschaft
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
 Bitte vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins
 zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
-{{else}} Ihre Spende von {{total_formatted}} ist erfolgreich bei uns
-eingegangen, vielen Dank!
+{{else}}
 
-{{/if}} Herzlich
+Ihre Spende von {{total_formatted}} ist erfolgreich bei uns eingegangen, vielen
+Dank!
+
+{{/if}}
+
+Herzlich
 
 Ihre Crew der Republik
 
@@ -43,9 +48,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/pledge_monthly_abo.txt
+++ b/packages/mail/templates/pledge_monthly_abo.txt
@@ -1,7 +1,7 @@
 Guten Tag
 
 Willkommen an Bord!
-Wir freuen uns sehr, Sie bei der Republik begrüssen zu dürfen. 
+Wir freuen uns sehr, Sie bei der Republik begrüssen zu dürfen.
 
 Sie können ab sofort das Magazin lesen {{link_signin}} , an sämtlichen Debatten
 teilnehmen {{link_dialog}} , eine öffentliche Profilseite aufschalten
@@ -16,7 +16,7 @@ regelmässig Neuigkeiten aus Redaktion und Verlag: zu Vorhaben, Hintergründen,
 Entscheidungen und Fehlern. Sie können Kritik üben und Vorschläge machen. Und
 sich mit Ihren Kolleginnen und Kollegen in der Verlagsetage austauschen.
 
-Die von Ihnen angegebene Kreditkarte belasten wir monatlich mit CHF 22.–. Unter 
+Die von Ihnen angegebene Kreditkarte belasten wir monatlich mit CHF 22.–. Unter
 Konto {{link_account}} finden Sie Ihre persönliche Übersicht zu Ihrem Abonnement
 {{link_account_abos}} . Am gleichen Ort können Sie alle Einstellungen vornehmen
 (z. B. Kreditkarteninformationen ändern) oder das Abo jederzeit kündigen. Was
@@ -34,9 +34,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/pledge_prolong.txt
+++ b/packages/mail/templates/pledge_prolong.txt
@@ -1,6 +1,8 @@
 Guten Tag
 
-{{#if `pledger_memberships_count > 0`}} Danke für Ihr Vertrauen.
+{{#if `pledger_memberships_count > 0`}}
+
+Danke für Ihr Vertrauen.
 
 Mit Ihrer Mitgliedschaft erhalten Sie von Montag bis Samstag ein hochwertiges
 digitales Magazin. Sie unterstützen aber auch eine wirklich unabhängige vierte
@@ -11,62 +13,77 @@ und die Werte der Aufklärung: für Treue zu Fakten, für Lösungen von Fall zu
 Fall, für Offenheit gegenüber Kritik, für Respektlosigkeit gegenüber der Macht
 und Respekt vor dem Menschen.
 
-{{/if}} Hier die wichtigsten Informationen über Ihre Verlängerung.
+{{/if}}
 
-{{#if `payment_method == "PAYMENTSLIP"`}} Sie haben Banküberweisung als Weg der
-Zahlung gewählt.
-Bitte überweisen Sie {{total_formatted}} bis spätestens {{due_date}}. an: 
+Hier die wichtigsten Informationen über Ihre Verlängerung.
+
+{{#if `payment_method == "PAYMENTSLIP"`}}
+
+Sie haben Banküberweisung als Weg der Zahlung gewählt.
+Bitte überweisen Sie {{total_formatted}} bis spätestens {{due_date}}. an:
 
 PC 61-11760-6
 IBAN: CH50 0900 0000 6101 1760 6
-BIC: POFICHBEXXX 
+BIC: POFICHBEXXX
 
 lautend auf:
 Project R Genossenschaft
 Sihlhallenstrasse 1
-8004 Zürich 
+8004 Zürich
 
 Bitte vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins
 zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
-{{else}} Ihre Zahlung in Höhe von {{total_formatted}} ist erfolgreich bei uns
+{{else}}
+
+Ihre Zahlung in Höhe von {{total_formatted}} ist erfolgreich bei uns
 eingegangen, herzlichen Dank!
 
-{{/if}}  * 
-* {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
-  {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
-  {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}} 
-* 
-* Gewünschte Preisreduktion: –{{discount_formatted}}
-* 
-* Spende: {{donation_formatted}}
-* 
-*  Total: {{total_formatted}} 
+{{/if}}
+   {{#options}}
+ * {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
+   {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
+   {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}}
+   {{/options}} {{#if discount}}
+ * Gewünschte Preisreduktion: –{{discount_formatted}}
+   {{/if}} {{#if donation}}
+ * Spende: {{donation_formatted}}
+   {{/if}}
+ * Total: {{total_formatted}}
 
-{{#if discount}} Wir haben Ihre Begründung für die Preisreduktion erhalten.
-Vielen Dank für Ihre Offenheit. Wir freuen uns, dass Sie an Bord sind!
+{{#if discount}}
 
-{{/if}} {{#if donation}} Ihnen ist die Republik mehr wert.
-{{donation_formatted}}, um genau zu sein. 
+Wir haben Ihre Begründung für die Preisreduktion erhalten. Vielen Dank für Ihre
+Offenheit. Wir freuen uns, dass Sie an Bord sind!
+
+{{/if}} {{#if donation}}
+
+Ihnen ist die Republik mehr wert. {{donation_formatted}}, um genau zu sein.
 Herzlichen Dank für Ihre grosszügige Spende!
 
-{{/if}} {{#if `gifted_memberships_count == 1`}} Vielen Dank, dass Sie die
-Republik anderen zukommen lassen: Sie verlängern auch das Geschenkabonnement.
-Wir haben die Beschenkte darüber per E-Mail informiert.
+{{/if}} {{#if `gifted_memberships_count == 1`}}
 
-{{elseif `gifted_memberships_count > 1`}} Vielen Dank, dass Sie die Republik
-anderen zukommen lassen: Sie verlängern auch Ihre Geschenkabonnemente. Wir haben
-die Beschenkten darüber per E-Mail informiert.
+Vielen Dank, dass Sie die Republik anderen zukommen lassen: Sie verlängern auch
+das Geschenkabonnement. Wir haben die Beschenkte darüber per E-Mail informiert.
 
-{{/if}} {{#unless waiting_for_payment}} {{#if goodies_count}} {{#if
-`goodies_count == 1`}} Sie haben sich noch ein Republik-Objekt gegönnt. {{elseif
-`goodies_count > 1`}} Sie haben sich noch mehrere Republik-Objekte gegönnt.
-{{/if}} Bücher und Taschen liefern wir innerhalb von 7 Werktagen. 
+{{elseif `gifted_memberships_count > 1`}}
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
+Vielen Dank, dass Sie die Republik anderen zukommen lassen: Sie verlängern auch
+Ihre Geschenkabonnemente. Wir haben die Beschenkten darüber per E-Mail
+informiert.
+
+{{/if}} {{#unless waiting_for_payment}} {{#if goodies_count}}
+
+{{#if `goodies_count == 1`}} Sie haben sich noch ein Republik-Objekt gegönnt.
+{{elseif `goodies_count > 1`}} Sie haben sich noch mehrere Republik-Objekte
+gegönnt. {{/if}} Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+
+Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.
 
-{{/if}} {{/unless}} Herzlich
+{{/if}} {{/unless}}
+
+Herzlich
 
 Ihre Crew der Republik
 
@@ -78,9 +95,9 @@ Beiträgen. In der App, auf der Website und als Newsletter.
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/pledge_tablebook.txt
+++ b/packages/mail/templates/pledge_tablebook.txt
@@ -3,25 +3,26 @@ Sehr geehrter Herr
 
 Vielen Dank für Ihre Bestellung. Hier die wichtigsten Informationen dazu:
 
-* 
-* {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
-  {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
-  {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}} 
-* 
-* Gewünschte Preisreduktion: –{{discount_formatted}}
-* 
-* Spende: {{donation_formatted}}
-* 
-*  Total: {{total_formatted}} 
+   {{#options}}
+ * {{#if `this.oamount > 1`}} {{this.oamount}} {{this.olabel}} à
+   {{this.oprice_formatted}}: {{this.ototal_formatted}} {{else}}
+   {{this.oamount}} {{this.olabel}}: {{this.ototal_formatted}} {{/if}}
+   {{/options}} {{#if discount}}
+ * Gewünschte Preisreduktion: –{{discount_formatted}}
+   {{/if}} {{#if donation}}
+ * Spende: {{donation_formatted}}
+   {{/if}}
+ * Total: {{total_formatted}}
 
 Bücher liefern wir innerhalb von 7 Werktagen. {{#if waiting_for_payment}}Der
 Versand erfolgt erst nach Zahlungseingang.{{/if}}
 
-Stellen Sie bitte sicher, dass Sie Ihre Adresse unter {{link_account}}
-{{link_account_account}} korrekt eingetragen haben.
+Stellen Sie bitte sicher, dass Sie Ihre Adresse unter {{link_account_account}}
+korrekt eingetragen haben.
 
-{{#if `payment_method == "PAYMENTSLIP"`}} Sie haben eine Banküberweisung als
-Zahlungsweg gewählt.
+{{#if `payment_method == "PAYMENTSLIP"`}}
+
+Sie haben eine Banküberweisung als Zahlungsweg gewählt.
 
 Bitte überweisen Sie {{total_formatted}} bis spätestens {{due_date}} an:
 
@@ -39,24 +40,27 @@ Sihlhallenstrasse 1
 Vergessen Sie nicht, {{HRID}} in das Feld «Betreff» des Einzahlungsscheins zu
 schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
-{{else}} Wir wünschen Ihnen anregende Lektüre mit der «Republik bei
-Stromausfall».
+{{else}}
 
-{{/if}} Herzlich
+Wir wünschen Ihnen anregende Lektüre mit der «Republik bei Stromausfall».
+
+{{/if}}
+
+Herzlich
 
 Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/signin.txt
+++ b/packages/mail/templates/signin.txt
@@ -1,16 +1,14 @@
 Guten Tag
 
 Haben Sie einen Zugriff auf republik.ch angefordert?
-Dann klicken Sie bitte auf den folgenden Link.
+Dann klicken Sie bitte auf den folgenden Link:
 
-Zugriff bestätigen: 
-{{LOGIN_LINK}} 
+Zugriff bestätigen {{LOGIN_LINK}}
 
-Falls Sie diese Zugriffsanfrage nicht
-ausgelöst haben, können Sie die Zugriffsaufforderung ablehnen: 
-{{LOGIN_LINK}}&noAutoAuthorize=true 
+Falls Sie diese Zugriffsanfrage nicht ausgelöst haben, können Sie die
+Zugriffsaufforderung ablehnen {{LOGIN_LINK}}&noAutoAuthorize=true .
 
-Wenn Sie diese E-Mail öfters unaufgefordert erhalten, wenden Sie sich bitte an 
+Wenn Sie diese E-Mail öfters unaufgefordert erhalten, wenden Sie sich bitte an
 kontakt@republik.ch .
 
 Herzlich
@@ -20,14 +18,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/signin_app_notice.txt
+++ b/packages/mail/templates/signin_app_notice.txt
@@ -19,14 +19,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/signin_code.txt
+++ b/packages/mail/templates/signin_code.txt
@@ -1,14 +1,14 @@
 Guten Tag
 
 Geben Sie zur Bestätigung Ihres Logins bitte folgende Ziffern auf der
-Republik-Website ein: 
+Republik-Website ein:
 
-{{code}} 
+{{code}}
 
 Die Bestätigungsziffern sind nur einmal gültig. Sie können die E-Mail
 anschliessend löschen.
 
-Wenn Sie diese E-Mail öfters unaufgefordert erhalten, wenden Sie sich bitte an 
+Wenn Sie diese E-Mail öfters unaufgefordert erhalten, wenden Sie sich bitte an
 kontakt@republik.ch .
 
 Herzlich
@@ -18,14 +18,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/subscription_end.txt
+++ b/packages/mail/templates/subscription_end.txt
@@ -1,19 +1,23 @@
 Guten Tag
 
-{{#if is_automatic_overdue_cancel}} Leider konnten wir Ihr Republik-Monatsabonnement {{link_account_abos}} 
+{{#if is_automatic_overdue_cancel}}
+
+Leider konnten wir Ihr Republik-Monatsabonnement {{link_account_abos}}
 wiederholt nicht von Ihrer Kreditkarte abbuchen und mussten es aus diesem Grund
 deaktivieren.
 
 Wir danken Ihnen herzlich für Ihr bisheriges Interesse und Ihre Unterstützung
 bis hierhin! Und wir würden uns sehr freuen, wenn Sie zu einem späteren
 Zeitpunkt wieder bei uns vorbeischauten. Sie haben jederzeit die Möglichkeit,
-erneut ein Monatsabonnement {{link_offer_monthly_abo}} oder eine 
+erneut ein Monatsabonnement {{link_offer_monthly_abo}} oder eine
 Jahresmitgliedschaft {{link_offer_abo}} abzuschliessen.
 
-Falls Sie Fragen haben, helfen wir Ihnen gerne weiter unter kontakt@republik.ch 
+Falls Sie Fragen haben, helfen wir Ihnen gerne weiter unter kontakt@republik.ch
 .
 
-{{else}} Heute endete Ihr Republik-Abonnement. Herzlichen Dank für Ihr Interesse und Ihre
+{{else}}
+
+Heute endete Ihr Republik-Abonnement. Herzlichen Dank für Ihr Interesse und Ihre
 Unterstützung bis hierhin!
 
 Wir würden uns sehr freuen, wenn Sie zu einem späteren Zeitpunkt wieder bei uns
@@ -22,21 +26,23 @@ vorbeischauten.
 Sie sind jederzeit willkommen und können Ihr Monatsabo hier ganz einfach wieder
 aktivieren {{link_account_abos}} .
 
-{{/if}} Herzlich
+{{/if}}
+
+Herzlich
 
 Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/subscription_failed.txt
+++ b/packages/mail/templates/subscription_failed.txt
@@ -8,7 +8,7 @@ Wir danken Ihnen dafür, dass Sie sicherstellen, dass Ihre Kreditkarte wieder
 belastbar ist.
 
 Falls Sie eine andere Kreditkarte verwenden wollen, können Sie die nötigen
-Änderungen hier jederzeit vornehmen: www.republik.ch/konto {{link_account}} 
+Änderungen hier jederzeit vornehmen: {{link_account}}
 
 Wenn wir Ihre Karte weiterhin nicht belasten können, gehen wir davon aus, dass
 Sie die Republik nicht mehr lesen möchten, und deaktivieren Ihr Abonnement.
@@ -16,19 +16,19 @@ Sie die Republik nicht mehr lesen möchten, und deaktivieren Ihr Abonnement.
 Haben Sie Fragen? Unter kontakt@republik.ch helfen wir Ihnen gerne weiter.
 
 Herzlich
-Ihre Crew der Republik 
+Ihre Crew der Republik
 
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/subscription_reactivate.txt
+++ b/packages/mail/templates/subscription_reactivate.txt
@@ -10,7 +10,7 @@ erhalten Sie mit dieser E-Mail auch Ihren Status als Verlegerin oder Verleger
 zurück.
 
 Die von Ihnen angegebene Kreditkarte belasten wir monatlich mit CHF 22.–.
-Ihre persönliche Übersicht zu Ihrem Abonnement finden Sie hier {{link_account}} 
+Ihre persönliche Übersicht zu Ihrem Abonnement finden Sie hier {{link_account}}
 .
 
 Am gleichen Ort können Sie alle Einstellungen vornehmen (und z. B.
@@ -24,14 +24,14 @@ Ihre Crew der Republik
 Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
 Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
 finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
-Beiträgen. In der App, auf der Website und als Newsletter. 
+Beiträgen. In der App, auf der Website und als Newsletter.
 
 
 Republik AG
 Sihlhallenstrasse 1, CH-8004 Zürich
-{{frontend_base_url}} 
-kontakt@republik.ch 
+{{frontend_base_url}}
+kontakt@republik.ch
 
-Unser Manifest {{link_manifest}} 
-Das Impressum {{link_imprint}} 
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
 Häufig gestellte Fragen {{link_faq}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4920,6 +4920,15 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-serializer@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.1.0.tgz#5f7c828f1bfc44887dc2a315ab5c45691d544b58"
+  integrity sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    entities "^2.0.0"
+
 dom-serializer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
@@ -4952,6 +4961,13 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^3.0.0, domhandler@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.3.0.tgz#6db7ea46e4617eb15cf875df68b2b8524ce0037a"
+  integrity sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==
+  dependencies:
+    domelementtype "^2.0.1"
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
@@ -4967,6 +4983,15 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.0.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.4.2.tgz#7ee5be261944e1ad487d9aa0616720010123922b"
+  integrity sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.3.0"
 
 dont-sniff-mimetype@1.1.0:
   version "1.1.0"
@@ -6895,17 +6920,18 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-html-to-text@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-5.1.1.tgz#2d89db7bf34bc7bcb7d546b1b228991a16926e87"
-  integrity sha512-Bci6bD/JIfZSvG4s0gW/9mMKwBRoe/1RWLxUME/d6WUSZCdY7T60bssf/jFf7EYXRyqU4P5xdClVqiYU0/ypdA==
+html-to-text@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-6.0.0.tgz#8b48adb1b781a8378f374c5bb481864a169f59f4"
+  integrity sha512-r0KNC5aqCAItsjlgtirW6RW25c92Ee3ybQj8z//4Sl4suE3HIPqM4deGpYCUJULLjtVPEP1+Ma+1ZeX1iMsCiA==
   dependencies:
+    deepmerge "^4.2.2"
     he "^1.2.0"
-    htmlparser2 "^3.10.1"
-    lodash "^4.17.11"
-    minimist "^1.2.0"
+    htmlparser2 "^4.1.0"
+    lodash "^4.17.20"
+    minimist "^1.2.5"
 
-htmlparser2@^3.10.1, htmlparser2@^3.9.1:
+htmlparser2@^3.9.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -6916,6 +6942,16 @@ htmlparser2@^3.10.1, htmlparser2@^3.9.1:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-cache-semantics@^4.0.0:
   version "4.1.0"
@@ -8700,6 +8736,11 @@ lodash@4.x, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, l
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-driver@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
This Pull Request moves [a claim link block towards beginning](https://github.com/orbiting/backends/pull/534/commits/673488ed13168edde975869452626bf77cbb6744) and to facilitate that, [updates dependencies and adopts script which generates plain text mail templates](https://github.com/orbiting/backends/commit/4423c1c8e2db36fc79389f46bba0f60ff9415a23).

It thus fixes several bugs or caveats:
- [missing handlebar tags to generate items](https://github.com/orbiting/backends/compare/pae/fix-mail-text-templates?expand=1#diff-4bf9f7fc07be08662775a7567cafe55d07061b0c1e690cce508ec8b80df00b2bR30-R32)
- [handlebar tag in confusing pairs](https://github.com/orbiting/backends/compare/pae/fix-mail-text-templates?expand=1#diff-f1d5391ab39c49b0700ddd77b5ac20e4cfca6211439b4f0f451eb4411d84ed89L29-L30)
- [renders customization restore message obsolete](https://github.com/orbiting/backends/commit/32e4e10d15d4c7dbf08864e54575a3e2be9438d4)
- [offers block looks much neater](https://github.com/orbiting/backends/compare/pae/fix-mail-text-templates?expand=1#diff-7fe687cae37b3a09baf555b85ed10141dde9a980334a35871b633bf81956edd2R37-R41)
- remove trailing whitespaces
- may introduce some more new lines than sexy (handlebar tags are considered "text blocks")

A note on review this motherload of changes: Check [code (and dependency) changes](https://github.com/orbiting/backends/commit/4423c1c8e2db36fc79389f46bba0f60ff9415a23) (comments should help along) and then walk through links in bugs and caveats list.