### PR TITLE
feat(discussions): Introduce featured targets

### DIFF
--- a/packages/discussions/graphql/resolvers/_mutations/featureComment.js
+++ b/packages/discussions/graphql/resolvers/_mutations/featureComment.js
@@ -1,8 +1,10 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
 const slack = require('../../../lib/slack')
 
+const { getDefaultFeaturedTarget } = require('../../../lib/Comment')
+
 module.exports = async (_, args, context) => {
-  const { id, content, targets = ['DEFAULT'] } = args
+  const { id, content, targets = [getDefaultFeaturedTarget()] } = args
   const { pgdb, user: me, t, loaders, pubsub } = context
 
   Roles.ensureUserHasRole(me, 'editor')

--- a/packages/discussions/graphql/resolvers/_mutations/featureComment.js
+++ b/packages/discussions/graphql/resolvers/_mutations/featureComment.js
@@ -41,6 +41,7 @@ module.exports = async (_, args, context) => {
       newComment,
       discussion,
       content,
+      targets,
       !!content,
       context,
     ),

--- a/packages/discussions/graphql/resolvers/_mutations/featureComment.js
+++ b/packages/discussions/graphql/resolvers/_mutations/featureComment.js
@@ -2,7 +2,7 @@ const { Roles } = require('@orbiting/backend-modules-auth')
 const slack = require('../../../lib/slack')
 
 module.exports = async (_, args, context) => {
-  const { id, content } = args
+  const { id, content, targets = ['DEFAULT'] } = args
   const { pgdb, user: me, t, loaders, pubsub } = context
 
   Roles.ensureUserHasRole(me, 'editor')
@@ -13,11 +13,18 @@ module.exports = async (_, args, context) => {
   }
   const discussion = await loaders.Discussion.byId.load(comment.discussionId)
 
+  console.log({
+    featuredAt: content ? new Date() : null,
+    featuredContent: content || null,
+    featuredTargets: content ? targets : null,
+  })
+
   const newComment = await pgdb.public.comments.updateAndGetOne(
     { id },
     {
       featuredAt: content ? new Date() : null,
       featuredContent: content || null,
+      featuredTargets: content ? targets : null,
     },
   )
 

--- a/packages/discussions/graphql/resolvers/_mutations/featureComment.js
+++ b/packages/discussions/graphql/resolvers/_mutations/featureComment.js
@@ -4,7 +4,7 @@ const slack = require('../../../lib/slack')
 const { getDefaultFeaturedTarget } = require('../../../lib/Comment')
 
 module.exports = async (_, args, context) => {
-  const { id, content, targets = [getDefaultFeaturedTarget()] } = args
+  const { id, content, targets = [] } = args
   const { pgdb, user: me, t, loaders, pubsub } = context
 
   Roles.ensureUserHasRole(me, 'editor')
@@ -15,11 +15,9 @@ module.exports = async (_, args, context) => {
   }
   const discussion = await loaders.Discussion.byId.load(comment.discussionId)
 
-  console.log({
-    featuredAt: content ? new Date() : null,
-    featuredContent: content || null,
-    featuredTargets: content ? targets : null,
-  })
+  if (!targets.length) {
+    targets.push(getDefaultFeaturedTarget())
+  }
 
   const newComment = await pgdb.public.comments.updateAndGetOne(
     { id },

--- a/packages/discussions/graphql/resolvers/_queries/comments.js
+++ b/packages/discussions/graphql/resolvers/_queries/comments.js
@@ -1,3 +1,4 @@
+const { getDefaultFeaturedTarget } = require('../../../lib/Comment')
 const getSortKey = require('../../../lib/sortKey')
 
 const MAX_LIMIT = 100
@@ -23,7 +24,7 @@ module.exports = async (_, args, context, info) => {
     focusId,
     lastId,
     featured,
-    featuredTarget
+    featuredTarget = getDefaultFeaturedTarget()
   } = options
 
   if (limit > MAX_LIMIT) {

--- a/packages/discussions/graphql/resolvers/_queries/comments.js
+++ b/packages/discussions/graphql/resolvers/_queries/comments.js
@@ -24,7 +24,7 @@ module.exports = async (_, args, context, info) => {
     focusId,
     lastId,
     featured,
-    featuredTarget = getDefaultFeaturedTarget()
+    featuredTarget = featured && getDefaultFeaturedTarget()
   } = options
 
   if (limit > MAX_LIMIT) {
@@ -41,7 +41,6 @@ module.exports = async (_, args, context, info) => {
         : ''
     }
     ${toDepth >= 0 ? 'c."depth" <= :toDepth AND' : ''}
-    ${featured ? 'c."featuredAt" IS NOT NULL AND' : ''}
     ${featuredTarget ? ':featuredTarget = ANY(c."featuredTargets") AND' : ''}
     c."published" = true AND
     c."adminUnpublished" = false

--- a/packages/discussions/graphql/resolvers/_queries/comments.js
+++ b/packages/discussions/graphql/resolvers/_queries/comments.js
@@ -23,6 +23,7 @@ module.exports = async (_, args, context, info) => {
     focusId,
     lastId,
     featured,
+    featuredTarget
   } = options
 
   if (limit > MAX_LIMIT) {
@@ -40,6 +41,7 @@ module.exports = async (_, args, context, info) => {
     }
     ${toDepth >= 0 ? 'c."depth" <= :toDepth AND' : ''}
     ${featured ? 'c."featuredAt" IS NOT NULL AND' : ''}
+    ${featuredTarget ? ':featuredTarget = ANY(c."featuredTargets") AND' : ''}
     c."published" = true AND
     c."adminUnpublished" = false
   `
@@ -67,7 +69,9 @@ module.exports = async (_, args, context, info) => {
       ${queryJoin}
       WHERE
         ${queryWhere}
-    `),
+    `, {
+      featuredTarget
+    }),
     pgdb.query(
       `
       SELECT
@@ -99,6 +103,7 @@ module.exports = async (_, args, context, info) => {
         lastId: lastId || null,
         limit,
         offset,
+        featuredTarget
       },
     ),
   ])

--- a/packages/discussions/graphql/schema-types.js
+++ b/packages/discussions/graphql/schema-types.js
@@ -214,8 +214,13 @@ type Comment {
 
   featuredAt: DateTime
   featuredText: String
+  featuredTargets: [CommentFeaturedTarget!]
 }
 
+enum CommentFeaturedTarget {
+  DEFAULT
+  MARKETING
+}
 
 type MentioningDocument {
   document: Document!

--- a/packages/discussions/graphql/schema-types.js
+++ b/packages/discussions/graphql/schema-types.js
@@ -1,3 +1,5 @@
+const { getFeaturedTargets } = require('../lib/Comment')
+
 module.exports = `
 
 type Credential {
@@ -218,8 +220,7 @@ type Comment {
 }
 
 enum CommentFeaturedTarget {
-  DEFAULT
-  MARKETING
+${getFeaturedTargets().join('\n')}
 }
 
 type MentioningDocument {

--- a/packages/discussions/graphql/schema.js
+++ b/packages/discussions/graphql/schema.js
@@ -24,6 +24,7 @@ type queries {
     focusId: ID
     lastId: ID
     featured: Boolean
+    featuredTarget: CommentFeaturedTarget
   ): CommentConnection!
 
   commentPreview(
@@ -88,6 +89,7 @@ type mutations {
   featureComment(
     id: ID!
     content: String
+    targets: [CommentFeaturedTarget!]
   ): Comment!
 }
 

--- a/packages/discussions/lib/Comment/index.js
+++ b/packages/discussions/lib/Comment/index.js
@@ -1,3 +1,22 @@
+const featuredTargets = [
+  { key: 'DEFAULT', default: true },
+  { key: 'MARKETING' }
+]
+
+if (!featuredTargets.find((t) => t.default)) {
+  throw new Error('At least featuredTarget needs default flag')
+}
+
+const getFeaturedTargets = () => {
+  return featuredTargets.map(t => t.key)
+}
+
+const getDefaultFeaturedTarget = () => {
+  return featuredTargets.find(t => t.default)?.key
+}
+
 module.exports = {
+  getFeaturedTargets,
+  getDefaultFeaturedTarget,
   transform: require('./transform'),
 }

--- a/packages/discussions/lib/Comment/index.js
+++ b/packages/discussions/lib/Comment/index.js
@@ -4,7 +4,7 @@ const featuredTargets = [
 ]
 
 if (!featuredTargets.find((t) => t.default)) {
-  throw new Error('At least featuredTarget needs default flag')
+  throw new Error('At least one featuredTarget needs default flag')
 }
 
 const getFeaturedTargets = () => {

--- a/packages/discussions/lib/slack.js
+++ b/packages/discussions/lib/slack.js
@@ -108,6 +108,7 @@ exports.publishCommentFeatured = async (
   comment,
   discussion,
   featuredText,
+  featuredTargets,
   featured,
   context,
 ) => {
@@ -119,10 +120,12 @@ exports.publishCommentFeatured = async (
         author,
       )}*`
 
+  const targets = featuredTargets.join(', ')
+
   const content = featured
     ? `${action} from <${await getCommentLink(comment, discussion, context)}|${
         discussion.title
-      }>:\n${featuredText}`
+      }> for target(s) ${targets}:\n${featuredText}`
     : `${action} from <${await getCommentLink(comment, discussion, context)}|${
         discussion.title
       }>`

--- a/packages/discussions/migrations/sqls/20201202033331-comment-featured-targets-down.sql
+++ b/packages/discussions/migrations/sqls/20201202033331-comment-featured-targets-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."comments" DROP COLUMN "featuredTargets";

--- a/packages/discussions/migrations/sqls/20201202033331-comment-featured-targets-up.sql
+++ b/packages/discussions/migrations/sqls/20201202033331-comment-featured-targets-up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."comments" ADD COLUMN "featuredTargets" text[];
+UPDATE "public"."comments" SET "featuredTargets" = '{DEFAULT}' WHERE "featuredAt" IS NOT NULL;

--- a/packages/migrations/migrations/20201202033331-comment-featured-targets.js
+++ b/packages/migrations/migrations/20201202033331-comment-featured-targets.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/discussions/migrations/sqls'
+const file = '20201202033331-comment-featured-targets'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)


### PR DESCRIPTION
This Pull Request allows to specify one or more targets a featured comment is aiming for and query for either target.

Available targets (`enum CommentFeaturedTarget`) thus far:

- `DEFAULT`
- `MARKETING`

A featured comment returns its targets on `Comment.featuredTargets`. If a comment is not featured, `Comment.featuredTargets` returns `null`.

**Mutations**

Mutation to feature a comment accepts no, one or more targets:

```gql
mutation featureCommentMutation($commentId: ID!, $content: String, $targets: [CommentFeaturedTarget!]) {
  featureComment(id: $commentId, content: $content, targets: $targets) {
    id
    __typename
  }
}
```

Providing no target will set `DEFAULT` as to prevent "targetless" featured comments.

**Queries**

Query for featured comments for Marketing purposes:

```gql
query featuredMarketing {
  comments(featuredTarget: MARKETING, orderBy: FEATURED_AT, orderDirection: DESC) {
    nodes {
      id
      featuredText
    }
  }
}
```

Query for featured comments for other purposes e.g. Magazine front:

```gql
query featuredMarketing {
  comments(featuredTarget: DEFAULT, orderBy: FEATURED_AT, orderDirection: DESC) {
    nodes {
      id
      featuredText
    }
  }
}
```

Query before is same as:

```gql
query featuredMarketing {
  comments(featured: true, orderBy: FEATURED_AT, orderDirection: DESC) {
    nodes {
      id
      featuredText
    }
  }
}
```