### PR TITLE
feat(documents): Process node modifiers

### DIFF
--- a/packages/documents/graphql/resolvers/Document.js
+++ b/packages/documents/graphql/resolvers/Document.js
@@ -6,6 +6,7 @@ const {
   processRepoImageUrlsInMeta,
   processImageUrlsInContent,
   processEmbedsInContent,
+  processNodeModifiersInContent,
 } = require('../../lib/process')
 const { getMeta } = require('../../lib/meta')
 
@@ -80,6 +81,7 @@ module.exports = {
       }
 
       processMembersOnlyZonesInContent(doc.content, context.user)
+      processNodeModifiersInContent(doc.content, context.user)
     }
     return doc.content
   },
@@ -161,6 +163,7 @@ module.exports = {
           processImageUrlsInContent(node, addWebpSuffix)
         }
         processMembersOnlyZonesInContent(node, context.user)
+        processNodeModifiersInContent(node, context.user)
 
         return extractIdsFromNode(node, doc.meta.repoId)
       })

--- a/packages/documents/lib/modifiers/index.js
+++ b/packages/documents/lib/modifiers/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  mergePropsWhenUserHasSomeRole: require('./mergePropsWhenUserHasSomeRole'),
+}

--- a/packages/documents/lib/modifiers/mergePropsWhenUserHasSomeRole.js
+++ b/packages/documents/lib/modifiers/mergePropsWhenUserHasSomeRole.js
@@ -1,0 +1,15 @@
+/**
+ * If user has one or more roles from {settings.roles}, {settings.props}
+ * is merged into {node.data.props}.
+ *
+ */
+module.exports = (settings, node, user) => {
+  const { roles, props } = settings
+
+  if (roles?.some?.((role) => user?.roles?.includes?.(role))) {
+    node.data.props = {
+      ...node.data.props,
+      ...props,
+    }
+  }
+}

--- a/packages/documents/lib/process.js
+++ b/packages/documents/lib/process.js
@@ -3,6 +3,8 @@ const {
   Roles: { userIsInRoles },
 } = require('@orbiting/backend-modules-auth')
 
+const modifiers = require('./modifiers')
+
 const { DOCUMENTS_RESTRICT_TO_ROLES } = process.env
 
 const processRepoImageUrlsInContent = (mdast, fn) => {
@@ -78,10 +80,22 @@ const processMembersOnlyZonesInContent = (mdast, user) => {
   })
 }
 
+const processNodeModifiersInContent = (mdast, user) => {
+  visit(mdast, 'zone', (node) => {
+    node.data?.modifiers?.forEach?.(({ name, ...settings }) =>
+      modifiers[name]?.(settings, node, user),
+    )
+
+    // Prevent modifiers prop to be exposed
+    delete node.data?.modifiers
+  })
+}
+
 module.exports = {
   processMembersOnlyZonesInContent,
   processRepoImageUrlsInContent,
   processRepoImageUrlsInMeta,
   processImageUrlsInContent,
   processEmbedsInContent,
+  processNodeModifiersInContent,
 }


### PR DESCRIPTION
This Pull Request is probably my most accomplished achievement.

A reviewer might want to freshen-up on [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) is it is used extensivly.

This Dynamic Component config …

```json
{
  "props": {
    "foo": "bar"
  },
  "src": "url-to-component",
  "modifiers": [
    {
      "name": "mergePropsWhenUserHasSomeRole",
      "props": {
        "additional": "additional-prop-when-user-has-member-role"
      },
      "roles": [
        "member"
      ]
    }
  ]
}
```

… should return when user is in member role:

```json
{
  "props": {
    "foo": "bar",
    "additional": "additional-prop-when-user-has-member-role"
  },
  "src": "url-to-component"
}
```

… should return when user has no member role:

```json
{
  "props": {
    "foo": "bar"
  },
  "src": "url-to-component"
}
```