### PR TITLE
Cancel notice w/ immediate deactivation phrase

### DIFF
--- a/packages/mail/templates/membership_cancel_notice.html
+++ b/packages/mail/templates/membership_cancel_notice.html
@@ -43,15 +43,13 @@
                   <td style="padding: 20px">
                     <p>Guten Tag</p>
                     <p>
-                      Schade, sind Sie nicht mehr Teil der Republik und der Idee
-                      hinter unserem gemeinsamen Projekt.
-                    </p>
-                    <p>
-                      Wir haben Ihre Kündigung erfasst:
-                      <strong
-                        >Ihr Abonnement läuft noch theoretisch bis zum
-                        {{end_date}} und wird nicht erneuert.</strong
-                      >
+                    {{#if membership_active}}
+                      Wir haben Ihre Kündigung erfasst. Ihr Abonnement läuft noch
+                      bis zum {{end_date}} und wird nicht erneuert.
+                    {{else}}
+                      Wir haben Ihre Kündigung erfasst und Ihr Abonnement
+                      deaktiviert.
+                    {{/if}}
                     </p>
                     <p>
                       Herzlichen Dank für Ihr Interesse und Ihre Unterstützung

--- a/packages/mail/templates/membership_cancel_notice.txt
+++ b/packages/mail/templates/membership_cancel_notice.txt
@@ -1,10 +1,8 @@
 Guten Tag
 
-Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
-gemeinsamen Projekt.
-
-Wir haben Ihre Kündigung erfasst: Ihr Abonnement läuft noch theoretisch bis zum
-{{end_date}} und wird nicht erneuert.
+{{#if membership_active}} Wir haben Ihre Kündigung erfasst. Ihr Abonnement läuft
+noch bis zum {{end_date}} und wird nicht erneuert. {{else}} Wir haben Ihre
+Kündigung erfasst und Ihr Abonnement deaktiviert. {{/if}}
 
 Herzlichen Dank für Ihr Interesse und Ihre Unterstützung bis hierhin!
 

--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/cancelMembership.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/cancelMembership.js
@@ -82,6 +82,7 @@ module.exports = async (_, args, context) => {
         email: user.email,
         name: user.name,
         endDate,
+        active: cancelledMembership.active,
         membershipType: membership.membershipType,
         reasonGiven: details.reason && details.reason.length > 1,
         t,

--- a/packages/republik-crowdfundings/lib/Mail.js
+++ b/packages/republik-crowdfundings/lib/Mail.js
@@ -246,6 +246,7 @@ mail.sendMembershipCancellation = async ({
   email,
   name,
   endDate,
+  active,
   membershipType,
   reasonGiven,
   t,
@@ -265,6 +266,10 @@ mail.sendMembershipCancellation = async ({
         {
           name: 'end_date',
           content: dateFormat(endDate),
+        },
+        {
+          name: 'membership_active',
+          content: active,
         },
         {
           name: 'membership_type',


### PR DESCRIPTION
This Pull Request enables switch in `membership_cancel_notice` template. It indicates whether membership is cancelled but remains active until last day, or is disabled at once.