### PR TITLE
Fix mutation mergeUsers

### DIFF
--- a/packages/migrations/migrations/20210118041504-user-addressid-ondelete-setnull.js
+++ b/packages/migrations/migrations/20210118041504-user-addressid-ondelete-setnull.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/republik/migrations/crowdfunding/sqls'
+const file = '20210118041504-user-addressid-ondelete-setnull'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
@@ -68,7 +68,7 @@ module.exports = async (_, args, context) => {
       },
     )
 
-    const newUser = await transaction.public.users.updateAndGetOne(
+    await transaction.public.users.updateOne(
       {
         id: targetUser.id,
       },
@@ -201,14 +201,6 @@ module.exports = async (_, args, context) => {
         passport: { user: targetUser.id },
       })
       await transaction.public.sessions.updateOne({ id: session.id }, { sess })
-    }
-
-    // remove addresses
-    const addressIds = users
-      .filter((u) => u.addressId && u.addressId !== newUser.addressId)
-      .map((u) => u.addressId)
-    if (addressIds.length) {
-      await transaction.public.addresses.deleteOne({ id: addressIds[0] })
     }
 
     // anonymize user answers, as an answer record can't be assigned to another user

--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/mergeUsers.js
@@ -213,21 +213,29 @@ module.exports = async (_, args, context) => {
 
     // anonymize user answers, as an answer record can't be assigned to another user
     const answers = await transaction.public.answers.find(from)
-    const questionnaireIds = [...new Set(answers.map(a => a.questionnaireId))]
-    const questionnaireSubmissions = await transaction.public.questionnaireSubmissions.find({
-      ...from,
-      questionnaireId: questionnaireIds,
-    })
+    const questionnaireIds = [...new Set(answers.map((a) => a.questionnaireId))]
+    const questionnaireSubmissions =
+      !!questionnaireIds.length &&
+      (await transaction.public.questionnaireSubmissions.find({
+        ...from,
+        questionnaireId: questionnaireIds,
+      }))
 
     for (const questionnaireId of questionnaireIds) {
-      const hasSubmission = questionnaireSubmissions.find(s => s.questionnaireId === questionnaireId)
+      const hasSubmission = questionnaireSubmissions.find(
+        (s) => s.questionnaireId === questionnaireId,
+      )
 
       // insert questionnaireSubmission record if missing
       if (!hasSubmission) {
-        const questionnaireAnswers = answers.filter(a => a.questionnaireId = questionnaireId)
+        const questionnaireAnswers = answers.filter(
+          (a) => (a.questionnaireId = questionnaireId),
+        )
 
         // use latest answer.createdAt as questionnaireSubmission.createdAt
-        const latestAnswerDate = new Date(Math.max(...questionnaireAnswers.map((a) => a.createdAt)))
+        const latestAnswerDate = new Date(
+          Math.max(...questionnaireAnswers.map((a) => a.createdAt)),
+        )
 
         await transaction.public.questionnaireSubmissions.insert({
           questionnaireId,
@@ -238,14 +246,14 @@ module.exports = async (_, args, context) => {
       }
 
       await transaction.public.answers.update(
-        { 
+        {
           ...from,
-          questionnaireId
+          questionnaireId,
         },
-        { 
+        {
           userId: null,
           pseudonym: uuid(),
-        }
+        },
       )
     }
 

--- a/packages/republik/migrations/crowdfunding/sqls/20210118041504-user-addressid-ondelete-setnull-down.sql
+++ b/packages/republik/migrations/crowdfunding/sqls/20210118041504-user-addressid-ondelete-setnull-down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."users"
+  DROP CONSTRAINT "users_addressId_fkey",
+  ADD CONSTRAINT "users_addressId_fkey" FOREIGN KEY ("addressId") REFERENCES "public"."addresses"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/republik/migrations/crowdfunding/sqls/20210118041504-user-addressid-ondelete-setnull-up.sql
+++ b/packages/republik/migrations/crowdfunding/sqls/20210118041504-user-addressid-ondelete-setnull-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."users"
+  DROP CONSTRAINT "users_addressId_fkey",
+  ADD CONSTRAINT "users_addressId_fkey" FOREIGN KEY ("addressId") REFERENCES "public"."addresses"("id") ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
This Pull Request fixes two bugs:
- Skip creating questionnaireSubmissions, merging answers. If there is no answers, it should no longer produce error: `Invalid conditions! empty array for field:"questionnaireId" and operator:"= ANY"`
- Set `users.addressId` to `NULL` if referenced address row is deleted. It should no longer attempt to delete user when deleting address row.