### PR TITLE
Fix parse creditor references

### DIFF
--- a/packages/invoices/lib/paymentslip.ts
+++ b/packages/invoices/lib/paymentslip.ts
@@ -232,7 +232,7 @@ export function getReference(hrid: string, pretty?: boolean): string {
 }
 
 export function getHrId(string: string): string | null {
-  const [reference, hrid] = string.replace(/[^A-Za-z0-9]/g, '').match(/RF\d\dHRID([A-Za-z0-9]{6})/) || []
+  const [reference, hrid] = string.replace(/[^A-Za-z0-9]/g, '').match(/RF\d\d0{0,11}HRID([A-Za-z0-9]{6})/) || []
 
   if (!reference) {
     return null

--- a/packages/republik-crowdfundings/lib/scheduler/payments/fixtures/camt053mitteilung.xml
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/fixtures/camt053mitteilung.xml
@@ -36,7 +36,7 @@
           <TxDtls>
             <RmtInf>
               <Ustrd>
-                AAAAAA
+                AA AA AA BBBBBB
               </Ustrd>
             </RmtInf>
             <RltdPties>
@@ -245,6 +245,52 @@
         </NtryDtls>
         <AddtlNtryInf>
           MITTEILUNGEN: Falsche Pruefsumme RF99 HRID CCCC CC
+        </AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">240.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <BookgDt>
+          <Dt>2020-09-18</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2020-09-18</Dt>
+        </ValDt>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>RCDT</Cd>
+              <SubFmlyCd>ATXN</SubFmlyCd>
+            </Fmly>
+          </Domn>
+        </BkTxCd>
+        <NtryDtls>
+          <Btch>
+            <NbOfTxs>1</NbOfTxs>
+          </Btch>
+          <TxDtls>
+            <RmtInf>
+              <Ustrd>
+                Referenz: RF96 HRID EEEE EE Foobar
+              </Ustrd>
+            </RmtInf>
+            <RltdPties>
+              <Dbtr>
+                <Nm>Pierre Spring</Nm>
+                <PstlAdr>
+                  <StrtNm>Strasse</StrtNm>
+                  <BldgNb>123</BldgNb>
+                  <PstCd>1700</PstCd>
+                  <TwnNm>Fribourg</TwnNm>
+                  <Ctry>CH</Ctry>
+                </PstlAdr>
+              </Dbtr>
+            </RltdPties>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>
+          MITTEILUNGEN: Referenz: RF96 HRID EEEE EE Foobar
         </AddtlNtryInf>
       </Ntry>
     </Stmt>

--- a/packages/republik-crowdfundings/lib/scheduler/payments/fixtures/camt053reference.xml
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/fixtures/camt053reference.xml
@@ -107,7 +107,154 @@
           </TxDtls>
         </NtryDtls>
         <AddtlNtryInf>
-          MITTEILUNGEN: NOTPROVIDED REFERENZEN: XX YY RF92HRIDBBBBBB
+          REFERENZEN: XX YY RF92HRIDBBBBBB
+        </AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">240.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <BookgDt>
+          <Dt>2020-09-18</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2020-09-18</Dt>
+        </ValDt>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>RCDT</Cd>
+              <SubFmlyCd>ATXN</SubFmlyCd>
+            </Fmly>
+          </Domn>
+        </BkTxCd>
+        <NtryDtls>
+          <Btch>
+            <NbOfTxs>1</NbOfTxs>
+          </Btch>
+          <TxDtls>
+            <RmtInf>
+              <Strd>
+                <CdtrRefInf>
+                  <Ref>RF61HRIDCCCCCC</Ref>
+                </CdtrRefInf>
+              </Strd>
+            </RmtInf>
+            <RltdPties>
+              <Dbtr>
+                <Nm>Pierre Spring</Nm>
+                <PstlAdr>
+                  <StrtNm>Strasse</StrtNm>
+                  <BldgNb>123</BldgNb>
+                  <PstCd>1700</PstCd>
+                  <TwnNm>Fribourg</TwnNm>
+                  <Ctry>CH</Ctry>
+                </PstlAdr>
+              </Dbtr>
+            </RltdPties>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>
+          REFERENZEN: ZZZZZZ RF61HRIDCCCCCC
+        </AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">240.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <BookgDt>
+          <Dt>2020-09-18</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2020-09-18</Dt>
+        </ValDt>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>RCDT</Cd>
+              <SubFmlyCd>ATXN</SubFmlyCd>
+            </Fmly>
+          </Domn>
+        </BkTxCd>
+        <NtryDtls>
+          <Btch>
+            <NbOfTxs>1</NbOfTxs>
+          </Btch>
+          <TxDtls>
+            <RmtInf>
+              <Strd>
+                <CdtrRefInf>
+                  <Ref>RF9600000000000HRIDEEEEEE</Ref>
+                </CdtrRefInf>
+              </Strd>
+            </RmtInf>
+            <RltdPties>
+              <Dbtr>
+                <Nm>Pierre Spring</Nm>
+                <PstlAdr>
+                  <StrtNm>Strasse</StrtNm>
+                  <BldgNb>123</BldgNb>
+                  <PstCd>1700</PstCd>
+                  <TwnNm>Fribourg</TwnNm>
+                  <Ctry>CH</Ctry>
+                </PstlAdr>
+              </Dbtr>
+            </RltdPties>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>
+          REFERENZEN: RF9600000000000HRIDEEEEEE
+        </AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">240.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <BookgDt>
+          <Dt>2020-09-18</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2020-09-18</Dt>
+        </ValDt>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>RCDT</Cd>
+              <SubFmlyCd>ATXN</SubFmlyCd>
+            </Fmly>
+          </Domn>
+        </BkTxCd>
+        <NtryDtls>
+          <Btch>
+            <NbOfTxs>1</NbOfTxs>
+          </Btch>
+          <TxDtls>
+            <RmtInf>
+              <Strd>
+                <CdtrRefInf>
+                  <Ref>RF65HRIDFFFFFF</Ref>
+                </CdtrRefInf>
+              </Strd>
+              <Ustrd>
+                YYYYYY
+              </Ustrd>
+            </RmtInf>
+            <RltdPties>
+              <Dbtr>
+                <Nm>Pierre Spring</Nm>
+                <PstlAdr>
+                  <StrtNm>Strasse</StrtNm>
+                  <BldgNb>123</BldgNb>
+                  <PstCd>1700</PstCd>
+                  <TwnNm>Fribourg</TwnNm>
+                  <Ctry>CH</Ctry>
+                </PstlAdr>
+              </Dbtr>
+            </RltdPties>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>
+          MITTEILUNG: YYYYYY REFERENZEN: XX ZZ RF65HRIDFFFFFF
         </AddtlNtryInf>
       </Ntry>
     </Stmt>

--- a/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
@@ -249,12 +249,6 @@ function getMitteilung(
   avisierungstext: Avisierungstext,
   transactionDetails?: TransactionDetails,
 ): string | null {
-  const match = avisierungstext.match(
-    /.*?MITTEILUNGEN:.*?\s([A-Za-z0-9]{6})(\s.*?|$)/,
-  )
-
-  if (match) return match[1]
-
   const creditorReference = transactionDetails?.RmtInf?.Strd?.CdtrRefInf?.Ref
   const referenceHrId = creditorReference && paymentslip.getHrId(creditorReference)
 
@@ -272,6 +266,7 @@ function getMitteilung(
   return (
     paymentslip.getHrId(remittanceInformation) ||
     remittanceInformation?.match(/\b([A-Za-z0-9]{6})\b/)?.[1] ||
+    avisierungstext.match(/.*?MITTEILUNGEN:.*?\s([A-Za-z0-9]{6})(\s.*?|$)/)?.[1] ||
     null
   )
 }

--- a/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.u.jest.ts
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.u.jest.ts
@@ -45,6 +45,9 @@ describe('parseCamt053():', () => {
     const paymentEntries = parseCamt053(xmlString)
     expect(paymentEntries[0].mitteilung).toEqual('AAAAAA')
     expect(paymentEntries[1].mitteilung).toEqual('BBBBBB')
+    expect(paymentEntries[2].mitteilung).toEqual('CCCCCC')
+    expect(paymentEntries[3].mitteilung).toEqual('EEEEEE')
+    expect(paymentEntries[4].mitteilung).toEqual('FFFFFF')
   })
 
   it('falls back to remittance information for `Mitteilung`', async () => {
@@ -55,6 +58,7 @@ describe('parseCamt053():', () => {
     expect(paymentEntries[2].mitteilung).toEqual('AAAAAA')
     expect(paymentEntries[3].mitteilung).toEqual('CCCCCC')
     expect(paymentEntries[4].mitteilung).toEqual(null)
+    expect(paymentEntries[5].mitteilung).toEqual('EEEEEE')
   })
 
   it('returns the reference for the sanned cash deposit', async () => {


### PR DESCRIPTION
This Pull Request ensures simple HR-IDs (`AABBCC`) are trumped by creditor references (`RF12HRID…`), will allow for padded creditor references (`RF1200000000HRID…`) and adds tests to this effect.