### PR TITLE
Revising transactional templates

### DIFF
--- a/packages/mail/lib/sendMailTemplate.js
+++ b/packages/mail/lib/sendMailTemplate.js
@@ -82,6 +82,10 @@ const envMergeVars = [
     content: `${FRONTEND_BASE_URL}/konto`,
   },
   {
+    name: 'link_account_goto',
+    content: `${FRONTEND_BASE_URL}/angebote?goto=account`,
+  },
+  {
     name: 'link_account_abos',
     content: `${FRONTEND_BASE_URL}/konto#abos`,
   },

--- a/packages/mail/templates/access_recipient_expired.html
+++ b/packages/mail/templates/access_recipient_expired.html
@@ -102,10 +102,8 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich automatisch, kann aber jederzeit und
-                          ohne Frist gekündigt werden. Mit diesem Abo erhalten
-                          Sie viel Kontext und Vertiefung – ohne dass Sie Teil
-                          unserer Genossenschaft werden.
+                          Mit diesem Abo erhalten Sie viel Kontext und Vertiefung
+                          – ohne dass Sie Teil unserer Genossenschaft werden.
                         </p>
                       </li>
                       <li>
@@ -114,12 +112,9 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich nicht automatisch, wir erinnern Sie
-                          aber immer rechtzeitig daran, die Mitgliedschaft zu
-                          erneuern. Mit dieser Mitgliedschaft erhalten Sie
-                          unabhängigen und werbefreien Qualitätsjournalismus und
-                          sind gleichzeitig Teil der Republik-Community und der
-                          Project R Genossenschaft.
+                          Mit dieser Mitgliedschaft erhalten Sie unabhängigen und
+                          werbefreien Qualitätsjournalismus und sind gleichzeitig
+                          Teil der Republik-Community und der Project R Genossenschaft.
                         </p>
                       </li>
                       <li>
@@ -130,8 +125,6 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich nicht automatisch, wir erinnern Sie
-                          aber rechtzeitig daran, die Gönnerschaft zu erneuern.
                           Mit der Gönnerschaft erhalten Sie Zugang zum
                           vollständigen Republik-Angebot, ein Extra-Dankeschön
                           in Form eines Buches und die Sicherheit, etwas sehr
@@ -149,9 +142,7 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich nicht automatisch, wir erinnern Sie
-                          aber rechtzeitig daran, die Mitgliedschaft zu
-                          erneuern. Mit dieser Mitgliedschaft erhalten alle
+                          Mit dieser Mitgliedschaft erhalten alle
                           Auszubildenden und Studierenden Zugang zum
                           vollständigen Republik-Angebot inklusive
                           Genossenschafts-Mitgliedschaft – zu einem reduzierten

--- a/packages/mail/templates/access_recipient_expired.html
+++ b/packages/mail/templates/access_recipient_expired.html
@@ -104,6 +104,8 @@
                         >
                           Mit diesem Abo erhalten Sie viel Kontext und Vertiefung
                           – ohne dass Sie Teil unserer Genossenschaft werden.
+                          Verlängert sich automatisch, kann aber jederzeit und
+                          ohne Frist gekündigt werden.
                         </p>
                       </li>
                       <li>

--- a/packages/mail/templates/access_recipient_expired.txt
+++ b/packages/mail/templates/access_recipient_expired.txt
@@ -37,32 +37,28 @@ Die Republik-Abonnemente/-Mitgliedschaften in der Übersicht:
 
  1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat
     
-    Verlängert sich automatisch, kann aber jederzeit und ohne Frist gekündigt
-    werden. Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass
-    Sie Teil unserer Genossenschaft werden.
+    Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass Sie Teil
+    unserer Genossenschaft werden.
 
  2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr
     
-    Verlängert sich nicht automatisch, wir erinnern Sie aber immer rechtzeitig
-    daran, die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten
-    Sie unabhängigen und werbefreien Qualitätsjournalismus und sind gleichzeitig
-    Teil der Republik-Community und der Project R Genossenschaft.
+    Mit dieser Mitgliedschaft erhalten Sie unabhängigen und werbefreien
+    Qualitätsjournalismus und sind gleichzeitig Teil der Republik-Community und
+    der Project R Genossenschaft.
 
  3. Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr
     
-    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
-    die Gönnerschaft zu erneuern. Mit der Gönnerschaft erhalten Sie Zugang zum
-    vollständigen Republik-Angebot, ein Extra-Dankeschön in Form eines Buches
-    und die Sicherheit, etwas sehr Wichtiges zur Erhaltung einer wirklich freien
-    Demokratie beigetragen zu haben. Zudem sind Sie Teil der Republik-Community
-    und der Project R Genossenschaft.
+    Mit der Gönnerschaft erhalten Sie Zugang zum vollständigen Republik-Angebot,
+    ein Extra-Dankeschön in Form eines Buches und die Sicherheit, etwas sehr
+    Wichtiges zur Erhaltung einer wirklich freien Demokratie beigetragen zu
+    haben. Zudem sind Sie Teil der Republik-Community und der Project R
+    Genossenschaft.
 
  4. Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} CHF 140.–/Jahr
     
-    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
-    die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten alle
-    Auszubildenden und Studierenden Zugang zum vollständigen Republik-Angebot
-    inklusive Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
+    Mit dieser Mitgliedschaft erhalten alle Auszubildenden und Studierenden
+    Zugang zum vollständigen Republik-Angebot inklusive
+    Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
 
 Haben Sie Fragen oder brauchen Sie Hilfe? Unter kontakt@republik.ch helfen wir
 Ihnen gerne weiter.

--- a/packages/mail/templates/access_recipient_expired.txt
+++ b/packages/mail/templates/access_recipient_expired.txt
@@ -38,7 +38,8 @@ Die Republik-Abonnemente/-Mitgliedschaften in der Übersicht:
  1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat
     
     Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass Sie Teil
-    unserer Genossenschaft werden.
+    unserer Genossenschaft werden. Verlängert sich automatisch, kann aber
+    jederzeit und ohne Frist gekündigt werden.
 
  2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr
     

--- a/packages/mail/templates/access_recipient_followup.html
+++ b/packages/mail/templates/access_recipient_followup.html
@@ -104,10 +104,10 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
+                          Mit diesem Abo erhalten Sie viel Kontext und Vertiefung
+                          – ohne dass Sie Teil unserer Genossenschaft werden.
                           Verlängert sich automatisch, kann aber jederzeit und
-                          ohne Frist gekündigt werden. Mit diesem Abo erhalten
-                          Sie viel Kontext und Vertiefung – ohne dass Sie Teil
-                          unserer Genossenschaft werden.
+                          ohne Frist gekündigt werden. 
                         </p>
                       </li>
                       <li>
@@ -116,12 +116,9 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich nicht automatisch, wir erinnern Sie
-                          aber immer rechtzeitig daran, die Mitgliedschaft zu
-                          erneuern. Mit dieser Mitgliedschaft erhalten Sie
-                          unabhängigen und werbefreien Qualitätsjournalismus und
-                          sind gleichzeitig Teil der Republik-Community und der
-                          Project R Genossenschaft.
+                          Mit dieser Mitgliedschaft erhalten Sie unabhängigen und
+                          werbefreien Qualitätsjournalismus und sind gleichzeitig
+                          Teil der Republik-Community und der Project R Genossenschaft.
                         </p>
                       </li>
                       <li>
@@ -132,8 +129,6 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich nicht automatisch, wir erinnern Sie
-                          aber rechtzeitig daran, die Gönnerschaft zu erneuern.
                           Mit der Gönnerschaft erhalten Sie Zugang zum
                           vollständigen Republik-Angebot, ein Extra-Dankeschön
                           in Form eines Buches und die Sicherheit, etwas sehr
@@ -151,11 +146,9 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich nicht automatisch, wir erinnern Sie
-                          aber rechtzeitig daran, die Mitgliedschaft zu
-                          erneuern. Mit dieser Mitgliedschaft erhalten alle
-                          Auszubildenden und Studierenden Zugang zum
-                          vollständigen Republik-Angebot inklusive
+                          Mit dieser Mitgliedschaft erhalten alle Auszubildenden
+                          und Studierenden Zugang zum vollständigen
+                          Republik-Angebot inklusive
                           Genossenschafts-Mitgliedschaft – zu einem reduzierten
                           Preis.
                         </p>

--- a/packages/mail/templates/access_recipient_followup.txt
+++ b/packages/mail/templates/access_recipient_followup.txt
@@ -36,32 +36,29 @@ Die Republik-Abonnemente/-Mitgliedschaften in der Übersicht:
 
  1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat
     
-    Verlängert sich automatisch, kann aber jederzeit und ohne Frist gekündigt
-    werden. Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass
-    Sie Teil unserer Genossenschaft werden.
+    Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass Sie Teil
+    unserer Genossenschaft werden. Verlängert sich automatisch, kann aber
+    jederzeit und ohne Frist gekündigt werden.
 
  2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr
     
-    Verlängert sich nicht automatisch, wir erinnern Sie aber immer rechtzeitig
-    daran, die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten
-    Sie unabhängigen und werbefreien Qualitätsjournalismus und sind gleichzeitig
-    Teil der Republik-Community und der Project R Genossenschaft.
+    Mit dieser Mitgliedschaft erhalten Sie unabhängigen und werbefreien
+    Qualitätsjournalismus und sind gleichzeitig Teil der Republik-Community und
+    der Project R Genossenschaft.
 
  3. Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr
     
-    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
-    die Gönnerschaft zu erneuern. Mit der Gönnerschaft erhalten Sie Zugang zum
-    vollständigen Republik-Angebot, ein Extra-Dankeschön in Form eines Buches
-    und die Sicherheit, etwas sehr Wichtiges zur Erhaltung einer wirklich freien
-    Demokratie beigetragen zu haben. Zudem sind Sie Teil der Republik-Community
-    und der Project R Genossenschaft.
+    Mit der Gönnerschaft erhalten Sie Zugang zum vollständigen Republik-Angebot,
+    ein Extra-Dankeschön in Form eines Buches und die Sicherheit, etwas sehr
+    Wichtiges zur Erhaltung einer wirklich freien Demokratie beigetragen zu
+    haben. Zudem sind Sie Teil der Republik-Community und der Project R
+    Genossenschaft.
 
  4. Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} CHF 140.–/Jahr
     
-    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
-    die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten alle
-    Auszubildenden und Studierenden Zugang zum vollständigen Republik-Angebot
-    inklusive Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
+    Mit dieser Mitgliedschaft erhalten alle Auszubildenden und Studierenden
+    Zugang zum vollständigen Republik-Angebot inklusive
+    Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
 
 Ob Sie dazugehören wollen, ist nun Ihre Entscheidung. {{link_offers_overview}}
 

--- a/packages/mail/templates/access_recipient_onboarding.html
+++ b/packages/mail/templates/access_recipient_onboarding.html
@@ -130,10 +130,10 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
+                          Mit diesem Abo erhalten Sie viel Kontext und Vertiefung
+                          – ohne dass Sie Teil unserer Genossenschaft werden.
                           Verlängert sich automatisch, kann aber jederzeit und
-                          ohne Frist gekündigt werden. Mit diesem Abo erhalten
-                          Sie viel Kontext und Vertiefung – ohne dass Sie Teil
-                          unserer Genossenschaft werden.
+                          ohne Frist gekündigt werden.
                         </p>
                       </li>
                       <li>
@@ -142,12 +142,9 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich nicht automatisch, wir erinnern Sie
-                          aber immer rechtzeitig daran, die Mitgliedschaft zu
-                          erneuern. Mit dieser Mitgliedschaft erhalten Sie
-                          unabhängigen und werbefreien Qualitätsjournalismus und
-                          sind gleichzeitig Teil der Republik-Community und der
-                          Project R Genossenschaft.
+                          Mit dieser Mitgliedschaft erhalten Sie unabhängigen und
+                          werbefreien Qualitätsjournalismus und sind gleichzeitig
+                          Teil der Republik-Community und der roject R Genossenschaft.
                         </p>
                       </li>
                       <li>
@@ -158,8 +155,6 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich nicht automatisch, wir erinnern Sie
-                          aber rechtzeitig daran, die Gönnerschaft zu erneuern.
                           Mit der Gönnerschaft erhalten Sie Zugang zum
                           vollständigen Republik-Angebot, ein Extra-Dankeschön
                           in Form eines Buches und die Sicherheit, etwas sehr
@@ -177,11 +172,9 @@
                         <p
                           style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
                         >
-                          Verlängert sich nicht automatisch, wir erinnern Sie
-                          aber rechtzeitig daran, die Mitgliedschaft zu
-                          erneuern. Mit dieser Mitgliedschaft erhalten alle
-                          Auszubildenden und Studierenden Zugang zum
-                          vollständigen Republik-Angebot inklusive
+                          Mit dieser Mitgliedschaft erhalten alle Auszubildenden
+                          und Studierenden Zugang zum vollständigen
+                          Republik-Angebot inklusive
                           Genossenschafts-Mitgliedschaft – zu einem reduzierten
                           Preis.
                         </p>

--- a/packages/mail/templates/access_recipient_onboarding.txt
+++ b/packages/mail/templates/access_recipient_onboarding.txt
@@ -49,32 +49,29 @@ Die Republik-Abonnemente/-Mitgliedschaften in der Übersicht:
 
  1. Monatsabonnement {{link_offer_monthly_abo}} CHF 22.–/Monat
     
-    Verlängert sich automatisch, kann aber jederzeit und ohne Frist gekündigt
-    werden. Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass
-    Sie Teil unserer Genossenschaft werden.
+    Mit diesem Abo erhalten Sie viel Kontext und Vertiefung – ohne dass Sie Teil
+    unserer Genossenschaft werden. Verlängert sich automatisch, kann aber
+    jederzeit und ohne Frist gekündigt werden.
 
  2. Jahresmitgliedschaft {{link_offer_abo}} CHF 240.–/Jahr
     
-    Verlängert sich nicht automatisch, wir erinnern Sie aber immer rechtzeitig
-    daran, die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten
-    Sie unabhängigen und werbefreien Qualitätsjournalismus und sind gleichzeitig
-    Teil der Republik-Community und der Project R Genossenschaft.
+    Mit dieser Mitgliedschaft erhalten Sie unabhängigen und werbefreien
+    Qualitätsjournalismus und sind gleichzeitig Teil der Republik-Community und
+    der roject R Genossenschaft.
 
  3. Gönnermitgliedschaft {{link_offer_benefactor}} ab CHF 1000.–/Jahr
     
-    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
-    die Gönnerschaft zu erneuern. Mit der Gönnerschaft erhalten Sie Zugang zum
-    vollständigen Republik-Angebot, ein Extra-Dankeschön in Form eines Buches
-    und die Sicherheit, etwas sehr Wichtiges zur Erhaltung einer wirklich freien
-    Demokratie beigetragen zu haben. Zudem sind Sie Teil der Republik-Community
-    und der Project R Genossenschaft.
+    Mit der Gönnerschaft erhalten Sie Zugang zum vollständigen Republik-Angebot,
+    ein Extra-Dankeschön in Form eines Buches und die Sicherheit, etwas sehr
+    Wichtiges zur Erhaltung einer wirklich freien Demokratie beigetragen zu
+    haben. Zudem sind Sie Teil der Republik-Community und der Project R
+    Genossenschaft.
 
  4. Ausbildungsmitgliedschaft {{link_offer_reduced_ausbildung}} CHF 140.–/Jahr
     
-    Verlängert sich nicht automatisch, wir erinnern Sie aber rechtzeitig daran,
-    die Mitgliedschaft zu erneuern. Mit dieser Mitgliedschaft erhalten alle
-    Auszubildenden und Studierenden Zugang zum vollständigen Republik-Angebot
-    inklusive Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
+    Mit dieser Mitgliedschaft erhalten alle Auszubildenden und Studierenden
+    Zugang zum vollständigen Republik-Angebot inklusive
+    Genossenschafts-Mitgliedschaft – zu einem reduzierten Preis.
 
 Haben Sie Fragen oder brauchen Sie Hilfe? Unter kontakt@republik.ch helfen wir
 Ihnen gerne weiter.

--- a/packages/mail/templates/membership_owner_autopay_failed.html
+++ b/packages/mail/templates/membership_owner_autopay_failed.html
@@ -41,10 +41,7 @@
               <tbody>
                 <tr>
                   <td style="padding: 20px">
-                    <p>
-                      Sehr geehrte Dame<br />
-                      Sehr geehrter Herr
-                    </p>
+                    <p>Guten Tag</p>
                     {{#if `attempt_number == 3`}}
                     <p>
                       Ihre Mitgliedschaft erneuerte sich am {{end_date}} um ein

--- a/packages/mail/templates/membership_owner_autopay_failed.txt
+++ b/packages/mail/templates/membership_owner_autopay_failed.txt
@@ -1,5 +1,4 @@
-Sehr geehrte Dame
-Sehr geehrter Herr
+Guten Tag
 
 {{#if `attempt_number == 3`}}
 

--- a/packages/mail/templates/membership_owner_autopay_notice.html
+++ b/packages/mail/templates/membership_owner_autopay_notice.html
@@ -41,10 +41,7 @@
               <tbody>
                 <tr>
                   <td style="padding: 20px">
-                    <p>
-                      Sehr geehrte Dame<br />
-                      Sehr geehrter Herr
-                    </p>
+                    <p>Guten Tag</p>
                     <p>
                       Am {{end_date}} erneuert sich Ihre Mitgliedschaft um ein
                       weiteres Jahr. Herzlichen Dank für Ihre Unterstützung. Wir

--- a/packages/mail/templates/membership_owner_autopay_notice.txt
+++ b/packages/mail/templates/membership_owner_autopay_notice.txt
@@ -1,5 +1,4 @@
-Sehr geehrte Dame
-Sehr geehrter Herr
+Guten Tag
 
 Am {{end_date}} erneuert sich Ihre Mitgliedschaft um ein weiteres Jahr.
 Herzlichen Dank für Ihre Unterstützung. Wir sind sehr froh, Sie an Bord zu

--- a/packages/mail/templates/membership_owner_autopay_successful.html
+++ b/packages/mail/templates/membership_owner_autopay_successful.html
@@ -41,10 +41,7 @@
               <tbody>
                 <tr>
                   <td style="padding: 20px">
-                    <p>
-                      Sehr geehrte Dame<br />
-                      Sehr geehrter Herr
-                    </p>
+                    <p>Guten Tag</p>
                     <p>
                       Wir haben Ihre Mitgliedschaft automatisch um ein weiteres
                       Jahr verlängert und dafür Ihre

--- a/packages/mail/templates/membership_owner_autopay_successful.txt
+++ b/packages/mail/templates/membership_owner_autopay_successful.txt
@@ -1,5 +1,4 @@
-Sehr geehrte Dame
-Sehr geehrter Herr
+Guten Tag
 
 Wir haben Ihre Mitgliedschaft automatisch um ein weiteres Jahr verlängert und
 dafür Ihre {{autopay_card_brand}}-Kreditkarte mit den Endziffern

--- a/packages/mail/templates/membership_owner_prolong_notice.html
+++ b/packages/mail/templates/membership_owner_prolong_notice.html
@@ -44,7 +44,7 @@
                     <p>Guten Tag</p>
                     <p>Ihre Mitgliedschaft erneuert sich am {{end_date}}.</p>
                     <p>
-                      Wir freuen uns, Sie weiterhin an Bord zu haben, denn die
+                      Wir freuen uns, Sie bei uns an Bord zu haben, denn die
                       Republik und die Idee hinter unserem gemeinsamen Projekt
                       brauchen Sie!
                     </p>
@@ -100,8 +100,8 @@
                         >Sie bleiben an Bord und investieren damit weiter in die
                         Republik und ihre Idee.</a
                       ><br />
-                      Sie kündigen Ihre Mitgliedschaft bis zum
-                      {{cancel_until_date}}.
+                      <a href="{{cancel_url}}">Sie kündigen Ihre Mitgliedschaft bis zum
+                      {{cancel_until_date}}.</a>
                     </p>
                     <p>
                       Wie auch immer Sie entscheiden: Wir hoffen, dass wir Sie

--- a/packages/mail/templates/membership_owner_prolong_notice.txt
+++ b/packages/mail/templates/membership_owner_prolong_notice.txt
@@ -2,7 +2,7 @@ Guten Tag
 
 Ihre Mitgliedschaft erneuert sich am {{end_date}}.
 
-Wir freuen uns, Sie weiterhin an Bord zu haben, denn die Republik und die Idee
+Wir freuen uns, Sie bei uns an Bord zu haben, denn die Republik und die Idee
 hinter unserem gemeinsamen Projekt brauchen Sie!
 
 Ganz gleich, ob Sie uns einmal pro Woche, einmal pro Monat oder einmal pro Jahr
@@ -25,7 +25,7 @@ Magazin über ihre Leserinnen und Leser.
 Nun haben Sie die Wahl:
 Sie bleiben an Bord und investieren damit weiter in die Republik und ihre Idee.
 {{prolong_url}}
-Sie kündigen Ihre Mitgliedschaft bis zum {{cancel_until_date}}.
+Sie kündigen Ihre Mitgliedschaft bis zum {{cancel_until_date}}. {{cancel_url}}
 
 Wie auch immer Sie entscheiden: Wir hoffen, dass wir Sie im vergangenen Jahr
 immer wieder erfolgreich informiert, unterhalten, geärgert und beglückt haben.

--- a/packages/mail/templates/membership_owner_prolong_notice_7.html
+++ b/packages/mail/templates/membership_owner_prolong_notice_7.html
@@ -47,7 +47,7 @@
                       {{end_date}} um ein weiteres Jahr.
                     </p>
                     <p>
-                      Wir freuen uns, Sie weiterhin an Bord zu haben, denn die
+                      Wir freuen uns, Sie bei uns an Bord zu haben, denn die
                       Republik und die Idee hinter unserem gemeinsamen Projekt
                       brauchen Sie.
                     </p>

--- a/packages/mail/templates/membership_owner_prolong_notice_7.txt
+++ b/packages/mail/templates/membership_owner_prolong_notice_7.txt
@@ -3,7 +3,7 @@ Guten Tag
 Wie Sie wissen, erneuert sich Ihre Mitgliedschaft schon am {{end_date}} um ein
 weiteres Jahr.
 
-Wir freuen uns, Sie weiterhin an Bord zu haben, denn die Republik und die Idee
+Wir freuen uns, Sie bei uns an Bord zu haben, denn die Republik und die Idee
 hinter unserem gemeinsamen Projekt brauchen Sie.
 
 Jetzt erneuern {{prolong_url}}

--- a/packages/mail/templates/membership_winback_NO_MONEY.html
+++ b/packages/mail/templates/membership_winback_NO_MONEY.html
@@ -44,7 +44,7 @@
                     <p>Guten Tag</p>
                     <p>
                       Sie haben sich entschieden, Ihre Mitgliedschaft zu
-                      künden.<br />
+                      kündigen.<br />
                       Schade, sind Sie nicht mehr Teil der Republik und der Idee
                       hinter unserem gemeinsamen Projekt!
                     </p>

--- a/packages/mail/templates/membership_winback_NO_MONEY.txt
+++ b/packages/mail/templates/membership_winback_NO_MONEY.txt
@@ -1,6 +1,6 @@
 Guten Tag
 
-Sie haben sich entschieden, Ihre Mitgliedschaft zu künden.
+Sie haben sich entschieden, Ihre Mitgliedschaft zu kündigen.
 Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
 gemeinsamen Projekt!
 

--- a/packages/mail/templates/membership_winback_NO_TIME.html
+++ b/packages/mail/templates/membership_winback_NO_TIME.html
@@ -44,7 +44,7 @@
                     <p>Guten Tag</p>
                     <p>
                       Sie haben sich entschieden, Ihre Mitgliedschaft zu
-                      künden.<br />
+                      kündigen.<br />
                       Schade, sind Sie nicht mehr Teil der Republik und der Idee
                       hinter unserem gemeinsamen Projekt!
                     </p>

--- a/packages/mail/templates/membership_winback_NO_TIME.txt
+++ b/packages/mail/templates/membership_winback_NO_TIME.txt
@@ -1,6 +1,6 @@
 Guten Tag
 
-Sie haben sich entschieden, Ihre Mitgliedschaft zu künden.
+Sie haben sich entschieden, Ihre Mitgliedschaft zu kündigen.
 Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
 gemeinsamen Projekt!
 

--- a/packages/mail/templates/membership_winback_PAPER.html
+++ b/packages/mail/templates/membership_winback_PAPER.html
@@ -44,7 +44,7 @@
                     <p>Guten Tag</p>
                     <p>
                       Sie haben sich entschieden, Ihre Mitgliedschaft zu
-                      künden.<br />
+                      kündigen.<br />
                       Schade, sind Sie nicht mehr Teil der Republik und der Idee
                       hinter unserem gemeinsamen Projekt!
                     </p>

--- a/packages/mail/templates/membership_winback_PAPER.txt
+++ b/packages/mail/templates/membership_winback_PAPER.txt
@@ -1,6 +1,6 @@
 Guten Tag
 
-Sie haben sich entschieden, Ihre Mitgliedschaft zu künden.
+Sie haben sich entschieden, Ihre Mitgliedschaft zu kündigen.
 Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
 gemeinsamen Projekt!
 

--- a/packages/mail/templates/membership_winback_TOO_EXPENSIVE.html
+++ b/packages/mail/templates/membership_winback_TOO_EXPENSIVE.html
@@ -44,7 +44,7 @@
                     <p>Guten Tag</p>
                     <p>
                       Sie haben sich entschieden, Ihre Mitgliedschaft zu
-                      künden.<br />
+                      kündigen.<br />
                       Schade, sind Sie nicht mehr Teil der Republik und der Idee
                       hinter unserem gemeinsamen Projekt!
                     </p>

--- a/packages/mail/templates/membership_winback_TOO_EXPENSIVE.txt
+++ b/packages/mail/templates/membership_winback_TOO_EXPENSIVE.txt
@@ -1,6 +1,6 @@
 Guten Tag
 
-Sie haben sich entschieden, Ihre Mitgliedschaft zu künden.
+Sie haben sich entschieden, Ihre Mitgliedschaft zu kündigen.
 Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
 gemeinsamen Projekt!
 

--- a/packages/mail/templates/payment_successful_abo.html
+++ b/packages/mail/templates/payment_successful_abo.html
@@ -103,8 +103,7 @@
                       Mitgliedschaft noch ein Republik-Objekt gegönnt. {{elseif
                       `goodies_count > 1`}} Sie haben sich zu Ihrer
                       Mitgliedschaft noch mehrere Republik-Objekte gegönnt.
-                      {{/if}} Bücher und Taschen liefern wir innerhalb von 7
-                      Werktagen.
+                      {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
                     </p>
                     <p>
                       <strong

--- a/packages/mail/templates/payment_successful_abo.html
+++ b/packages/mail/templates/payment_successful_abo.html
@@ -105,14 +105,6 @@
                       Mitgliedschaft noch mehrere Republik-Objekte gegönnt.
                       {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
                     </p>
-                    <p>
-                      <strong
-                        >Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                        unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
-                    </p>
                     {{/if}} {{#if `total > 1000`}}
                     <p>
                       Vielen Dank!<br />

--- a/packages/mail/templates/payment_successful_abo.txt
+++ b/packages/mail/templates/payment_successful_abo.txt
@@ -34,8 +34,8 @@ sich mit Ihren Kolleginnen und Kollegen in der Verlagsetage austauschen.
 
 {{#if `goodies_count == 1`}} Sie haben sich zu Ihrer Mitgliedschaft noch ein
 Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer
-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Bücher und Taschen
-liefern wir innerhalb von 7 Werktagen.
+Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Diese liefern wir
+innerhalb von 7 Werktagen.
 
 Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.

--- a/packages/mail/templates/payment_successful_abo.txt
+++ b/packages/mail/templates/payment_successful_abo.txt
@@ -37,9 +37,6 @@ Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer
 Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Diese liefern wir
 innerhalb von 7 Werktagen.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{/if}} {{#if `total > 1000`}}
 
 Vielen Dank!

--- a/packages/mail/templates/payment_successful_abo_give.html
+++ b/packages/mail/templates/payment_successful_abo_give.html
@@ -92,12 +92,6 @@
                       {{/if}} {{/options}}
                     </ul>
 
-                    <p>
-                      Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                      unter
-                      <a href="{{link_account_account}}">{{link_account}}</a>
-                      korrekt eingetragen haben.
-                    </p>
                     {{/if}} {{#if `num_access_granted_memberships > 0`}} {{#if
                     `num_access_granted_memberships == 1`}}
                     <p>

--- a/packages/mail/templates/payment_successful_abo_give.html
+++ b/packages/mail/templates/payment_successful_abo_give.html
@@ -82,7 +82,7 @@
                       Republik-Objekt eignet sich perfekt für die Code-Übergabe.
                       {{elseif `goodies_count > 1`}} Auch Ihre bestellten
                       Republik-Objekte eignen sich perfekt für die
-                      Code-Übergabe. {{/if}} Bücher und Taschen liefern wir
+                      Code-Übergabe. {{/if}} Wir liefern Ihnen die Bestellung
                       innerhalb von 7 Werktagen.
                     </p>
 

--- a/packages/mail/templates/payment_successful_abo_give.txt
+++ b/packages/mail/templates/payment_successful_abo_give.txt
@@ -29,9 +29,6 @@ Wir liefern Ihnen die Bestellung innerhalb von 7 Werktagen.
  * {{this.oamount}} {{this.olabel}}
    {{/if}} {{/options}}
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{/if}} {{#if `num_access_granted_memberships > 0`}} {{#if
 `num_access_granted_memberships == 1`}}
 

--- a/packages/mail/templates/payment_successful_abo_give.txt
+++ b/packages/mail/templates/payment_successful_abo_give.txt
@@ -23,7 +23,7 @@ nur auf die Seite {{link_claim}} gehen. Und ihn dort eingeben.
 {{#if `goodies_count == 1`}} Auch Ihr bestelltes Republik-Objekt eignet sich
 perfekt für die Code-Übergabe. {{elseif `goodies_count > 1`}} Auch Ihre
 bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. {{/if}}
-Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+Wir liefern Ihnen die Bestellung innerhalb von 7 Werktagen.
 
    {{#options}} {{#if `this.otype == "Goodie"`}}
  * {{this.oamount}} {{this.olabel}}

--- a/packages/mail/templates/payment_successful_abo_give_months.html
+++ b/packages/mail/templates/payment_successful_abo_give_months.html
@@ -85,15 +85,6 @@
                       <li>{{this.oamount}} {{this.olabel}}</li>
                       {{/if}} {{/options}}
                     </ul>
-
-                    <p>
-                      <strong
-                        >Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                        unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
-                    </p>
                     {{/if}}
 
                     <p>

--- a/packages/mail/templates/payment_successful_abo_give_months.html
+++ b/packages/mail/templates/payment_successful_abo_give_months.html
@@ -76,7 +76,7 @@
                       Republik-Objekt eignet sich perfekt für die Code-Übergabe.
                       {{elseif `goodies_count > 1`}} Auch Ihre bestellten
                       Republik-Objekte eignen sich perfekt für die
-                      Code-Übergabe. {{/if}} Bücher und Taschen liefern wir
+                      Code-Übergabe. {{/if}} Wir liefern Ihnen die Bestellung
                       innerhalb von 7 Werktagen.
                     </p>
 

--- a/packages/mail/templates/payment_successful_abo_give_months.txt
+++ b/packages/mail/templates/payment_successful_abo_give_months.txt
@@ -20,7 +20,7 @@ nur auf die Seite {{link_claim}} gehen. Und ihn dort eingeben.
 {{#if `goodies_count == 1`}} Auch Ihr bestelltes Republik-Objekt eignet sich
 perfekt für die Code-Übergabe. {{elseif `goodies_count > 1`}} Auch Ihre
 bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. {{/if}}
-Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+Wir liefern Ihnen die Bestellung innerhalb von 7 Werktagen.
 
    {{#options}} {{#if `this.otype == "Goodie"`}}
  * {{this.oamount}} {{this.olabel}}

--- a/packages/mail/templates/payment_successful_abo_give_months.txt
+++ b/packages/mail/templates/payment_successful_abo_give_months.txt
@@ -26,9 +26,6 @@ Wir liefern Ihnen die Bestellung innerhalb von 7 Werktagen.
  * {{this.oamount}} {{this.olabel}}
    {{/if}} {{/options}}
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{/if}}
 
 Vielen Dank!

--- a/packages/mail/templates/payment_successful_benefactor.html
+++ b/packages/mail/templates/payment_successful_benefactor.html
@@ -101,7 +101,7 @@
                       Gönner-Mitgliedschaft noch ein Republik-Objekt gegönnt.
                       {{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer
                       Gönner-Mitgliedschaft noch mehrere Republik-Objekte
-                      gegönnt. {{/if}} Bücher und Taschen liefern wir innerhalb
+                      gegönnt. {{/if}} Diese liefern wir innerhalb
                       von 7 Werktagen.
                     </p>
 

--- a/packages/mail/templates/payment_successful_benefactor.html
+++ b/packages/mail/templates/payment_successful_benefactor.html
@@ -88,13 +88,6 @@
                       >» zu.
                     </p>
 
-                    <p>
-                      Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                      unter
-                      <a href="{{link_account_account}}">{{link_account}}</a>
-                      korrekt eingetragen haben.
-                    </p>
-
                     {{#if goodies_count}}
                     <p>
                       {{#if `goodies_count == 1`}} Sie haben sich zu Ihrer
@@ -110,14 +103,6 @@
                       <li>{{this.oamount}} {{this.olabel}}</li>
                       {{/if}} {{/options}}
                     </ul>
-                    <p>
-                      <strong
-                        >Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                        unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
-                    </p>
                     {{/if}} {{#if `total > 1000`}}
                     <p>
                       Vielen Dank!<br />

--- a/packages/mail/templates/payment_successful_benefactor.txt
+++ b/packages/mail/templates/payment_successful_benefactor.txt
@@ -33,8 +33,8 @@ Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 
 {{#if `goodies_count == 1`}} Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch
 ein Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu
-Ihrer Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}}
-Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+Ihrer Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Diese
+liefern wir innerhalb von 7 Werktagen.
 
    {{#options}} {{#if `this.otype == "Goodie"`}}
  * {{this.oamount}} {{this.olabel}}

--- a/packages/mail/templates/payment_successful_benefactor.txt
+++ b/packages/mail/templates/payment_successful_benefactor.txt
@@ -26,9 +26,6 @@ exklusiven Republik-Anstecker in Gold sowie einer signierten Ausgabe von
 Constantin Seibts Buch «Deadline – Wie man besser schreibt
 https://keinundaber.ch/de/literary-work/deadline/ » zu.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{#if goodies_count}}
 
 {{#if `goodies_count == 1`}} Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch
@@ -39,9 +36,6 @@ liefern wir innerhalb von 7 Werktagen.
    {{#options}} {{#if `this.otype == "Goodie"`}}
  * {{this.oamount}} {{this.olabel}}
    {{/if}} {{/options}}
-
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
 
 {{/if}} {{#if `total > 1000`}}
 

--- a/packages/mail/templates/payment_successful_prolong.html
+++ b/packages/mail/templates/payment_successful_prolong.html
@@ -100,14 +100,6 @@
                       Sie haben sich noch mehrere Republik-Objekte gegönnt.
                       {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
                     </p>
-                    <p>
-                      <strong
-                        >Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                        unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
-                    </p>
                     {{/if}}
 
                     <p>

--- a/packages/mail/templates/payment_successful_prolong.html
+++ b/packages/mail/templates/payment_successful_prolong.html
@@ -83,25 +83,22 @@
                     </p>
                     {{/if}} {{#if `gifted_memberships_count == 1`}}
                     <p>
-                      Schön, dass Sie die Verbreitung der Republik noch mehr
-                      unterstützen: Sie haben auch die Geschenkmitgliedschaft
-                      verlängert. Wir haben die Beschenkte darüber per E-Mail
-                      informiert.
+                      Schön, dass Sie die Verbreitung der Republik auch mit
+                      einer Geschenkmitgliedschaft unterstützen. Wir haben die
+                      Beschenkte darüber per E-Mail informiert.
                     </p>
                     {{elseif `gifted_memberships_count > 1`}}
                     <p>
-                      Schön, dass Sie die Verbreitung der Republik noch mehr
-                      unterstützen: Sie haben auch Ihre Geschenkmitgliedschaften
-                      verlängert. Wir haben die Beschenkten darüber per E-Mail
-                      informiert.
+                      Schön, dass Sie die Verbreitung der Republik auch mit
+                      Geschenkmitgliedschaften unterstützen. Wir haben die
+                      Beschenkte darüber per E-Mail informiert.
                     </p>
                     {{/if}} {{#if goodies_count}}
                     <p>
                       {{#if `goodies_count == 1`}} Sie haben sich noch ein
                       Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}}
                       Sie haben sich noch mehrere Republik-Objekte gegönnt.
-                      {{/if}} Bücher und Taschen liefern wir innerhalb von 7
-                      Werktagen.
+                      {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
                     </p>
                     <p>
                       <strong

--- a/packages/mail/templates/payment_successful_prolong.txt
+++ b/packages/mail/templates/payment_successful_prolong.txt
@@ -42,9 +42,6 @@ unterstützen. Wir haben die Beschenkte darüber per E-Mail informiert.
 {{elseif `goodies_count > 1`}} Sie haben sich noch mehrere Republik-Objekte
 gegönnt. {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{/if}}
 
 Herzlich

--- a/packages/mail/templates/payment_successful_prolong.txt
+++ b/packages/mail/templates/payment_successful_prolong.txt
@@ -27,21 +27,20 @@ Herzlichen Dank für Ihre grosszügige Spende.
 
 {{/if}} {{#if `gifted_memberships_count == 1`}}
 
-Schön, dass Sie die Verbreitung der Republik noch mehr unterstützen: Sie haben
-auch die Geschenkmitgliedschaft verlängert. Wir haben die Beschenkte darüber per
-E-Mail informiert.
+Schön, dass Sie die Verbreitung der Republik auch mit einer
+Geschenkmitgliedschaft unterstützen. Wir haben die Beschenkte darüber per E-Mail
+informiert.
 
 {{elseif `gifted_memberships_count > 1`}}
 
-Schön, dass Sie die Verbreitung der Republik noch mehr unterstützen: Sie haben
-auch Ihre Geschenkmitgliedschaften verlängert. Wir haben die Beschenkten darüber
-per E-Mail informiert.
+Schön, dass Sie die Verbreitung der Republik auch mit Geschenkmitgliedschaften
+unterstützen. Wir haben die Beschenkte darüber per E-Mail informiert.
 
 {{/if}} {{#if goodies_count}}
 
 {{#if `goodies_count == 1`}} Sie haben sich noch ein Republik-Objekt gegönnt.
 {{elseif `goodies_count > 1`}} Sie haben sich noch mehrere Republik-Objekte
-gegönnt. {{/if}} Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+gegönnt. {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
 
 Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.

--- a/packages/mail/templates/payment_successful_tablebook.html
+++ b/packages/mail/templates/payment_successful_tablebook.html
@@ -69,13 +69,6 @@
 
                     <p>Bücher liefern wir innerhalb von 7 Werktagen.</p>
                     <p>
-                      <strong
-                        >Stellen Sie bitte sicher, dass Sie Ihre Adresse unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
-                    </p>
-                    <p>
                       Wir wünschen Ihnen anregende Lektüre mit der «Republik bei
                       Stromausfall».
                     </p>

--- a/packages/mail/templates/payment_successful_tablebook.txt
+++ b/packages/mail/templates/payment_successful_tablebook.txt
@@ -16,9 +16,6 @@ Ihre Zahlung ist erfolgreich bei uns eingegangen. Vielen Dank!
 
 Bücher liefern wir innerhalb von 7 Werktagen.
 
-Stellen Sie bitte sicher, dass Sie Ihre Adresse unter {{link_account_account}}
-korrekt eingetragen haben.
-
 Wir wünschen Ihnen anregende Lektüre mit der «Republik bei Stromausfall».
 
 Herzlich

--- a/packages/mail/templates/pledge_abo.html
+++ b/packages/mail/templates/pledge_abo.html
@@ -149,8 +149,7 @@
                       Mitgliedschaft noch ein Republik-Objekt gegönnt. {{elseif
                       `goodies_count > 1`}} Sie haben sich zu Ihrer
                       Mitgliedschaft noch mehrere Republik-Objekte gegönnt.
-                      {{/if}} Bücher und Taschen liefern wir innerhalb von 7
-                      Werktagen.
+                      {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
                     </p>
                     <p>
                       <strong

--- a/packages/mail/templates/pledge_abo.html
+++ b/packages/mail/templates/pledge_abo.html
@@ -151,14 +151,6 @@
                       Mitgliedschaft noch mehrere Republik-Objekte gegönnt.
                       {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
                     </p>
-                    <p>
-                      <strong
-                        >Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                        unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
-                    </p>
                     {{/if}} {{/unless}}
 
                     <p>

--- a/packages/mail/templates/pledge_abo.txt
+++ b/packages/mail/templates/pledge_abo.txt
@@ -71,9 +71,6 @@ Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer
 Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Diese liefern wir
 innerhalb von 7 Werktagen.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{/if}} {{/unless}}
 
 Vielen Dank!

--- a/packages/mail/templates/pledge_abo.txt
+++ b/packages/mail/templates/pledge_abo.txt
@@ -68,8 +68,8 @@ zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
 {{#if `goodies_count == 1`}} Sie haben sich zu Ihrer Mitgliedschaft noch ein
 Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer
-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Bücher und Taschen
-liefern wir innerhalb von 7 Werktagen.
+Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Diese liefern wir
+innerhalb von 7 Werktagen.
 
 Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.

--- a/packages/mail/templates/pledge_abo_give.html
+++ b/packages/mail/templates/pledge_abo_give.html
@@ -78,7 +78,7 @@
                       Republik-Objekt eignet sich perfekt für die Code-Übergabe.
                       {{elseif `goodies_count > 1`}} Auch Ihre bestellten
                       Republik-Objekte eignen sich perfekt für die
-                      Code-Übergabe. {{/if}} Bücher und Taschen liefern wir
+                      Code-Übergabe. {{/if}} Wir liefern Ihnen die Bestellung
                       innerhalb von 7 Werktagen.
                     </p>
 

--- a/packages/mail/templates/pledge_abo_give.html
+++ b/packages/mail/templates/pledge_abo_give.html
@@ -87,12 +87,6 @@
                       <li>{{this.oamount}} {{this.olabel}}</li>
                       {{/if}} {{/options}}
                     </ul>
-                    <p>
-                      Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                      unter
-                      <a href="{{link_account_account}}">{{link_account}}</a>
-                      korrekt eingetragen haben.
-                    </p>
                     {{/if}} {{/if}} {{#if `num_access_granted_memberships > 0`}}
                     {{#if `num_access_granted_memberships == 1`}}
                     <p>

--- a/packages/mail/templates/pledge_abo_give.txt
+++ b/packages/mail/templates/pledge_abo_give.txt
@@ -34,9 +34,6 @@ Wir liefern Ihnen die Bestellung innerhalb von 7 Werktagen.
  * {{this.oamount}} {{this.olabel}}
    {{/if}} {{/options}}
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{/if}} {{/if}} {{#if `num_access_granted_memberships > 0`}} {{#if
 `num_access_granted_memberships == 1`}}
 

--- a/packages/mail/templates/pledge_abo_give.txt
+++ b/packages/mail/templates/pledge_abo_give.txt
@@ -28,7 +28,7 @@ nur auf die Seite {{link_claim}} gehen. Und den Code dort eingeben.
 {{#if `goodies_count == 1`}} Auch Ihr bestelltes Republik-Objekt eignet sich
 perfekt für die Code-Übergabe. {{elseif `goodies_count > 1`}} Auch Ihre
 bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. {{/if}}
-Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+Wir liefern Ihnen die Bestellung innerhalb von 7 Werktagen.
 
    {{#options}} {{#if `this.otype == "Goodie"`}}
  * {{this.oamount}} {{this.olabel}}

--- a/packages/mail/templates/pledge_abo_give_months.html
+++ b/packages/mail/templates/pledge_abo_give_months.html
@@ -80,14 +80,6 @@
                       <li>{{this.oamount}} {{this.olabel}}</li>
                       {{/if}} {{/options}}
                     </ul>
-                    <p>
-                      <strong
-                        >Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                        unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
-                    </p>
                     {{/if}} {{/if}}
 
                     <p>

--- a/packages/mail/templates/pledge_abo_give_months.html
+++ b/packages/mail/templates/pledge_abo_give_months.html
@@ -71,7 +71,7 @@
                       Republik-Objekt eignet sich perfekt für die Code-Übergabe.
                       {{elseif `goodies_count > 1`}} Auch Ihre bestellten
                       Republik-Objekte eignen sich perfekt für die
-                      Code-Übergabe. {{/if}} Bücher und Taschen liefern wir
+                      Code-Übergabe. {{/if}} Wir liefern Ihnen die Bestellung
                       innerhalb von 7 Werktagen.
                     </p>
 

--- a/packages/mail/templates/pledge_abo_give_months.txt
+++ b/packages/mail/templates/pledge_abo_give_months.txt
@@ -21,7 +21,7 @@ nur auf die Seite {{link_claim}} gehen. Und den Code dort eingeben.
 {{#if `goodies_count == 1`}} Auch Ihr bestelltes Republik-Objekt eignet sich
 perfekt für die Code-Übergabe. {{elseif `goodies_count > 1`}} Auch Ihre
 bestellten Republik-Objekte eignen sich perfekt für die Code-Übergabe. {{/if}}
-Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+Wir liefern Ihnen die Bestellung innerhalb von 7 Werktagen.
 
    {{#options}} {{#if `this.otype == "Goodie"`}}
  * {{this.oamount}} {{this.olabel}}

--- a/packages/mail/templates/pledge_abo_give_months.txt
+++ b/packages/mail/templates/pledge_abo_give_months.txt
@@ -27,9 +27,6 @@ Wir liefern Ihnen die Bestellung innerhalb von 7 Werktagen.
  * {{this.oamount}} {{this.olabel}}
    {{/if}} {{/options}}
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{/if}} {{/if}}
 
 Informationen zur Zahlung Ihres Geschenkabonnements:

--- a/packages/mail/templates/pledge_benefactor.html
+++ b/packages/mail/templates/pledge_benefactor.html
@@ -93,12 +93,6 @@
                         >Deadline – Wie man besser schreibt</a
                       >» zu.
                     </p>
-                    <p>
-                      Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                      unter
-                      <a href="{{link_account_account}}">{{link_account}}</a>
-                      korrekt eingetragen haben.
-                    </p>
                     {{/if}}
 
                     <p>
@@ -169,14 +163,6 @@
                       Gönner-Mitgliedschaft noch mehrere Republik-Objekte
                       gegönnt. {{/if}} Diese liefern wir innerhalb
                       von 7 Werktagen.
-                    </p>
-                    <p>
-                      <strong
-                        >Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                        unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
                     </p>
                     {{/if}} {{/unless}}
 

--- a/packages/mail/templates/pledge_benefactor.html
+++ b/packages/mail/templates/pledge_benefactor.html
@@ -167,7 +167,7 @@
                       Gönner-Mitgliedschaft noch ein Republik-Objekt gegönnt.
                       {{elseif `goodies_count > 1`}} Sie haben sich zu Ihrer
                       Gönner-Mitgliedschaft noch mehrere Republik-Objekte
-                      gegönnt. {{/if}} Bücher und Taschen liefern wir innerhalb
+                      gegönnt. {{/if}} Diese liefern wir innerhalb
                       von 7 Werktagen.
                     </p>
                     <p>

--- a/packages/mail/templates/pledge_benefactor.txt
+++ b/packages/mail/templates/pledge_benefactor.txt
@@ -32,9 +32,6 @@ exklusiven Republik-Anstecker in Gold sowie einer signierten Ausgabe von
 Constantin Seibts Buch «Deadline – Wie man besser schreibt
 https://keinundaber.ch/de/literary-work/deadline/ » zu.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{/if}}
 
 Informationen zur Zahlung Ihres Abonnements und Ihrer Gönnerschaft:
@@ -80,9 +77,6 @@ zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 ein Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu
 Ihrer Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Diese
 liefern wir innerhalb von 7 Werktagen.
-
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
 
 {{/if}} {{/unless}}
 

--- a/packages/mail/templates/pledge_benefactor.txt
+++ b/packages/mail/templates/pledge_benefactor.txt
@@ -78,8 +78,8 @@ zu schreiben, sonst funktioniert die Zuordnung nicht. Danke!
 
 {{#if `goodies_count == 1`}} Sie haben sich zu Ihrer Gönner-Mitgliedschaft noch
 ein Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}} Sie haben sich zu
-Ihrer Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}}
-Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+Ihrer Gönner-Mitgliedschaft noch mehrere Republik-Objekte gegönnt. {{/if}} Diese
+liefern wir innerhalb von 7 Werktagen.
 
 Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.

--- a/packages/mail/templates/pledge_donate.html
+++ b/packages/mail/templates/pledge_donate.html
@@ -60,12 +60,11 @@
                       unserer Demokratie.
                     </p>
 
+                    {{#if `payment_method == "PAYMENTSLIP"`}}
                     <p>
                       Wichtige Informationen zu den Zahlungsformalitäten Ihrer
                       Spende:
                     </p>
-
-                    {{#if `payment_method == "PAYMENTSLIP"`}}
                     <p>
                       Sie haben den Weg der Banküberweisung für Ihre Spende
                       gewählt.<br />

--- a/packages/mail/templates/pledge_donate.txt
+++ b/packages/mail/templates/pledge_donate.txt
@@ -11,9 +11,9 @@ gegenüber der Macht und Respekt vor dem Menschen.
 Mit Ihrem Geld fördern Sie die Republik – und damit auch eine unabhängige vierte
 Gewalt als zentrale Institution unserer Demokratie.
 
-Wichtige Informationen zu den Zahlungsformalitäten Ihrer Spende:
-
 {{#if `payment_method == "PAYMENTSLIP"`}}
+
+Wichtige Informationen zu den Zahlungsformalitäten Ihrer Spende:
 
 Sie haben den Weg der Banküberweisung für Ihre Spende gewählt.
 Bitte überweisen Sie {{total_formatted}} an:

--- a/packages/mail/templates/pledge_monthly_abo.html
+++ b/packages/mail/templates/pledge_monthly_abo.html
@@ -75,8 +75,8 @@
                     <p>
                       Die von Ihnen angegebene Kreditkarte belasten wir
                       monatlich mit CHF 22.–. Unter
-                      <a href="{{link_account}}">Konto</a> finden Sie Ihre
-                      <a href="{{link_account_abos}}"
+                      <a href="{{link_account_goto}}">Konto</a> finden Sie Ihre
+                      <a href="{{link_account_abos_goto}}"
                         >persönliche Übersicht zu Ihrem Abonnement</a
                       >. Am gleichen Ort können Sie alle Einstellungen vornehmen
                       (z. B. Kreditkarteninformationen ändern) oder das Abo

--- a/packages/mail/templates/pledge_monthly_abo.txt
+++ b/packages/mail/templates/pledge_monthly_abo.txt
@@ -17,10 +17,10 @@ Entscheidungen und Fehlern. Sie können Kritik üben und Vorschläge machen. Und
 sich mit Ihren Kolleginnen und Kollegen in der Verlagsetage austauschen.
 
 Die von Ihnen angegebene Kreditkarte belasten wir monatlich mit CHF 22.–. Unter
-Konto {{link_account}} finden Sie Ihre persönliche Übersicht zu Ihrem Abonnement
-{{link_account_abos}} . Am gleichen Ort können Sie alle Einstellungen vornehmen
-(z. B. Kreditkarteninformationen ändern) oder das Abo jederzeit kündigen. Was
-wir natürlich nicht hoffen.
+Konto {{link_account_goto}} finden Sie Ihre persönliche Übersicht zu Ihrem
+Abonnement {{link_account_abos_goto}} . Am gleichen Ort können Sie alle
+Einstellungen vornehmen (z. B. Kreditkarteninformationen ändern) oder das Abo
+jederzeit kündigen. Was wir natürlich nicht hoffen.
 
 Viel Vergnügen beim Start mit der Republik.
 

--- a/packages/mail/templates/pledge_prolong.html
+++ b/packages/mail/templates/pledge_prolong.html
@@ -130,13 +130,13 @@
                     {{/if}} {{#if `gifted_memberships_count == 1`}}
                     <p>
                       Vielen Dank, dass Sie die Republik anderen zukommen
-                      lassen: Sie verlängern auch das Geschenkabonnement. Wir
+                      lassen: Sie verlängern die Geschenkmitgliedschaft. Wir
                       haben die Beschenkte darüber per E-Mail informiert.
                     </p>
                     {{elseif `gifted_memberships_count > 1`}}
                     <p>
                       Vielen Dank, dass Sie die Republik anderen zukommen
-                      lassen: Sie verlängern auch Ihre Geschenkabonnemente. Wir
+                      lassen: Sie verlängern Geschenkmitgliedschaften. Wir
                       haben die Beschenkten darüber per E-Mail informiert.
                     </p>
                     {{/if}} {{#unless waiting_for_payment}} {{#if
@@ -145,7 +145,7 @@
                       {{#if `goodies_count == 1`}} Sie haben sich noch ein
                       Republik-Objekt gegönnt. {{elseif `goodies_count > 1`}}
                       Sie haben sich noch mehrere Republik-Objekte gegönnt.
-                      {{/if}} Bücher und Taschen liefern wir innerhalb von 7
+                      {{/if}} Diese liefern wir innerhalb von 7
                       Werktagen.
                     </p>
                     <p>

--- a/packages/mail/templates/pledge_prolong.html
+++ b/packages/mail/templates/pledge_prolong.html
@@ -148,14 +148,6 @@
                       {{/if}} Diese liefern wir innerhalb von 7
                       Werktagen.
                     </p>
-                    <p>
-                      <strong
-                        >Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse
-                        unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
-                    </p>
                     {{/if}} {{/unless}}
 
                     <p>Herzlich</p>

--- a/packages/mail/templates/pledge_prolong.txt
+++ b/packages/mail/templates/pledge_prolong.txt
@@ -78,9 +78,6 @@ informiert.
 {{elseif `goodies_count > 1`}} Sie haben sich noch mehrere Republik-Objekte
 gegönnt. {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
 
-Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
-{{link_account_account}} korrekt eingetragen haben.
-
 {{/if}} {{/unless}}
 
 Herzlich

--- a/packages/mail/templates/pledge_prolong.txt
+++ b/packages/mail/templates/pledge_prolong.txt
@@ -63,20 +63,20 @@ Herzlichen Dank für Ihre grosszügige Spende!
 
 {{/if}} {{#if `gifted_memberships_count == 1`}}
 
-Vielen Dank, dass Sie die Republik anderen zukommen lassen: Sie verlängern auch
-das Geschenkabonnement. Wir haben die Beschenkte darüber per E-Mail informiert.
+Vielen Dank, dass Sie die Republik anderen zukommen lassen: Sie verlängern die
+Geschenkmitgliedschaft. Wir haben die Beschenkte darüber per E-Mail informiert.
 
 {{elseif `gifted_memberships_count > 1`}}
 
-Vielen Dank, dass Sie die Republik anderen zukommen lassen: Sie verlängern auch
-Ihre Geschenkabonnemente. Wir haben die Beschenkten darüber per E-Mail
+Vielen Dank, dass Sie die Republik anderen zukommen lassen: Sie verlängern
+Geschenkmitgliedschaften. Wir haben die Beschenkten darüber per E-Mail
 informiert.
 
 {{/if}} {{#unless waiting_for_payment}} {{#if goodies_count}}
 
 {{#if `goodies_count == 1`}} Sie haben sich noch ein Republik-Objekt gegönnt.
 {{elseif `goodies_count > 1`}} Sie haben sich noch mehrere Republik-Objekte
-gegönnt. {{/if}} Bücher und Taschen liefern wir innerhalb von 7 Werktagen.
+gegönnt. {{/if}} Diese liefern wir innerhalb von 7 Werktagen.
 
 Stellen Sie dafür bitte sicher, dass Sie Ihre Adresse unter
 {{link_account_account}} korrekt eingetragen haben.

--- a/packages/mail/templates/pledge_tablebook.html
+++ b/packages/mail/templates/pledge_tablebook.html
@@ -73,14 +73,6 @@
                       Zahlungseingang.{{/if}}
                     </p>
 
-                    <p>
-                      <strong
-                        >Stellen Sie bitte sicher, dass Sie Ihre Adresse unter
-                        <a href="{{link_account_account}}">{{link_account}}</a>
-                        korrekt eingetragen haben.</strong
-                      >
-                    </p>
-
                     {{#if `payment_method == "PAYMENTSLIP"`}}
                     <p>
                       Sie haben eine Banküberweisung als Zahlungsweg gewählt.

--- a/packages/mail/templates/pledge_tablebook.txt
+++ b/packages/mail/templates/pledge_tablebook.txt
@@ -17,9 +17,6 @@ Vielen Dank für Ihre Bestellung. Hier die wichtigsten Informationen dazu:
 Bücher liefern wir innerhalb von 7 Werktagen. {{#if waiting_for_payment}}Der
 Versand erfolgt erst nach Zahlungseingang.{{/if}}
 
-Stellen Sie bitte sicher, dass Sie Ihre Adresse unter {{link_account_account}}
-korrekt eingetragen haben.
-
 {{#if `payment_method == "PAYMENTSLIP"`}}
 
 Sie haben eine Banküberweisung als Zahlungsweg gewählt.

--- a/packages/mail/templates/subscription_end.html
+++ b/packages/mail/templates/subscription_end.html
@@ -45,7 +45,7 @@
                     {{#if is_automatic_overdue_cancel}}
                     <p>
                       Leider konnten wir
-                      <a href="{{link_account_abos}}"
+                      <a href="{{link_account_abos_goto}}"
                         >Ihr Republik-Monatsabonnement</a
                       >
                       wiederholt nicht von Ihrer Kreditkarte abbuchen und
@@ -79,7 +79,7 @@
                     </p>
                     <p>
                       Sie sind jederzeit willkommen und können
-                      <a href="{{link_account_abos}}"
+                      <a href="{{link_account_abos_goto}}"
                         >Ihr Monatsabo hier ganz einfach wieder aktivieren</a
                       >.
                     </p>

--- a/packages/mail/templates/subscription_end.html
+++ b/packages/mail/templates/subscription_end.html
@@ -56,9 +56,8 @@
                       Ihre Unterstützung bis hierhin! Und wir würden uns sehr
                       freuen, wenn Sie zu einem späteren Zeitpunkt wieder bei
                       uns vorbeischauten. Sie haben jederzeit die Möglichkeit,
-                      erneut ein
-                      <a href="{{link_offer_monthly_abo}}">Monatsabonnement</a>
-                      oder eine
+                      <a href="{{link_account_abos_goto}}">Ihr Monatsabonnement
+                        zu reaktivieren</a> oder eine
                       <a href="{{link_offer_abo}}">Jahresmitgliedschaft</a>
                       abzuschliessen.
                     </p>

--- a/packages/mail/templates/subscription_end.txt
+++ b/packages/mail/templates/subscription_end.txt
@@ -2,7 +2,7 @@ Guten Tag
 
 {{#if is_automatic_overdue_cancel}}
 
-Leider konnten wir Ihr Republik-Monatsabonnement {{link_account_abos}}
+Leider konnten wir Ihr Republik-Monatsabonnement {{link_account_abos_goto}}
 wiederholt nicht von Ihrer Kreditkarte abbuchen und mussten es aus diesem Grund
 deaktivieren.
 
@@ -24,7 +24,7 @@ Wir würden uns sehr freuen, wenn Sie zu einem späteren Zeitpunkt wieder bei un
 vorbeischauten.
 
 Sie sind jederzeit willkommen und können Ihr Monatsabo hier ganz einfach wieder
-aktivieren {{link_account_abos}} .
+aktivieren {{link_account_abos_goto}} .
 
 {{/if}}
 

--- a/packages/mail/templates/subscription_end.txt
+++ b/packages/mail/templates/subscription_end.txt
@@ -9,7 +9,7 @@ deaktivieren.
 Wir danken Ihnen herzlich für Ihr bisheriges Interesse und Ihre Unterstützung
 bis hierhin! Und wir würden uns sehr freuen, wenn Sie zu einem späteren
 Zeitpunkt wieder bei uns vorbeischauten. Sie haben jederzeit die Möglichkeit,
-erneut ein Monatsabonnement {{link_offer_monthly_abo}} oder eine
+Ihr Monatsabonnement zu reaktivieren {{link_account_abos_goto}} oder eine
 Jahresmitgliedschaft {{link_offer_abo}} abzuschliessen.
 
 Falls Sie Fragen haben, helfen wir Ihnen gerne weiter unter kontakt@republik.ch

--- a/packages/mail/templates/subscription_failed.html
+++ b/packages/mail/templates/subscription_failed.html
@@ -54,7 +54,7 @@
                     <p>
                       Falls Sie eine andere Kreditkarte verwenden wollen, können
                       Sie die nötigen Änderungen hier jederzeit vornehmen:
-                      <a href="{{link_account}}">www.republik.ch/konto</a>
+                      <a href="{{link_account_goto}}">www.republik.ch/konto</a>
                     </p>
                     <p>
                       Und für den Fall, dass Sie sich vorstellen könnten,

--- a/packages/mail/templates/subscription_failed.html
+++ b/packages/mail/templates/subscription_failed.html
@@ -57,6 +57,13 @@
                       <a href="{{link_account}}">www.republik.ch/konto</a>
                     </p>
                     <p>
+                      Und für den Fall, dass Sie sich vorstellen könnten,
+                      längerfristig bei uns an Bord zu bleiben, würden wir uns
+                      sehr freuen, wenn Sie bei dieser Gelegenheit auf eine
+                      <a href="{{link_offer_abo}}">Jahresmitgliedschaft</a>
+                      wechselten.
+                    </p>
+                    <p>
                       Wenn wir Ihre Karte weiterhin nicht belasten können, gehen
                       wir davon aus, dass Sie die Republik nicht mehr lesen
                       möchten, und deaktivieren Ihr Abonnement.

--- a/packages/mail/templates/subscription_failed.txt
+++ b/packages/mail/templates/subscription_failed.txt
@@ -10,6 +10,10 @@ belastbar ist.
 Falls Sie eine andere Kreditkarte verwenden wollen, können Sie die nötigen
 Änderungen hier jederzeit vornehmen: {{link_account}}
 
+Und für den Fall, dass Sie sich vorstellen könnten, längerfristig bei uns an
+Bord zu bleiben, würden wir uns sehr freuen, wenn Sie bei dieser Gelegenheit auf
+eine Jahresmitgliedschaft {{link_offer_abo}} wechselten.
+
 Wenn wir Ihre Karte weiterhin nicht belasten können, gehen wir davon aus, dass
 Sie die Republik nicht mehr lesen möchten, und deaktivieren Ihr Abonnement.
 

--- a/packages/mail/templates/subscription_failed.txt
+++ b/packages/mail/templates/subscription_failed.txt
@@ -8,7 +8,7 @@ Wir danken Ihnen dafür, dass Sie sicherstellen, dass Ihre Kreditkarte wieder
 belastbar ist.
 
 Falls Sie eine andere Kreditkarte verwenden wollen, können Sie die nötigen
-Änderungen hier jederzeit vornehmen: {{link_account}}
+Änderungen hier jederzeit vornehmen: {{link_account_goto}}
 
 Und für den Fall, dass Sie sich vorstellen könnten, längerfristig bei uns an
 Bord zu bleiben, würden wir uns sehr freuen, wenn Sie bei dieser Gelegenheit auf

--- a/packages/mail/templates/subscription_reactivate.html
+++ b/packages/mail/templates/subscription_reactivate.html
@@ -63,7 +63,7 @@
                       Die von Ihnen angegebene Kreditkarte belasten wir
                       monatlich mit CHF 22.–.<br />
                       Ihre
-                      <a href="{{link_account}}"
+                      <a href="{{link_account_abos_goto}}"
                         >persönliche Übersicht zu Ihrem Abonnement finden Sie
                         hier</a
                       >.

--- a/packages/mail/templates/subscription_reactivate.txt
+++ b/packages/mail/templates/subscription_reactivate.txt
@@ -10,8 +10,8 @@ erhalten Sie mit dieser E-Mail auch Ihren Status als Verlegerin oder Verleger
 zurück.
 
 Die von Ihnen angegebene Kreditkarte belasten wir monatlich mit CHF 22.–.
-Ihre persönliche Übersicht zu Ihrem Abonnement finden Sie hier {{link_account}}
-.
+Ihre persönliche Übersicht zu Ihrem Abonnement finden Sie hier
+{{link_account_abos_goto}} .
 
 Am gleichen Ort können Sie alle Einstellungen vornehmen (und z. B.
 Kreditkarteninformationen ändern) oder das Abo auch wieder jederzeit kündigen.


### PR DESCRIPTION
Revision includes:
- [Changes suggested in "Transactional-E-Mails November 2020"](https://docs.google.com/document/d/1P5wc-ILZ16nGTj_cK0fcabwFt3BGS05Zte0qYNpK0QM/edit?ts=5fca5c23#).
- To avoid opening app if membership-altering links are used, it uses `/angebote?goto=account` ("proxy link") instead of `/account`.
- In light of [shipping address feature coming up](https://github.com/orbiting/backends/pull/541), paragraphs inquiring to add address were removed.