### PR TITLE
Hide or default props data on unpublished nodes

### DIFF
--- a/packages/discussions/graphql/resolvers/Comment.js
+++ b/packages/discussions/graphql/resolvers/Comment.js
@@ -193,7 +193,7 @@ module.exports = {
   displayAuthor: async (comment, args, context) => {
     const { user: me, t, loaders } = context
 
-    const user = loaders.User.byId.load(comment.userId)
+    const user = await loaders.User.byId.load(comment.userId)
 
     if (
       (!comment.published && !Roles.userIsMe(user, me)) ||

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -719,6 +719,10 @@
       "value": "Sie können nur Ihre eigenen Beiträge bearbeiten."
     },
     {
+      "key": "api/comment/hidden/displayName",
+      "value": "Verborgen"
+    },
+    {
       "key": "api/comment/anonymous/displayName",
       "value": "Anonym"
     },


### PR DESCRIPTION
This Pull Request will hide (`displayAuthor`) or default `Comment` props (`upVotes`, `downVotes`). It also forwards `Comment.adminUnpublished` prop untarnished.

