### PR TITLE
Fix Draft Exposure

### DIFF
--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/submitPledge.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/submitPledge.js
@@ -289,7 +289,10 @@ module.exports = async (_, args, context) => {
         }) // try to load existing user by email
         if (
           user &&
-          !!(await transaction.public.pledges.findFirst({ userId: user.id }))
+          !!(await transaction.public.pledges.findFirst({
+            userId: user.id,
+            'status !=': 'DRAFT',
+          }))
         ) {
           // user has pledges
           await transaction.transactionRollback()

--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/submitPledge.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/submitPledge.js
@@ -289,7 +289,7 @@ module.exports = async (_, args, context) => {
         }) // try to load existing user by email
         if (
           user &&
-          !!(await transaction.public.pledges.findFirst({
+          !!(await transaction.public.pledges.count({
             userId: user.id,
             'status !=': 'DRAFT',
           }))

--- a/packages/republik/graphql/resolvers/User.js
+++ b/packages/republik/graphql/resolvers/User.js
@@ -139,10 +139,6 @@ module.exports = {
     key ? getKeyId(key) : null,
   ),
   email: (user, ...rest) => {
-    // special case for pledging: check packages/republik-crowdfundings/graphql/resolvers/Pledge.js
-    if (user._exposeEmail) {
-      return user.email
-    }
     return exposeAccessField('emailAccessRole', 'email')(user, ...rest)
   },
   emailAccessRole(user, args, { user: me }) {


### PR DESCRIPTION
For aborted PostFinance and PayPal transaction I need to be able to query `firstName`, `lastName` and `shippingAddress` when not signed in.

Also changes `submitPledge` to skip `emailVerify` if a user only has draft pledges (e.g. an aborted PostFinance pledge).