### PR TITLE
Add T+0, T+14 templates for ABO_GIVE_MONTHS

### DIFF
--- a/packages/mail/templates/membership_deactivated_abo_give_months_uncancelled.html
+++ b/packages/mail/templates/membership_deactivated_abo_give_months_uncancelled.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!--[if gte mso 15]>
+      <xml>
+        <o:officedocumentsettings>
+          <o:allowpng />
+          <o:pixelsperinch>96</o:pixelsperinch>
+        </o:officedocumentsettings>
+      </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table
+              align="center"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              width="100%"
+              style="max-width:640px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"
+            >
+              <tbody>
+                <tr>
+                  <td style="padding: 20px">
+                    <table
+                      width="100%"
+                      border="0"
+                      cellspacing="0"
+                      cellpadding="0"
+                    >
+                      <tr>
+                        <td>
+                          <table border="0" cellspacing="0" cellpadding="0">
+                            <tr>
+                              <td align="center" bgcolor="#3CAD00">
+                                <a
+                                  href="{{prolong_url}}"
+                                  style="font-size:20px;{{sg_font_style_sans_serif_regular}}color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;"
+                                  >Abonnement jetzt reaktivieren</a
+                                >
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+                    <br />
+                    <hr />
+                    <p>Guten Tag</p>
+                    <p>
+                      Schade, sind Sie nicht mehr Teil der Republik und der Idee
+                      hinter unserem Projekt!
+                    </p>
+                    <p>
+                      Wir haben Ihnen eine E-Mail für die Verlängerung oder
+                      Kündigung Ihres Abonnements geschickt. Aber darauf noch
+                      keine Antwort erhalten. Einen Zahlungseingang für die
+                      Verlängerung Ihres Abonnements können wir bis heute auch
+                      nicht verzeichnen.
+                    </p>
+                    <p>
+                      Deshalb verlieren Ihre Zugangsdaten ab sofort leider ihre
+                      Gültigkeit.
+                    </p>
+                    <p>
+                      Wenn Sie schlicht alle E-Mails übersehen haben –
+                      <a href="{{prolong_url}}"
+                        >lösen Sie jetzt eine Jahresmitgliedschaft</a
+                      >. Das dauert nicht einmal drei Minuten.
+                    </p>
+                    <p>
+                      Falls Sie uns lieber kurzfristiger unterstützen wollen,
+                      gibt es die Möglichkeit, ein (unbegrenztes)
+                      <a href="{{link_offer_monthly_abo}}">Monatsabo</a> zu
+                      kaufen. Das kostet nur CHF 22 im Monat, wird Ihrer
+                      Kreditkarte belastet und verlängert sich automatisch –
+                      kann dabei aber jederzeit und ohne Frist gekündigt werden.
+                    </p>
+                    <p>
+                      Auch mit diesem Abo erhalten Sie viel Kontext und
+                      Vertiefung und stärken den kritischen Journalismus, die
+                      vierte Gewalt und unser Projekt gegen den Zynismus und die
+                      Diktatur der Angst. Einfach ohne dass Sie Teil unserer
+                      Genossenschaft sind.
+                    </p>
+                    <p>
+                      Und wenn Sie einen finanziellen Engpass haben, schreiben
+                      Sie uns auf
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >. Wir finden eine Lösung!
+                    </p>
+                    <p>
+                      Sollte uns hingegen ein Fehler unterlaufen sein, nehmen
+                      Sie bitte ebenfalls so schnell wie möglich Kontakt mit uns
+                      auf:
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >.
+                    </p>
+                    <p>Herzlich</p>
+                    <p>Ihre Crew der Republik</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 20px">
+                    <p
+                      style="font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      Die Republik ist ein unabhängiges und werbefreies
+                      digitales Magazin für Politik, Wirtschaft, Gesellschaft
+                      und Kultur. Es wird von seinen Leserinnen und Lesern
+                      finanziert und erscheint von Montag bis Samstag mit
+                      täglich ein bis drei neuen Beiträgen. In der App, auf der
+                      Website und als Newsletter.
+                    </p>
+                    <p
+                      style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <img
+                        height="79"
+                        src="{{frontend_base_url}}/static/logo_republik_newsletter.png"
+                        style="
+                          border: 0px;
+                          width: 180px !important;
+                          height: 79px !important;
+                          margin: 0px;
+                        "
+                        width="180"
+                        alt=""
+                      />
+                      <br />
+                      Republik AG<br />
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br />
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >
+                    </p>
+                    <p
+                      style="font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <a href="{{link_manifest}}">Unser Manifest</a><br />
+                      <a href="{{link_imprint}}">Das Impressum</a><br />
+                      <a href="{{link_faq}}">Häufig gestellte Fragen</a>
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/mail/templates/membership_deactivated_abo_give_months_uncancelled.txt
+++ b/packages/mail/templates/membership_deactivated_abo_give_months_uncancelled.txt
@@ -1,0 +1,54 @@
+Abonnement jetzt reaktivieren {{prolong_url}}
+
+
+--------------------------------------------------------------------------------
+
+Guten Tag
+
+Schade, sind Sie nicht mehr Teil der Republik und der Idee hinter unserem
+Projekt!
+
+Wir haben Ihnen eine E-Mail für die Verlängerung oder Kündigung Ihres
+Abonnements geschickt. Aber darauf noch keine Antwort erhalten. Einen
+Zahlungseingang für die Verlängerung Ihres Abonnements können wir bis heute auch
+nicht verzeichnen.
+
+Deshalb verlieren Ihre Zugangsdaten ab sofort leider ihre Gültigkeit.
+
+Wenn Sie schlicht alle E-Mails übersehen haben – lösen Sie jetzt eine
+Jahresmitgliedschaft {{prolong_url}} . Das dauert nicht einmal drei Minuten.
+
+Falls Sie uns lieber kurzfristiger unterstützen wollen, gibt es die Möglichkeit,
+ein (unbegrenztes) Monatsabo {{link_offer_monthly_abo}} zu kaufen. Das kostet
+nur CHF 22 im Monat, wird Ihrer Kreditkarte belastet und verlängert sich
+automatisch – kann dabei aber jederzeit und ohne Frist gekündigt werden.
+
+Auch mit diesem Abo erhalten Sie viel Kontext und Vertiefung und stärken den
+kritischen Journalismus, die vierte Gewalt und unser Projekt gegen den Zynismus
+und die Diktatur der Angst. Einfach ohne dass Sie Teil unserer Genossenschaft
+sind.
+
+Und wenn Sie einen finanziellen Engpass haben, schreiben Sie uns auf
+kontakt@republik.ch . Wir finden eine Lösung!
+
+Sollte uns hingegen ein Fehler unterlaufen sein, nehmen Sie bitte ebenfalls so
+schnell wie möglich Kontakt mit uns auf: kontakt@republik.ch .
+
+Herzlich
+
+Ihre Crew der Republik
+
+Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
+Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
+finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
+Beiträgen. In der App, auf der Website und als Newsletter.
+
+
+Republik AG
+Sihlhallenstrasse 1, CH-8004 Zürich
+{{frontend_base_url}}
+kontakt@republik.ch
+
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
+Häufig gestellte Fragen {{link_faq}}

--- a/packages/mail/templates/membership_owner_prolong_abo_give_months_notice_0.html
+++ b/packages/mail/templates/membership_owner_prolong_abo_give_months_notice_0.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!--[if gte mso 15]>
+      <xml>
+        <o:officedocumentsettings>
+          <o:allowpng />
+          <o:pixelsperinch>96</o:pixelsperinch>
+        </o:officedocumentsettings>
+      </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table
+              align="center"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              width="100%"
+              style="max-width:640px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"
+            >
+              <tbody>
+                <tr>
+                  <td style="padding: 20px">
+                    <p>Guten Tag</p>
+                    <p>
+                      Heute endet Ihr Republik-Abonnement. Herzlichen Dank für
+                      Ihr Interesse und Ihre Neugier bis hierhin!
+                    </p>
+                    <p>
+                      <a href="{{prolong_url}}"
+                        >Wir würden uns sehr freuen, wenn Sie weiter an Bord
+                        blieben.</a
+                      >
+                    </p>
+                    <p>
+                      Jede Mitgliedschaft, jedes Abo unterstützt die Republik
+                      und die Idee einer wirklich unabhängigen vierten Gewalt
+                      und zentralen demokratischen Institution. Und stärkt unser
+                      gemeinsames Projekt gegen den Zynismus, den Vormarsch der
+                      Autoritären und gegen die Diktatur der Angst.
+                    </p>
+                    <p>
+                      Sie wollen lieber auf ein anderes Abonnement wechseln?
+                      <a href="{{link_offers_overview}}">Hier entlang</a>.
+                    </p>
+                    <p>
+                      Sollten Sie das nicht tun, verlieren Ihre Zugangsdaten am
+                      {{grace_end_date}} leider ihre Gültigkeit.
+                    </p>
+                    <p>Herzlich</p>
+                    <p>Ihre Crew der Republik</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 20px">
+                    <p
+                      style="font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      Die Republik ist ein unabhängiges und werbefreies
+                      digitales Magazin für Politik, Wirtschaft, Gesellschaft
+                      und Kultur. Es wird von seinen Leserinnen und Lesern
+                      finanziert und erscheint von Montag bis Samstag mit
+                      täglich ein bis drei neuen Beiträgen. In der App, auf der
+                      Website und als Newsletter.
+                    </p>
+                    <p
+                      style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <img
+                        height="79"
+                        src="{{frontend_base_url}}/static/logo_republik_newsletter.png"
+                        style="
+                          border: 0px;
+                          width: 180px !important;
+                          height: 79px !important;
+                          margin: 0px;
+                        "
+                        width="180"
+                        alt=""
+                      />
+                      <br />
+                      Republik AG<br />
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br />
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >
+                    </p>
+                    <p
+                      style="font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <a href="{{link_manifest}}">Unser Manifest</a><br />
+                      <a href="{{link_imprint}}">Das Impressum</a><br />
+                      <a href="{{link_faq}}">Häufig gestellte Fragen</a>
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/mail/templates/membership_owner_prolong_abo_give_months_notice_0.txt
+++ b/packages/mail/templates/membership_owner_prolong_abo_give_months_notice_0.txt
@@ -1,0 +1,36 @@
+Guten Tag
+
+Heute endet Ihr Republik-Abonnement. Herzlichen Dank für Ihr Interesse und Ihre
+Neugier bis hierhin!
+
+Wir würden uns sehr freuen, wenn Sie weiter an Bord blieben. {{prolong_url}}
+
+Jede Mitgliedschaft, jedes Abo unterstützt die Republik und die Idee einer
+wirklich unabhängigen vierten Gewalt und zentralen demokratischen Institution.
+Und stärkt unser gemeinsames Projekt gegen den Zynismus, den Vormarsch der
+Autoritären und gegen die Diktatur der Angst.
+
+Sie wollen lieber auf ein anderes Abonnement wechseln? Hier entlang
+{{link_offers_overview}} .
+
+Sollten Sie das nicht tun, verlieren Ihre Zugangsdaten am {{grace_end_date}}
+leider ihre Gültigkeit.
+
+Herzlich
+
+Ihre Crew der Republik
+
+Die Republik ist ein unabhängiges und werbefreies digitales Magazin für Politik,
+Wirtschaft, Gesellschaft und Kultur. Es wird von seinen Leserinnen und Lesern
+finanziert und erscheint von Montag bis Samstag mit täglich ein bis drei neuen
+Beiträgen. In der App, auf der Website und als Newsletter.
+
+
+Republik AG
+Sihlhallenstrasse 1, CH-8004 Zürich
+{{frontend_base_url}}
+kontakt@republik.ch
+
+Unser Manifest {{link_manifest}}
+Das Impressum {{link_imprint}}
+Häufig gestellte Fragen {{link_faq}}

--- a/packages/republik-crowdfundings/graphql/resolvers/User.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/User.js
@@ -99,17 +99,6 @@ module.exports = {
 
       memberships = await resolveMemberships({ memberships, pgdb })
 
-      const activeMembership = memberships.find((m) => m.active)
-      if (
-        activeMembership &&
-        activeMembership.membershipType.name === 'ABO_GIVE_MONTHS'
-      ) {
-        debug(
-          'active membership type "ABO_GIVE_MONTHS", return prolongBeforeDate: null',
-        )
-        return null
-      }
-
       const eligableMemberships = findEligableMemberships({
         memberships,
         user,
@@ -138,6 +127,7 @@ module.exports = {
         return null
       }
 
+      const activeMembership = memberships.find((m) => m.active)
       const lastEndDate = moment(getLastEndDate(allMembershipPeriods))
       if (!ignoreAutoPayFlag && activeMembership && activeMembership.autoPay) {
         const autoPay = await autoPaySuggest(activeMembership.id, pgdb)

--- a/packages/republik-crowdfundings/lib/scheduler/owners.js
+++ b/packages/republik-crowdfundings/lib/scheduler/owners.js
@@ -100,7 +100,6 @@ const createBuckets = (now) => [
       max: getMaxEndDate(now, 0),
     },
     predicate: ({ id: userId, membershipType, membershipAutoPay, autoPay }) => {
-      console.log({ userId, membershipType })
       return (
         membershipType === 'ABO_GIVE_MONTHS' &&
         (membershipAutoPay === false ||
@@ -247,8 +246,6 @@ const getBuckets = async ({ now }, context) => {
         { ignoreAutoPayFlag: true },
         { ...context, user },
       ).then((date) => date && moment(date))
-
-      console.log(user.membershipType, prolongBeforeDate)
 
       stats.numNeedProlongProgress++
 

--- a/packages/republik-crowdfundings/lib/scheduler/owners.js
+++ b/packages/republik-crowdfundings/lib/scheduler/owners.js
@@ -94,6 +94,26 @@ const createBuckets = (now) => [
     handler: mailings,
   },
   {
+    name: 'membership_owner_prolong_abo_give_months_notice_0',
+    endDate: {
+      min: getMinEndDate(now, -3),
+      max: getMaxEndDate(now, 0),
+    },
+    predicate: ({ id: userId, membershipType, membershipAutoPay, autoPay }) => {
+      console.log({ userId, membershipType })
+      return (
+        membershipType === 'ABO_GIVE_MONTHS' &&
+        (membershipAutoPay === false ||
+          (membershipAutoPay === true &&
+            (!autoPay || (autoPay && userId !== autoPay.userId))))
+      )
+    },
+    payload: {
+      templateName: 'membership_owner_prolong_abo_give_months_notice_0',
+    },
+    handler: mailings,
+  },
+  {
     name: 'membership_owner_prolong_winback_7',
     endDate: {
       min: getMinEndDate(now, -10),
@@ -227,6 +247,8 @@ const getBuckets = async ({ now }, context) => {
         { ignoreAutoPayFlag: true },
         { ...context, user },
       ).then((date) => date && moment(date))
+
+      console.log(user.membershipType, prolongBeforeDate)
 
       stats.numNeedProlongProgress++
 

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -643,6 +643,10 @@
       "value": "Ihre Abonnementsrechnung"
     },
     {
+      "key": "api/email/membership_owner_prolong_abo_give_months_notice_0/subject",
+      "value": "Ihr letzter Tag an Bord"
+    },
+    {
       "key": "api/email/membership_owner_prolong_winback_7/subject",
       "value": "Ihr Mitgliedschaftsbeitrag ist überfällig"
     },
@@ -665,6 +669,10 @@
     {
       "key": "api/email/membership_deactivated_benefactor_abo_uncancelled/sequenceNumber/true/subject",
       "value": "Ihre Mitgliedschaft Nr. {sequenceNumber} wurde deaktiviert"
+    },
+    {
+      "key": "api/email/membership_deactivated_abo_give_months_uncancelled/subject",
+      "value": "Ihr Republik-Abonnement wurde deaktiviert"
     },
     {
       "key": "api/email/membership_deactivated/subject",


### PR DESCRIPTION
Add some transactional templates for membership type `ABO_GIVE_MONTHS`, sends T+0 `membership_owner_prolong_abo_give_months_notice_0`. Other template is send when membership is deactivated.

It removes `ABO_GIVE_MONTHS` early exit on `User.prolongBeforeDate` resolver and will thus return a date for `ABO_GIVE_MONTSH` memberships, too.

⚠️ This change impacts current version of [republik-frontend](https://github.com/orbiting/republik-frontend/tree/903dcbb310829affba633fc4c2b4899e8dd5b270). Changes suggested [here](https://github.com/orbiting/republik-frontend/pull/530).