### PR TITLE
feat(mail): Add subject prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,9 @@ SEND_MAILS_TAGS=dev,localhost
 # If Regular Expression is matched on a template name, mail is schedule instead of sent
 #SEND_MAILS_SCHEDULE_TEMPLATE_REGEX=^[^signin].*
 
+# If set, subject lines will be prefixed with "[Prefix]".
+SEND_MAILS_SUBJECT_PREFIX=Test
+
 # required for mails to work, set SEND_MAILS to false for a quick start
 #MANDRILL_API_KEY=
 

--- a/packages/mail/lib/sendMail.js
+++ b/packages/mail/lib/sendMail.js
@@ -51,7 +51,7 @@ module.exports = async (mail, context, log) => {
       // Default method to send emails
       const mandrill = MandrillInterface({ logger: console })
       if (mandrill.isUsable(mail, message)) {
-        return mandrill.send(mail)
+        return mandrill.send(message)
       }
 
       return [{ error: 'No mailing interface usable', status: 'error' }]

--- a/packages/mail/lib/sendMail.js
+++ b/packages/mail/lib/sendMail.js
@@ -13,6 +13,7 @@ const {
   DEFAULT_MAIL_FROM_ADDRESS,
   DEFAULT_MAIL_FROM_NAME,
   SEND_MAILS_TAGS,
+  SEND_MAILS_SUBJECT_PREFIX,
 } = process.env
 
 // usage
@@ -33,6 +34,10 @@ module.exports = async (mail, context, log) => {
   mail.from_email = mail.fromEmail || DEFAULT_MAIL_FROM_ADDRESS
   mail.from_name = mail.fromName || DEFAULT_MAIL_FROM_NAME
   mail.tags = tags
+  mail.subject =
+    (SEND_MAILS_SUBJECT_PREFIX &&
+      `[${SEND_MAILS_SUBJECT_PREFIX}] ${mail.subject}`) ||
+    mail.subject
   delete mail.fromName
   delete mail.fromEmail
 

--- a/packages/mail/lib/sendMailTemplate.js
+++ b/packages/mail/lib/sendMailTemplate.js
@@ -22,6 +22,7 @@ const {
   DEFAULT_MAIL_FROM_ADDRESS,
   DEFAULT_MAIL_FROM_NAME,
   SEND_MAILS_TAGS,
+  SEND_MAILS_SUBJECT_PREFIX,
   FRONTEND_BASE_URL,
   SG_FONT_STYLES,
   SG_FONT_FACES,
@@ -247,7 +248,10 @@ module.exports = async (mail, context, log) => {
 
   const message = {
     to: [{ email: mail.to }],
-    subject: mail.subject,
+    subject:
+      (SEND_MAILS_SUBJECT_PREFIX &&
+        `[${SEND_MAILS_SUBJECT_PREFIX}] ${mail.subject}`) ||
+      mail.subject,
     from_email: mail.fromEmail || DEFAULT_MAIL_FROM_ADDRESS,
     from_name: mail.fromName || DEFAULT_MAIL_FROM_NAME,
     html,


### PR DESCRIPTION
This Pull Request will prepend environment variable `SEND_MAILS_SUBJECT_PREFIX` to all transactional email subject lines. It should help recognize development, test and staging emails.

Example:
- `SEND_MAILS_SUBJECT_PREFIX=Test` will send email «Am 15.01.2021 erneuert sich Ihre Mitgliedschaft» as «[Test] Am 15.01.2021 erneuert sich Ihre Mitgliedschaft»