### PR TITLE
refactor(discussions): Replace ban environment variable w/ suspensions table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,10 +176,6 @@ AWS_SECRET_ACCESS_KEY=
 # the secret to hash userIds in discussions
 DISPLAY_AUTHOR_SECRET=RANDOM
 
-# temporary discussion bans, array of objects with userId & expire date as json
-# DISCUSSION_BANS=[{"userId": "57ff6996-e3ef-4186-a2e6-95376f2b086b", "expire": "2019-04-26T03:31:42.327Z"}]
-
-
 #############
 # github
 #############

--- a/packages/discussions/graphql/resolvers/DiscussionSuspension.js
+++ b/packages/discussions/graphql/resolvers/DiscussionSuspension.js
@@ -1,7 +1,21 @@
+const { Roles } = require('@orbiting/backend-modules-auth')
+
 module.exports = {
   user: (discussionSuspension, args, context) => {
     const { loaders } = context
 
     return loaders.User.byId.load(discussionSuspension.userId)
+  },
+  issuer: (discussionSuspension, args, context) => {
+    const { loaders, user: me } = context
+
+    if (
+      !discussionSuspension.issuerUserId ||
+      !Roles.userIsInRoles(me, ['editor', 'admin'])
+    ) {
+      return null
+    }
+
+    return loaders.User.byId.load(discussionSuspension.issuerUserId)
   },
 }

--- a/packages/discussions/graphql/resolvers/DiscussionSuspension.js
+++ b/packages/discussions/graphql/resolvers/DiscussionSuspension.js
@@ -1,0 +1,7 @@
+module.exports = {
+  user: (discussionSuspension, args, context) => {
+    const { loaders } = context
+
+    return loaders.User.byId.load(discussionSuspension.userId)
+  },
+}

--- a/packages/discussions/graphql/resolvers/User.js
+++ b/packages/discussions/graphql/resolvers/User.js
@@ -73,4 +73,38 @@ module.exports = {
       nodes,
     }
   },
+
+  isSuspended: async (user, args, { loaders, user: me }) => {
+    if (Roles.userIsMeOrInRoles(user, me, ['admin', 'supporter'])) {
+      return !!(await loaders.DiscussionSuspension.byUserId.load(user.id))
+        .length
+    }
+
+    return null
+  },
+  suspendedUntil: async (user, args, { loaders, user: me }) => {
+    if (Roles.userIsMeOrInRoles(user, me, ['admin', 'supporter'])) {
+      const suspensions = await loaders.DiscussionSuspension.byUserId.load(
+        user.id,
+      )
+
+      if (suspensions.length) {
+        const until = Math.max(...suspensions.map((s) => s.endAt))
+        return new Date(until)
+      }
+    }
+
+    return null
+  },
+  suspensions: async (user, args, { pgdb, loaders, user: me }) => {
+    if (Roles.userIsMeOrInRoles(user, me, ['admin', 'supporter'])) {
+      if (args.withInactive) {
+        return loaders.DiscussionSuspension.byUserIdWithInactive.load(user.id)
+      }
+
+      return loaders.DiscussionSuspension.byUserId.load(user.id)
+    }
+
+    return null
+  },
 }

--- a/packages/discussions/graphql/resolvers/_mutations/submitComment.js
+++ b/packages/discussions/graphql/resolvers/_mutations/submitComment.js
@@ -48,7 +48,7 @@ module.exports = async (_, args, context) => {
 
   const [canComment, waitUntil] = await Promise.all([
     userCanComment(discussion, null, context),
-    userWaitUntil(discussion, null, { pgdb, user }),
+    userWaitUntil(discussion, null, context),
   ])
   if (!canComment) {
     throw new Error(t('api/comment/canNotComment'))

--- a/packages/discussions/graphql/resolvers/_mutations/suspendUser.js
+++ b/packages/discussions/graphql/resolvers/_mutations/suspendUser.js
@@ -1,0 +1,25 @@
+const { Roles } = require('@orbiting/backend-modules-auth')
+
+module.exports = async (_, args, context) => {
+  const { pgdb, loaders, user: me } = context
+
+  Roles.ensureUserIsInRoles(me, ['admin', 'supporter'])
+
+  const tx = await pgdb.transactionBegin()
+  try {
+    await pgdb.public.discussionSuspensions.insert({
+      userId: args.id,
+      beginAt: new Date(),
+      ...(args.until && { endAt: args.until }),
+      ...(args.reason && { reason: args.reason }),
+    })
+    await tx.transactionCommit()
+  } catch (e) {
+    await tx.transactionRollback()
+    throw e
+  }
+
+  loaders.DiscussionSuspension.clear(args.id)
+
+  return loaders.User.byId.load(args.id)
+}

--- a/packages/discussions/graphql/resolvers/_mutations/suspendUser.js
+++ b/packages/discussions/graphql/resolvers/_mutations/suspendUser.js
@@ -1,5 +1,7 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
 
+const slack = require('../../../lib/slack')
+
 const DEFAULT_INTERVAL_DAYS = 7
 
 module.exports = async (_, args, context) => {
@@ -26,5 +28,10 @@ module.exports = async (_, args, context) => {
 
   loaders.DiscussionSuspension.clear(args.id)
 
-  return loaders.User.byId.load(args.id)
+  const suspensions = await loaders.DiscussionSuspension.byUserId.load(args.id)
+  const user = await loaders.User.byId.load(args.id)
+
+  await slack.publishUserSuspended(suspensions, user, context)
+
+  return user
 }

--- a/packages/discussions/graphql/resolvers/_mutations/suspendUser.js
+++ b/packages/discussions/graphql/resolvers/_mutations/suspendUser.js
@@ -1,5 +1,7 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
 
+const DEFAULT_INTERVAL_DAYS = 7
+
 module.exports = async (_, args, context) => {
   const { pgdb, loaders, user: me } = context
 
@@ -7,10 +9,13 @@ module.exports = async (_, args, context) => {
 
   const tx = await pgdb.transactionBegin()
   try {
+    const now = new Date()
     await pgdb.public.discussionSuspensions.insert({
       userId: args.id,
-      beginAt: new Date(),
-      ...(args.until && { endAt: args.until }),
+      beginAt: now,
+      endAt:
+        args.until || new Date().setDate(now.getDate() + DEFAULT_INTERVAL_DAYS),
+      issuerUserId: me.id,
       ...(args.reason && { reason: args.reason }),
     })
     await tx.transactionCommit()

--- a/packages/discussions/graphql/resolvers/_mutations/unsuspendUser.js
+++ b/packages/discussions/graphql/resolvers/_mutations/unsuspendUser.js
@@ -1,13 +1,16 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
 
+const slack = require('../../../lib/slack')
+
 module.exports = async (_, args, context) => {
   const { pgdb, loaders, user: me } = context
 
   Roles.ensureUserIsInRoles(me, ['admin', 'supporter'])
 
   const suspensions = await loaders.DiscussionSuspension.byUserId.load(args.id)
+  const user = await loaders.User.byId.load(args.id)
 
-  if (suspensions.length) {
+  if (user && suspensions.length) {
     const tx = await pgdb.transactionBegin()
     try {
       const now = new Date()
@@ -24,7 +27,9 @@ module.exports = async (_, args, context) => {
     }
 
     loaders.DiscussionSuspension.clear(args.id)
+
+    await slack.publishUserUnsuspended(null, user, context)
   }
 
-  return loaders.User.byId.load(args.id)
+  return user
 }

--- a/packages/discussions/graphql/resolvers/_mutations/unsuspendUser.js
+++ b/packages/discussions/graphql/resolvers/_mutations/unsuspendUser.js
@@ -1,0 +1,30 @@
+const { Roles } = require('@orbiting/backend-modules-auth')
+
+module.exports = async (_, args, context) => {
+  const { pgdb, loaders, user: me } = context
+
+  Roles.ensureUserIsInRoles(me, ['admin', 'supporter'])
+
+  const suspensions = await loaders.DiscussionSuspension.byUserId.load(args.id)
+
+  if (suspensions.length) {
+    const tx = await pgdb.transactionBegin()
+    try {
+      const now = new Date()
+
+      await pgdb.public.discussionSuspensions.update(
+        { id: suspensions.map((s) => s.id) },
+        { endAt: now, updatedAt: now },
+      )
+
+      await tx.transactionCommit()
+    } catch (e) {
+      await tx.transactionRollback()
+      throw e
+    }
+
+    loaders.DiscussionSuspension.clear(args.id)
+  }
+
+  return loaders.User.byId.load(args.id)
+}

--- a/packages/discussions/graphql/schema-types.js
+++ b/packages/discussions/graphql/schema-types.js
@@ -16,6 +16,10 @@ extend type User {
 
   defaultDiscussionNotificationOption: DiscussionNotificationOption
   discussionNotificationChannels: [DiscussionNotificationChannel!]!
+
+  isSuspended: Boolean
+  suspendedUntil: DateTime
+  suspensions(withInactive: Boolean): [DiscussionSuspension!]
 }
 
 enum Permission {
@@ -33,6 +37,16 @@ enum DiscussionNotificationChannel {
   WEB
   EMAIL
   APP
+}
+
+type DiscussionSuspension {
+  id: ID!
+  user: User!
+  beginAt: DateTime!
+  endAt: DateTime!
+  reason: String
+  createdAt: DateTime!
+  updatedAt: DateTime!
 }
 
 type DiscussionRules {

--- a/packages/discussions/graphql/schema-types.js
+++ b/packages/discussions/graphql/schema-types.js
@@ -45,6 +45,7 @@ type DiscussionSuspension {
   beginAt: DateTime!
   endAt: DateTime!
   reason: String
+  issuer: User
   createdAt: DateTime!
   updatedAt: DateTime!
 }

--- a/packages/discussions/graphql/schema.js
+++ b/packages/discussions/graphql/schema.js
@@ -91,6 +91,9 @@ type mutations {
     content: String
     targets: [CommentFeaturedTarget!]
   ): Comment!
+
+  suspendUser(id: ID!, until: DateTime, reason: String): User!
+  unsuspendUser(id: ID!): User!
 }
 
 type subscriptions {

--- a/packages/discussions/lib/slack.js
+++ b/packages/discussions/lib/slack.js
@@ -135,3 +135,30 @@ exports.publishCommentFeatured = async (
     unfurl_media: false,
   })
 }
+
+exports.publishUserSuspended = async (suspensions, user, context) => {
+  const until = Math.max(...suspensions.map((s) => s.endAt))
+
+  const content = [
+    `:children_crossing: *${getProfileLink(user)} suspended*`,
+    `ends on ${new Date(until).toISOString()}`,
+    `issued by ${getProfileLink(context.user)}`,
+  ].join('\n')
+
+  return publish(SLACK_CHANNEL_COMMENTS_ADMIN, content, {
+    unfurl_links: true,
+    unfurl_media: true,
+  })
+}
+
+exports.publishUserUnsuspended = async (suspensions, user, context) => {
+  const content = [
+    `:dove_of_peace: *${getProfileLink(user)} unsuspended early*`,
+    `by ${getProfileLink(context.user)}`,
+  ].join('\n')
+
+  return publish(SLACK_CHANNEL_COMMENTS_ADMIN, content, {
+    unfurl_links: true,
+    unfurl_media: true,
+  })
+}

--- a/packages/discussions/loaders/DiscussionSuspension.js
+++ b/packages/discussions/loaders/DiscussionSuspension.js
@@ -14,4 +14,12 @@ module.exports = (context) => ({
     null,
     (key, rows) => rows.filter((row) => row.userId === key),
   ),
+  byUserIdWithInactive: createDataLoader(
+    (userIds) =>
+      context.pgdb.public.discussionSuspensions.find({
+        userId: userIds,
+      }),
+    null,
+    (key, rows) => rows.filter((row) => row.userId === key),
+  ),
 })

--- a/packages/discussions/loaders/DiscussionSuspension.js
+++ b/packages/discussions/loaders/DiscussionSuspension.js
@@ -1,6 +1,16 @@
 const createDataLoader = require('@orbiting/backend-modules-dataloader')
 
 module.exports = (context) => ({
+  clear: async (userId) => {
+    const {
+      loaders: {
+        DiscussionSuspension: { byUserId, byUserIdWithInactive },
+      },
+    } = context
+
+    byUserId.clear(userId)
+    byUserIdWithInactive.clear(userId)
+  },
   byUserId: createDataLoader(
     (userIds) => {
       const now = new Date()

--- a/packages/discussions/loaders/DiscussionSuspension.js
+++ b/packages/discussions/loaders/DiscussionSuspension.js
@@ -1,0 +1,17 @@
+const createDataLoader = require('@orbiting/backend-modules-dataloader')
+
+module.exports = (context) => ({
+  byUserId: createDataLoader(
+    (userIds) => {
+      const now = new Date()
+
+      return context.pgdb.public.discussionSuspensions.find({
+        userId: userIds,
+        'beginAt <=': now,
+        'endAt >=': now,
+      })
+    },
+    null,
+    (key, rows) => rows.filter((row) => row.userId === key),
+  ),
+})

--- a/packages/discussions/loaders/index.js
+++ b/packages/discussions/loaders/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   Comment: require('./Comment'),
   Discussion: require('./Discussion'),
+  DiscussionSuspension: require('./DiscussionSuspension'),
 }

--- a/packages/discussions/migrations/sqls/20201218010032-user-suspensions-down.sql
+++ b/packages/discussions/migrations/sqls/20201218010032-user-suspensions-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "discussionSuspensions";

--- a/packages/discussions/migrations/sqls/20201218010032-user-suspensions-up.sql
+++ b/packages/discussions/migrations/sqls/20201218010032-user-suspensions-up.sql
@@ -1,11 +1,13 @@
 CREATE TABLE "discussionSuspensions" (
-  "id" uuid,
+  "id" uuid DEFAULT uuid_generate_v4(),
   "userId" uuid,
   "beginAt" timestamp with time zone NOT NULL DEFAULT now(),
   "endAt" timestamp with time zone NOT NULL DEFAULT now() + '1 week'::interval,
   "reason" text,
+  "issuerUserId" uuid,
   "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
   "updatedAt" timestamp with time zone NOT NULL DEFAULT now(),
   PRIMARY KEY ("id"),
-  FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+  FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY ("issuerUserId") REFERENCES "public"."users"("id") ON DELETE SET NULL ON UPDATE CASCADE
 );

--- a/packages/discussions/migrations/sqls/20201218010032-user-suspensions-up.sql
+++ b/packages/discussions/migrations/sqls/20201218010032-user-suspensions-up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "discussionSuspensions" (
+  "id" uuid,
+  "userId" uuid,
+  "beginAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "endAt" timestamp with time zone NOT NULL DEFAULT now() + '1 week'::interval,
+  "reason" text,
+  "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "updatedAt" timestamp with time zone NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id"),
+  FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/packages/migrations/migrations/20201218010032-user-suspensions.js
+++ b/packages/migrations/migrations/20201218010032-user-suspensions.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/discussions/migrations/sqls'
+const file = '20201218010032-user-suspensions'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
@@ -141,6 +141,7 @@ module.exports = async (_, args, context) => {
     await transaction.public.comments.update(from, to)
     await transaction.public.credentials.update(from, to)
     await transaction.public.consents.update(from, to)
+    await transaction.public.discussionSuspensions.update(from, to)
 
     await mergeCustomers({
       targetUserId: targetUser.id,
@@ -221,7 +222,7 @@ module.exports = async (_, args, context) => {
       () =>
         transaction.public.mailLog.update(
           { userId: null, email: sourceUser.email },
-          to
+          to,
         ),
       () => transaction.public.notifications.update(from, to),
       () =>

--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
@@ -142,6 +142,10 @@ module.exports = async (_, args, context) => {
     await transaction.public.credentials.update(from, to)
     await transaction.public.consents.update(from, to)
     await transaction.public.discussionSuspensions.update(from, to)
+    await transaction.public.discussionSuspensions.update(
+      { issuerUserId: sourceUser.id },
+      { issuerUserId: targetUser.id },
+    )
 
     await mergeCustomers({
       targetUserId: targetUser.id,


### PR DESCRIPTION
This Pull Request ought to replace `DISCUSSION_BANS` environment variable.

It allows to suspend via GraphQL mutations if current user has admin or supporter role:

```gql
mutation {
  suspendUser(id:"some-user-uuid" until:"2021-05-05") {
    suspendedUntil
  }
}
```

One might also want to revert a suspension prematurly with `unsuspendUser`:

```gql
mutation {
  unsuspendUser(id:"some-user-uuid") {
    isSuspended
  }
}
```

A suspended user is unable to post a new comment.

User data is extend with these props, accessible for user itself or user with admin or supporter role:

- `User.isSuspended: Boolean`, indicates whether or not a user is currently suspended
- `User.suspendedUntil: DateTime`, indicates until when a user is suspended
- `User.suspensions: [DiscussionSuspension!]`, returns a list of current suspensions. Use `withInactive: Boolean` argument to return inactive suspensions, too.



