### PR TITLE
Invoices and receipts

### DIFF
--- a/packages/auth/lib/AccessToken.js
+++ b/packages/auth/lib/AccessToken.js
@@ -57,7 +57,10 @@ const scopeConfigs = {
     expireAtFormat: 'YYYY-MM-DDTHH:mm:ss.SSSZZ',
   },
   INVOICE: {
-    allowedReqPaths: [/^\/invoices\/paymentslip\/(.{6})\.pdf?$/],
+    allowedReqPaths: [
+      /^\/invoices\/(.{6})\.pdf?$/,
+      /^\/invoices\/paymentslip\/(.{6})\.pdf?$/,
+    ],
     ttlDays: 5,
   },
 }

--- a/packages/formats/index.d.ts
+++ b/packages/formats/index.d.ts
@@ -1,1 +1,2 @@
 export function formatPrice(price: number): string
+export function timeFormat(specifier: string)

--- a/packages/invoices/express/index.ts
+++ b/packages/invoices/express/index.ts
@@ -1,5 +1,5 @@
 import { Express } from 'express'
-import * as paymentslip from '../lib/paymentslip'
+import * as invoices from '../'
 
 const { AccessToken } = require('@orbiting/backend-modules-auth')
 
@@ -10,6 +10,15 @@ const middleware = async (
   _redis: any,
   context: any,
 ) => {
+  server.get('/invoices/:hrid.pdf', async (req, res) => {
+    // @TODO: AccessToken-Check
+
+    const { hrid } = req.params
+    const payment = await invoices.commons.resolvePayment({ hrid }, context)
+
+    res.json(payment)
+  })
+
   server.get('/invoices/paymentslip/:hrid.pdf', async (req, res, next) => {
     const { token } = req.query
 
@@ -24,9 +33,9 @@ const middleware = async (
     }
 
     const { hrid } = req.params
-    const payment = await paymentslip.resolve({ hrid }, context)
+    const payment = await invoices.commons.resolvePayment({ hrid }, context)
 
-    if (!paymentslip.isApplicable(payment)) {
+    if (!invoices.paymentslip.isApplicable(payment)) {
       return next()
     }
 
@@ -34,7 +43,7 @@ const middleware = async (
       return next()
     }
 
-    const pdf = await paymentslip.generate(payment)
+    const pdf = await invoices.paymentslip.generate(payment)
 
     res
       .writeHead(200, {

--- a/packages/invoices/index.ts
+++ b/packages/invoices/index.ts
@@ -1,1 +1,2 @@
+export * as commons from './lib/commons'
 export * as paymentslip from './lib/paymentslip'

--- a/packages/invoices/index.ts
+++ b/packages/invoices/index.ts
@@ -1,2 +1,3 @@
 export * as commons from './lib/commons'
+export * as invoice from './lib/invoice'
 export * as paymentslip from './lib/paymentslip'

--- a/packages/invoices/lib/commons.ts
+++ b/packages/invoices/lib/commons.ts
@@ -97,7 +97,13 @@ interface Membership {
 
 interface Package {
   companyId: string
+  company: Company
   bankAccount?: BankAccount
+}
+
+interface Company {
+  id: string
+  name: string
 }
 
 interface BankAccount {
@@ -230,6 +236,10 @@ export async function resolvePayment(
     pledge?.packageId &&
     (await pgdb.public.packages.findOne({ id: pledge.packageId }))
 
+  const company: Company =
+    pkg?.companyId &&
+    (await pgdb.public.companies.findOne({ id: pkg.companyId }))
+
   const bankAccount: BankAccount =
     pkg?.companyId &&
     (await pgdb.public.bankAccounts.findOne({
@@ -254,6 +264,7 @@ export async function resolvePayment(
       ...pledge,
       package: {
         ...pkg,
+        company,
         bankAccount: {
           ...bankAccount,
           address: bankAccountAddress,

--- a/packages/invoices/lib/commons.ts
+++ b/packages/invoices/lib/commons.ts
@@ -1,3 +1,4 @@
+import { data as BillData } from 'swissqrbill'
 import {
   generate as generateReference,
   validate as validateReference,
@@ -14,7 +15,7 @@ interface PaymentHridInput {
 }
 
 export interface PaymentResolved extends Payment {
-  pledge?: Pledge
+  pledge: Pledge
 }
 
 export enum PaymentMethod {
@@ -38,18 +39,60 @@ interface Payment {
   method: PaymentMethod
   status: PaymentStatus
   total: number
+  createdAt: Date
 }
 
 interface PledgePayment {
   pledgeId: string
-  pledge?: Pledge
+  pledge: Pledge
 }
 
 interface Pledge {
+  id: string
   packageId: string
   package: Package
   userId: string
   user: User
+  options: PledgeOption[]
+  donation: number
+  total: number
+}
+
+export interface PledgeOption {
+  id: string
+  templateId: string
+  membershipId: string
+  amount: number
+  price: number
+  periods: number
+  option?: PackageOption
+  period?: Period
+}
+
+interface PackageOption {
+  id: string
+  rewardId?: string
+  reward?: Reward
+}
+
+interface Reward {
+  rewardId: string
+  rewardType: string
+  name: string
+  interval: string
+}
+
+interface Period {
+  id: string
+  membershipId: string
+  membership?: Membership
+  beginDate: Date
+  endDate: Date
+}
+
+interface Membership {
+  id: string
+  sequenceNumber: number
 }
 
 interface Package {
@@ -61,15 +104,20 @@ interface BankAccount {
   iban: string
   addressId?: string
   address?: Address
+  image?: Buffer
+  canInvoice: boolean
 }
 
-interface User {
+export interface User {
   id: string
+  email: string
+  firstName: string
+  lastName: string
   addressId?: string
   address?: Address
 }
 
-interface Address {
+export interface Address {
   id: string
   name: string
   line1: string
@@ -77,6 +125,14 @@ interface Address {
   postalCode: string
   city: string
   country: string
+}
+
+export interface IsApplicableFn {
+  (payment: PaymentResolved): boolean
+}
+
+export interface GenerateFn {
+  (payment: PaymentResolved, context?: Context): Promise<Buffer>
 }
 
 export async function resolvePayment(
@@ -91,9 +147,84 @@ export async function resolvePayment(
     payment?.id &&
     (await pgdb.public.pledgePayments.findOne({ paymentId: payment.id }))
 
+  const periods: Period[] =
+    pledgePayment?.pledgeId &&
+    (await pgdb.public.membershipPeriods.find({
+      pledgeId: pledgePayment.pledgeId,
+    }))
+
+  const memberships: Membership[] =
+    (periods.length &&
+      (await pgdb.public.memberships.find({
+        id: periods.map((p) => p.membershipId),
+      }))) ||
+    []
+
+  periods.forEach((period, index, periods) => {
+    periods[index].membership = memberships.find(
+      (m) => m.id === period.membershipId,
+    )
+  })
+
+  const pledgeOptions: PledgeOption[] =
+    (pledgePayment?.pledgeId &&
+      (await pgdb.public.pledgeOptions.find(
+        {
+          pledgeId: pledgePayment.pledgeId,
+          'amount >': 0,
+        },
+        {
+          orderBy: {
+            amount: 'desc',
+          },
+        },
+      ))) ||
+    []
+
+  const packageOptions: PackageOption[] =
+    (pledgeOptions.length &&
+      (await pgdb.public.packageOptions.find({
+        id: pledgeOptions.map((o) => o.templateId),
+      }))) ||
+    []
+
+  const rewardGoodies: Reward[] =
+    (pledgeOptions.length &&
+      (await pgdb.public.goodies.find({
+        rewardId: packageOptions.map((o) => o.rewardId),
+      }))) ||
+    []
+
+  const rewardMembershipTypes: Reward[] =
+    (pledgeOptions.length &&
+      (await pgdb.public.membershipTypes.find({
+        rewardId: packageOptions.map((o) => o.rewardId),
+      }))) ||
+    []
+
+  const rewards: Reward[] = [...rewardGoodies, ...rewardMembershipTypes]
+
+  packageOptions.forEach((packageOption, index, packageOptions) => {
+    packageOptions[index].reward = rewards.find(
+      (r) => r.rewardId === packageOption.rewardId,
+    )
+  })
+
+  pledgeOptions.forEach((pledgeOption, index, pledgeOptions) => {
+    pledgeOptions[index].option = packageOptions.find(
+      (o) => o.id === pledgeOption.templateId,
+    )
+
+    pledgeOptions[index].period = periods.find(
+      (p) => p.membershipId === pledgeOption.membershipId,
+    )
+  })
+
   const pledge: Pledge =
     pledgePayment?.pledgeId &&
     (await pgdb.public.pledges.findOne({ id: pledgePayment.pledgeId }))
+
+  pledge.options = pledgeOptions
 
   const pkg: Package =
     pledge?.packageId &&
@@ -136,7 +267,7 @@ export async function resolvePayment(
   }
 }
 
-export function getCountryCode(string: string): string {
+function getCountryCode(string: string): string {
   switch (string.trim().toLowerCase()) {
     case 'deutschland':
       return 'DE'
@@ -186,4 +317,52 @@ export function getHrId(string: string): string | null {
   }
 
   return hrid
+}
+
+export function getSwissQrBillData(payment: PaymentResolved): BillData {
+  if (!payment.hrid) {
+    throw new Error('Payment HR-ID missing')
+  }
+
+  const account = payment?.pledge?.package?.bankAccount?.iban
+
+  if (!account) {
+    throw new Error('Creditor IBAN missing')
+  }
+
+  const creditorAddress = payment?.pledge?.package?.bankAccount?.address
+
+  if (!creditorAddress) {
+    throw new Error('Creditor address missing')
+  }
+
+  if (!Number(creditorAddress.postalCode)) {
+    throw new Error('Creditor address postal code is not a number')
+  }
+
+  const debtorAddress = payment?.pledge?.user?.address
+
+  return {
+    currency: 'CHF',
+    amount: payment.total / 100,
+    reference: getReference(payment.hrid),
+    creditor: {
+      account,
+      name: creditorAddress.name,
+      address: creditorAddress.line1,
+      zip: Number(creditorAddress.postalCode),
+      city: creditorAddress.city,
+      country: getCountryCode(creditorAddress.country),
+    },
+    ...(debtorAddress &&
+      Number(debtorAddress.postalCode) && {
+        debtor: {
+          name: debtorAddress.name,
+          address: debtorAddress.line1,
+          zip: Number(debtorAddress.postalCode),
+          city: debtorAddress.city,
+          country: getCountryCode(creditorAddress.country),
+        },
+      }),
+  }
 }

--- a/packages/invoices/lib/commons.ts
+++ b/packages/invoices/lib/commons.ts
@@ -1,0 +1,189 @@
+import {
+  generate as generateReference,
+  validate as validateReference,
+} from 'node-iso11649'
+
+import { Context } from '@orbiting/backend-modules-types'
+
+interface PaymentIdInput {
+  id: string
+}
+
+interface PaymentHridInput {
+  hrid: string
+}
+
+export interface PaymentResolved extends Payment {
+  pledge?: Pledge
+}
+
+export enum PaymentMethod {
+  STRIPE = 'STRIPE',
+  POSTFINANCECARD = 'POSTFINANCECARD',
+  PAYPAL = 'PAYPAL',
+  PAYMENTSLIP = 'PAYMENTSLIP',
+}
+
+export enum PaymentStatus {
+  WAITING = 'WAITING',
+  PAID = 'PAID',
+  WAITING_FOR_REFUND = 'WAITING_FOR_REFUND',
+  REFUNDED = 'REFUNDED',
+  CANCELLED = 'CANCELLED',
+}
+
+interface Payment {
+  id: string
+  hrid: string
+  method: PaymentMethod
+  status: PaymentStatus
+  total: number
+}
+
+interface PledgePayment {
+  pledgeId: string
+  pledge?: Pledge
+}
+
+interface Pledge {
+  packageId: string
+  package: Package
+  userId: string
+  user: User
+}
+
+interface Package {
+  companyId: string
+  bankAccount?: BankAccount
+}
+
+interface BankAccount {
+  iban: string
+  addressId?: string
+  address?: Address
+}
+
+interface User {
+  id: string
+  addressId?: string
+  address?: Address
+}
+
+interface Address {
+  id: string
+  name: string
+  line1: string
+  line2?: string
+  postalCode: string
+  city: string
+  country: string
+}
+
+export async function resolvePayment(
+  input: PaymentIdInput | PaymentHridInput,
+  context: Context,
+): Promise<PaymentResolved> {
+  const { pgdb } = context
+
+  const payment: Payment = await pgdb.public.payments.findOne(input)
+
+  const pledgePayment: PledgePayment =
+    payment?.id &&
+    (await pgdb.public.pledgePayments.findOne({ paymentId: payment.id }))
+
+  const pledge: Pledge =
+    pledgePayment?.pledgeId &&
+    (await pgdb.public.pledges.findOne({ id: pledgePayment.pledgeId }))
+
+  const pkg: Package =
+    pledge?.packageId &&
+    (await pgdb.public.packages.findOne({ id: pledge.packageId }))
+
+  const bankAccount: BankAccount =
+    pkg?.companyId &&
+    (await pgdb.public.bankAccounts.findOne({
+      companyId: pkg.companyId,
+      default: true,
+    }))
+
+  const bankAccountAddress: Address =
+    bankAccount?.addressId &&
+    (await pgdb.public.addresses.findOne({ id: bankAccount.addressId }))
+
+  const user: User =
+    pledge?.userId && (await pgdb.public.users.findOne({ id: pledge.userId }))
+
+  const userAddress: Address =
+    user?.addressId &&
+    (await pgdb.public.addresses.findOne({ id: user.addressId }))
+
+  return {
+    ...payment,
+    pledge: {
+      ...pledge,
+      package: {
+        ...pkg,
+        bankAccount: {
+          ...bankAccount,
+          address: bankAccountAddress,
+        },
+      },
+      user: {
+        ...user,
+        address: userAddress,
+      },
+    },
+  }
+}
+
+export function getCountryCode(string: string): string {
+  switch (string.trim().toLowerCase()) {
+    case 'deutschland':
+      return 'DE'
+    case 'frankreich':
+      return 'FR'
+    case 'italia':
+    case 'italien':
+      return 'IT'
+    case 'liechtenstein':
+      return 'LI'
+    case 'niederlande':
+      return 'NL'
+    case 'österreich':
+      return 'AT'
+    case 'spanien':
+      return 'ES'
+    case 'usa':
+      return 'US'
+    default:
+      return 'CH'
+  }
+}
+
+export function getReference(hrid: string, pretty?: boolean): string {
+  if (!hrid) {
+    throw new Error('hrid is missing')
+  }
+
+  return generateReference({
+    reference: `HRID${hrid}`,
+    pretty,
+  })
+}
+
+export function getHrId(string: string): string | null {
+  const [reference, hrid] =
+    string
+      .replace(/[^A-Za-z0-9]/g, '')
+      .match(/RF\d\d0{0,11}HRID([A-Za-z0-9]{6})/) || []
+
+  if (!reference) {
+    return null
+  }
+
+  if (!validateReference(reference)) {
+    return null
+  }
+
+  return hrid
+}

--- a/packages/invoices/lib/invoice.ts
+++ b/packages/invoices/lib/invoice.ts
@@ -251,6 +251,7 @@ function addTable(doc: PDF, payment: PaymentResolved, context: Context) {
   const { t } = context
 
   const pledgeTotal = payment.pledge?.total || 0
+  const companyName = payment?.pledge.package.company.name
 
   const header = getTableRow(
     t('api/invoices/table/option'),
@@ -282,9 +283,17 @@ function addTable(doc: PDF, payment: PaymentResolved, context: Context) {
     )
   }
 
-  const total = getTableRow(t('api/invoices/table/total'), null, pledgeTotal, {
-    bold: true,
-  })
+  const total = getTableRow(
+    t.first([
+      `api/invoices/table/${companyName}/total`,
+      'api/invoices/table/total',
+    ]),
+    null,
+    pledgeTotal,
+    {
+      bold: true,
+    },
+  )
 
   rows.push(total)
 

--- a/packages/invoices/lib/invoice.ts
+++ b/packages/invoices/lib/invoice.ts
@@ -1,0 +1,328 @@
+import { utils, PDF } from 'swissqrbill'
+
+import { Context } from '@orbiting/backend-modules-types'
+import { formatPrice, timeFormat } from '@orbiting/backend-modules-formats'
+
+import {
+  IsApplicableFn,
+  PaymentResolved,
+  PaymentStatus,
+  PledgeOption,
+  User,
+  Address,
+  getReference,
+  getSwissQrBillData,
+  GenerateFn,
+} from './commons'
+import * as paymentslip from './paymentslip'
+
+interface RowConfig {
+  bold?: boolean
+}
+
+const formatDate = timeFormat('%x')
+
+const PADDING_MM = 20 // 2cm
+const CREDITOR_INDENT_MM = 140 // 14cm
+const REGULAR_FONT_SIZE = 11
+const DEBTOR_FONT_SIZE = 12
+const TITLE_FONT_SIZE = 16
+const REGULAR_FONT_NAME = 'Helvetica'
+const BOLD_FONT_NAME = 'Helvetica-Bold'
+
+export const isApplicable: IsApplicableFn = function (payment) {
+  if (!payment.id) {
+    return false
+  }
+
+  if (![PaymentStatus.WAITING, PaymentStatus.PAID].includes(payment.status)) {
+    return false
+  }
+
+  if (!payment.pledge.package.bankAccount?.canInvoice) {
+    return false
+  }
+
+  return true
+}
+
+function addTopLeftPadding(doc: PDF) {
+  doc.x = doc.y = utils.mmToPoints(PADDING_MM)
+}
+
+function addCreditor(doc: PDF, payment: PaymentResolved) {
+  const creditorAddress = payment?.pledge.package.bankAccount?.address
+  const image = payment?.pledge.package.bankAccount?.image
+
+  if (!creditorAddress) {
+    throw new Error('Creditor address missing')
+  }
+
+  if (!Number(creditorAddress.postalCode)) {
+    throw new Error('Creditor address postal code is not a number')
+  }
+
+  const { x } = doc
+
+  doc.x = utils.mmToPoints(CREDITOR_INDENT_MM)
+
+  if (image) {
+    // Use data URI instead of Buffer
+    const dataUri = `data:image/*;base64,${image.toString('base64')}`
+
+    doc.image(dataUri, { fit: [utils.mmToPoints(45), 100] }).moveDown()
+  }
+
+  doc
+    .fontSize(REGULAR_FONT_SIZE)
+    .text(
+      [
+        creditorAddress.name,
+        creditorAddress.line1,
+        creditorAddress.line2,
+        `${Number(creditorAddress.postalCode)} ${creditorAddress.city}`,
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    )
+    .moveDown()
+
+  doc.x = x
+}
+
+function getDebtorAddress(address: Address | undefined): string {
+  if (!address) {
+    return ''
+  }
+
+  const { name, line1, line2, postalCode, city } = address
+
+  const string = [name, line1, line2, `${postalCode} ${city}`.trim()]
+    .filter(Boolean)
+    .join('\n')
+
+  return string
+}
+
+function getDebtorEmail(user: User): string {
+  const { firstName, lastName, email } = user
+
+  return [`${firstName} ${lastName}`.trim(), email].filter(Boolean).join('\n')
+}
+
+function addDebtor(doc: PDF, payment: PaymentResolved) {
+  doc
+    .fontSize(DEBTOR_FONT_SIZE)
+    .moveDown()
+    .text(
+      getDebtorAddress(payment?.pledge.user.address) ||
+        getDebtorEmail(payment?.pledge.user),
+    )
+    .moveDown()
+}
+
+function addMeta(doc: PDF, payment: PaymentResolved, context: Context) {
+  const { t } = context
+
+  const { method, status } = payment
+
+  const metaFragmentPaymentMethod = t(`api/invoices/paymentMethod/${method}`)
+
+  doc
+    .fontSize(TITLE_FONT_SIZE)
+    .moveDown(2)
+    .text(t.first([`api/invoices/${status}/title`, 'api/invoices/title']))
+    .fontSize(REGULAR_FONT_SIZE)
+    .moveDown()
+    .text(
+      t.first([`api/invoices/${status}/meta`, 'api/invoices/meta'], {
+        date: formatDate(payment.createdAt),
+        reference: getReference(payment.hrid, true),
+        paymentMethod: metaFragmentPaymentMethod,
+      }),
+    )
+    .moveDown()
+}
+
+function getTableRow(
+  option: string,
+  units: number | null,
+  rowTotal: number | string,
+  config?: RowConfig,
+) {
+  const font = config?.bold ? BOLD_FONT_NAME : REGULAR_FONT_NAME
+
+  return {
+    columns: [
+      {
+        text: option,
+        font,
+      },
+      {
+        text: units || '',
+        width: utils.mmToPoints(20),
+        font,
+      },
+      {
+        text: typeof rowTotal === 'number' ? formatPrice(rowTotal) : rowTotal,
+        width: utils.mmToPoints(30),
+        font,
+      },
+    ],
+  }
+}
+
+function getTableOptionRows(option: PledgeOption, context: Context) {
+  const {
+    price,
+    periods,
+    amount,
+    option: { reward } = {},
+    period: { beginDate, endDate, membership } = {},
+  } = option
+  const { t } = context
+
+  const type = reward?.rewardType
+  const name = reward?.name
+  const interval = reward?.interval
+
+  const pricePerUnit = price * (periods || 1)
+  const rowTotal = amount * pricePerUnit
+
+  const labelFragmentInterval = t.pluralize(
+    `api/email/option/interval/${interval}/periods`,
+    { count: periods },
+  )
+
+  const replacements = {
+    count: amount,
+    interval: labelFragmentInterval,
+    sequenceNumber: membership?.sequenceNumber,
+    period: beginDate && `${formatDate(beginDate)} - ${formatDate(endDate)}`,
+  }
+
+  const label = t.pluralize(`api/invoices/option/${type}/${name}`, replacements)
+
+  const meta = t.first(
+    [
+      replacements.period &&
+        `api/invoices/option/${type}/${name}/withPeriod/meta`,
+      `api/invoices/option/${type}/${name}/meta`,
+      replacements.period && `api/invoices/option/${type}/withPeriod/meta`,
+      `api/invoices/option/${type}/meta`,
+      `api/invoices/option/meta`,
+    ].filter(Boolean),
+    replacements,
+    '',
+  )
+
+  return getTableRow(
+    [label, meta].filter(Boolean).join('\n'),
+    amount || 0,
+    rowTotal,
+  )
+}
+
+function getDonationOrDiscount(
+  total: number,
+  donation: number,
+  options: PledgeOption[],
+) {
+  const optionsTotal = options.reduce((prev: number, option) => {
+    const { price, periods, amount } = option
+
+    const pricePerUnit = price * (periods || 1)
+    const optionTotal = amount * pricePerUnit
+
+    return prev + optionTotal
+  }, 0)
+
+  return donation + Math.max(0, total - optionsTotal - donation)
+}
+
+function addTable(doc: PDF, payment: PaymentResolved, context: Context) {
+  const { t } = context
+
+  const pledgeTotal = payment.pledge?.total || 0
+
+  const header = getTableRow(
+    t('api/invoices/table/option'),
+    t('api/invoices/table/units'),
+    t('api/invoices/table/rowTotal'),
+  )
+
+  // Relevant are only pledge options w/ rewards, like a Goodie or MembershipType
+  const relevantOptions = payment.pledge?.options.filter(
+    (option) => option.option?.reward,
+  )
+
+  const options =
+    relevantOptions.map((option) => getTableOptionRows(option, context)) || []
+
+  const rows = [header, ...options]
+
+  const donationOrDiscount = getDonationOrDiscount(
+    pledgeTotal,
+    payment.pledge.donation,
+    relevantOptions,
+  )
+
+  if (donationOrDiscount !== 0) {
+    const type = donationOrDiscount > 0 ? 'donation' : 'discount'
+
+    rows.push(
+      getTableRow(t(`api/invoices/table/${type}`), null, donationOrDiscount),
+    )
+  }
+
+  const total = getTableRow(t('api/invoices/table/total'), null, pledgeTotal, {
+    bold: true,
+  })
+
+  rows.push(total)
+
+  const padding: [number, number, number, number] = [
+    0,
+    0,
+    utils.mmToPoints(5),
+    0,
+  ]
+
+  doc.moveDown().addTable({ padding, width: utils.mmToPoints(170), rows })
+}
+
+export const generate: GenerateFn = function (payment, context) {
+  if (!context) {
+    throw new Error('context is required')
+  }
+
+  const data = getSwissQrBillData(payment)
+
+  return new Promise((resolve, reject) => {
+    try {
+      const doc = new PDF(data, '/dev/null', {
+        autoGenerate: false,
+        size: 'A4',
+      })
+
+      addTopLeftPadding(doc)
+      addCreditor(doc, payment)
+      addDebtor(doc, payment)
+      addMeta(doc, payment, context)
+      addTable(doc, payment, context)
+
+      if (paymentslip.isApplicable(payment)) {
+        doc.addQRBill()
+      }
+
+      doc.end()
+
+      const buffers: Buffer[] = []
+      doc.on('data', buffers.push.bind(buffers))
+      doc.on('end', () => resolve(Buffer.concat(buffers)))
+      doc.on('error', () => reject())
+    } catch (e) {
+      reject(e)
+    }
+  })
+}

--- a/packages/invoices/lib/paymentslip.ts
+++ b/packages/invoices/lib/paymentslip.ts
@@ -1,136 +1,12 @@
 import { PDF, data as BillData } from 'swissqrbill'
+
 import {
-  generate as generateReference,
-  validate as validateReference
-} from 'node-iso11649'
-
-import { Context } from '@orbiting/backend-modules-types'
-
-interface PaymentIdInput {
-  id: string
-}
-interface PaymentHridInput {
-  hrid: string
-}
-interface PaymentResolved extends Payment {
-  pledge?: Pledge
-}
-
-export enum PaymentMethod {
-  STRIPE = 'STRIPE',
-  POSTFINANCECARD = 'POSTFINANCECARD',
-  PAYPAL = 'PAYPAL',
-  PAYMENTSLIP = 'PAYMENTSLIP',
-}
-
-export enum PaymentStatus {
-  WAITING = 'WAITING',
-  PAID = 'PAID',
-  WAITING_FOR_REFUND = 'WAITING_FOR_REFUND',
-  REFUNDED = 'REFUNDED',
-  CANCELLED = 'CANCELLED',
-}
-interface Payment {
-  id: string
-  hrid: string
-  method: PaymentMethod
-  status: PaymentStatus
-  total: number
-}
-interface PledgePayment {
-  pledgeId: string
-  pledge?: Pledge
-}
-
-interface Pledge {
-  packageId: string
-  package: Package
-  userId: string
-  user: User
-}
-
-interface Package {
-  companyId: string
-  bankAccount?: BankAccount
-}
-
-interface BankAccount {
-  iban: string
-  addressId?: string
-  address?: Address
-}
-interface User {
-  id: string
-  addressId?: string
-  address?: Address
-}
-
-interface Address {
-  id: string
-  name: string
-  line1: string
-  line2?: string
-  postalCode: string
-  city: string
-  country: string
-}
-
-export async function resolve(
-  input: PaymentIdInput | PaymentHridInput,
-  context: Context,
-): Promise<PaymentResolved> {
-  const { pgdb } = context
-
-  const payment: Payment = await pgdb.public.payments.findOne(input)
-
-  const pledgePayment: PledgePayment =
-    payment?.id &&
-    (await pgdb.public.pledgePayments.findOne({ paymentId: payment.id }))
-
-  const pledge: Pledge =
-    pledgePayment?.pledgeId &&
-    (await pgdb.public.pledges.findOne({ id: pledgePayment.pledgeId }))
-
-  const pkg: Package =
-    pledge?.packageId &&
-    (await pgdb.public.packages.findOne({ id: pledge.packageId }))
-
-  const bankAccount: BankAccount =
-    pkg?.companyId &&
-    (await pgdb.public.bankAccounts.findOne({
-      companyId: pkg.companyId,
-      default: true,
-    }))
-
-  const bankAccountAddress: Address =
-    bankAccount?.addressId &&
-    (await pgdb.public.addresses.findOne({ id: bankAccount.addressId }))
-
-  const user: User =
-    pledge?.userId && (await pgdb.public.users.findOne({ id: pledge.userId }))
-
-  const userAddress: Address =
-    user?.addressId &&
-    (await pgdb.public.addresses.findOne({ id: user.addressId }))
-
-  return {
-    ...payment,
-    pledge: {
-      ...pledge,
-      package: {
-        ...pkg,
-        bankAccount: {
-          ...bankAccount,
-          address: bankAccountAddress,
-        },
-      },
-      user: {
-        ...user,
-        address: userAddress,
-      },
-    },
-  }
-}
+  PaymentResolved,
+  PaymentMethod,
+  PaymentStatus,
+  getReference,
+  getCountryCode,
+} from './commons'
 
 export function isApplicable(payment: PaymentResolved): boolean {
   if (!payment.id) {
@@ -146,30 +22,6 @@ export function isApplicable(payment: PaymentResolved): boolean {
   }
 
   return true
-}
-
-function getCountryCode(string: string): string {
-  switch (string.trim().toLowerCase()) {
-    case 'deutschland':
-      return 'DE'
-    case 'frankreich':
-      return 'FR'
-    case 'italia':
-    case 'italien':
-      return 'IT'
-    case 'liechtenstein':
-      return 'LI'
-    case 'niederlande':
-      return 'NL'
-    case 'österreich':
-      return 'AT'
-    case 'spanien':
-      return 'ES'
-    case 'usa':
-      return 'US'
-    default:
-      return 'CH'
-  }
 }
 
 function getSwissQrBillData(payment: PaymentResolved): BillData {
@@ -218,31 +70,6 @@ function getSwissQrBillData(payment: PaymentResolved): BillData {
         },
       }),
   }
-}
-
-export function getReference(hrid: string, pretty?: boolean): string {
-  if (!hrid) {
-    throw new Error('hrid is missing')
-  }
-
-  return generateReference({
-    reference: `HRID${hrid}`,
-    pretty
-  })
-}
-
-export function getHrId(string: string): string | null {
-  const [reference, hrid] = string.replace(/[^A-Za-z0-9]/g, '').match(/RF\d\d0{0,11}HRID([A-Za-z0-9]{6})/) || []
-
-  if (!reference) {
-    return null
-  }
-
-  if (!validateReference(reference)) {
-    return null
-  }
-
-  return hrid
 }
 
 export async function generate(payment: PaymentResolved): Promise<Buffer> {

--- a/packages/invoices/lib/paymentslip.ts
+++ b/packages/invoices/lib/paymentslip.ts
@@ -1,7 +1,6 @@
 import { PDF } from 'swissqrbill'
 
 import {
-  PaymentResolved,
   PaymentMethod,
   PaymentStatus,
   getSwissQrBillData,

--- a/packages/invoices/lib/paymentslip.ts
+++ b/packages/invoices/lib/paymentslip.ts
@@ -1,14 +1,15 @@
-import { PDF, data as BillData } from 'swissqrbill'
+import { PDF } from 'swissqrbill'
 
 import {
   PaymentResolved,
   PaymentMethod,
   PaymentStatus,
-  getReference,
-  getCountryCode,
+  getSwissQrBillData,
+  IsApplicableFn,
+  GenerateFn,
 } from './commons'
 
-export function isApplicable(payment: PaymentResolved): boolean {
+export const isApplicable: IsApplicableFn = function (payment) {
   if (!payment.id) {
     return false
   }
@@ -24,56 +25,8 @@ export function isApplicable(payment: PaymentResolved): boolean {
   return true
 }
 
-function getSwissQrBillData(payment: PaymentResolved): BillData {
-  if (!payment.hrid) {
-    throw new Error('Payment HR-ID missing')
-  }
-
-  const account = payment?.pledge?.package?.bankAccount?.iban
-
-  if (!account) {
-    throw new Error('Creditor IBAN missing')
-  }
-
-  const creditorAddress = payment?.pledge?.package?.bankAccount?.address
-
-  if (!creditorAddress) {
-    throw new Error('Creditor address missing')
-  }
-
-  if (!Number(creditorAddress.postalCode)) {
-    throw new Error('Creditor address postal code is not a number')
-  }
-
-  const debtorAddress = payment?.pledge?.user?.address
-
-  return {
-    currency: 'CHF',
-    amount: payment.total / 100,
-    reference: getReference(payment.hrid),
-    creditor: {
-      account,
-      name: creditorAddress.name,
-      address: creditorAddress.line1,
-      zip: Number(creditorAddress.postalCode),
-      city: creditorAddress.city,
-      country: getCountryCode(creditorAddress.country),
-    },
-    ...(debtorAddress &&
-      Number(debtorAddress.postalCode) && {
-        debtor: {
-          name: debtorAddress.name,
-          address: debtorAddress.line1,
-          zip: Number(debtorAddress.postalCode),
-          city: debtorAddress.city,
-          country: getCountryCode(creditorAddress.country),
-        },
-      }),
-  }
-}
-
-export async function generate(payment: PaymentResolved): Promise<Buffer> {
-  const data = await getSwissQrBillData(payment)
+export const generate: GenerateFn = function (payment) {
+  const data = getSwissQrBillData(payment)
 
   return new Promise((resolve, reject) => {
     try {

--- a/packages/invoices/package.json
+++ b/packages/invoices/package.json
@@ -21,6 +21,6 @@
   },
   "dependencies": {
     "node-iso11649": "^2.1.2",
-    "swissqrbill": "^2.1.0"
+    "swissqrbill": "^2.3.0"
   }
 }

--- a/packages/migrations/migrations/20210127094404-bank-account-invoicing.js
+++ b/packages/migrations/migrations/20210127094404-bank-account-invoicing.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/republik/migrations/crowdfunding/sqls'
+const file = '20210127094404-bank-account-invoicing'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/republik-crowdfundings/graphql/resolvers/PledgePayment.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/PledgePayment.js
@@ -45,6 +45,27 @@ module.exports = {
     }
     return transformUser(users[0])
   },
+  async invoiceUrl(payment, args, context) {
+    const { user: me } = context
+
+    if (!Roles.userIsInRoles(me, ['admin', 'supporter'])) {
+      return null
+    }
+
+    const resolvedPayment = await invoices.commons.resolvePayment(
+      { id: payment.id },
+      context,
+    )
+
+    if (!invoices.invoice.isApplicable(resolvedPayment)) {
+      return null
+    }
+
+    const user = resolvedPayment?.pledge?.user
+
+    const token = AccessToken.generateForUser(user, 'INVOICE')
+    return `${PUBLIC_URL}/invoices/${payment.hrid}.pdf?token=${token}`
+  },
   async paymentslipUrl(payment, args, context) {
     const { user: me } = context
     const resolvedPayment = await invoices.commons.resolvePayment(

--- a/packages/republik-crowdfundings/graphql/resolvers/PledgePayment.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/PledgePayment.js
@@ -3,13 +3,13 @@ const {
   AccessToken,
   transformUser,
 } = require('@orbiting/backend-modules-auth')
-const { paymentslip } = require('@orbiting/backend-modules-invoices')
+const invoices = require('@orbiting/backend-modules-invoices')
 
 const { PUBLIC_URL } = process.env
 
 module.exports = {
   reference(payment, args) {
-    return paymentslip.getReference(payment.hrid, args.pretty)
+    return invoices.commons.getReference(payment.hrid, args.pretty)
   },
   async user(payment, args, { pgdb }) {
     const users = await pgdb.query(
@@ -47,12 +47,12 @@ module.exports = {
   },
   async paymentslipUrl(payment, args, context) {
     const { user: me } = context
-    const resolvedPayment = await paymentslip.resolve(
+    const resolvedPayment = await invoices.commons.resolvePayment(
       { id: payment.id },
       context,
     )
 
-    if (!paymentslip.isApplicable(resolvedPayment)) {
+    if (!invoices.paymentslip.isApplicable(resolvedPayment)) {
       return null
     }
 

--- a/packages/republik-crowdfundings/graphql/schema-types.js
+++ b/packages/republik-crowdfundings/graphql/schema-types.js
@@ -284,6 +284,7 @@ type PledgePayment {
   status: PaymentStatus!
   hrid: String
   reference(pretty: Boolean): String
+  invoiceUrl: String
   paymentslipUrl: String
   pspId: String
   dueDate: DateTime

--- a/packages/republik-crowdfundings/lib/payments/paymentslip/sendPaymentReminders.ts
+++ b/packages/republik-crowdfundings/lib/payments/paymentslip/sendPaymentReminders.ts
@@ -8,7 +8,7 @@ import {
 import { formatPrice } from '@orbiting/backend-modules-formats'
 import { Context } from '@orbiting/backend-modules-types'
 import { publishFinance } from '@orbiting/backend-modules-republik/lib/slack'
-import { paymentslip } from '@orbiting/backend-modules-invoices'
+import * as invoices from '@orbiting/backend-modules-invoices'
 
 const { sendMailTemplate } = require('@orbiting/backend-modules-mail')
 const { PAYMENT_DEADLINE_DAYS } = require('./helpers')
@@ -229,7 +229,7 @@ async function send({
     `api/email/payment/reminder${isLast ? '/last' : ''}/default/subject`,
   ])
 
-  const resolvedPayment = await paymentslip.resolve(
+  const resolvedPayment = await invoices.commons.resolvePayment(
     { hrid: payment.hrid },
     context,
   )
@@ -253,18 +253,23 @@ async function send({
         },
         {
           name: 'reference',
-          content: paymentslip.getReference(resolvedPayment.hrid, true),
+          content: invoices.commons.getReference(resolvedPayment.hrid, true),
         },
       ],
       attachments: [
         {
           type: 'application/pdf',
-          name: [
-            'QR-Rechnung',
-            creditor?.address?.name,
-            paymentslip.getReference(resolvedPayment.hrid, true)
-          ].filter(Boolean).join(' ') + '.pdf',
-          content: (await paymentslip.generate(resolvedPayment)).toString('base64'),
+          name:
+            [
+              'QR-Rechnung',
+              creditor?.address?.name,
+              invoices.commons.getReference(resolvedPayment.hrid, true),
+            ]
+              .filter(Boolean)
+              .join(' ') + '.pdf',
+          content: (
+            await invoices.paymentslip.generate(resolvedPayment)
+          ).toString('base64'),
         },
       ],
     },

--- a/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
@@ -1,7 +1,7 @@
 import parser from 'fast-xml-parser'
 import { Nominal } from 'simplytyped'
 
-import { paymentslip } from '@orbiting/backend-modules-invoices'
+import * as invoices from '@orbiting/backend-modules-invoices'
 
 type Amount = Nominal<string, 'amount'>
 type AmountInCents = Nominal<number, 'cents'>
@@ -45,7 +45,7 @@ type TransactionDetails = {
       CdtrRefInf?: {
         Ref?: string
       }
-    } 
+    }
   }
 }
 
@@ -250,7 +250,8 @@ function getMitteilung(
   transactionDetails?: TransactionDetails,
 ): string | null {
   const creditorReference = transactionDetails?.RmtInf?.Strd?.CdtrRefInf?.Ref
-  const referenceHrId = creditorReference && paymentslip.getHrId(creditorReference)
+  const referenceHrId =
+    creditorReference && invoices.commons.getHrId(creditorReference)
 
   if (referenceHrId) return referenceHrId
 
@@ -264,9 +265,11 @@ function getMitteilung(
   }
 
   return (
-    paymentslip.getHrId(remittanceInformation) ||
+    invoices.commons.getHrId(remittanceInformation) ||
     remittanceInformation?.match(/\b([A-Za-z0-9]{6})\b/)?.[1] ||
-    avisierungstext.match(/.*?MITTEILUNGEN:.*?\s([A-Za-z0-9]{6})(\s.*?|$)/)?.[1] ||
+    avisierungstext.match(
+      /.*?MITTEILUNGEN:.*?\s([A-Za-z0-9]{6})(\s.*?|$)/,
+    )?.[1] ||
     null
   )
 }

--- a/packages/republik/migrations/crowdfunding/sqls/20210127094404-bank-account-invoicing-down.sql
+++ b/packages/republik/migrations/crowdfunding/sqls/20210127094404-bank-account-invoicing-down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."bankAccounts"
+  DROP COLUMN "image",
+  DROP COLUMN "canInvoice";

--- a/packages/republik/migrations/crowdfunding/sqls/20210127094404-bank-account-invoicing-up.sql
+++ b/packages/republik/migrations/crowdfunding/sqls/20210127094404-bank-account-invoicing-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."bankAccounts"
+  ADD COLUMN "image" bytea,
+  ADD COLUMN "canInvoice" boolean NOT NULL DEFAULT false;

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -2003,6 +2003,10 @@
       "value": "Ermässigung"
     },
     {
+      "key": "api/invoices/table/PROJECT_R/total",
+      "value": "Gesamtbetrag (nicht MWST-pflichtig)"
+    },
+    {
       "key": "api/invoices/table/total",
       "value": "Gesamtbetrag"
     },

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1941,6 +1941,162 @@
     {
       "key": "api/repo/phase/published",
       "value": "Publiziert"
+    },
+    {
+      "key": "api/invoices/PAID/title",
+      "value": "Beleg"
+    },
+    {
+      "key": "api/invoices/title",
+      "value": "Rechnung"
+    },
+    {
+      "key": "api/invoices/PAID/meta",
+      "value": "Datum: {date}\nBelegnummer: {reference}\nZahlungsmittel: {paymentMethod}"
+    },
+    {
+      "key": "api/invoices/meta",
+      "value": "Datum: {date}\nRechnungsnummer: {reference}\nZahlungsmittel: {paymentMethod}"
+    },
+    {
+      "key": "api/invoices/paymentMethod/STRIPE",
+      "value": "Kreditkarte"
+    },
+    {
+      "key": "api/invoices/paymentMethod/POSTFINANCECARD",
+      "value": "Postcard"
+    },
+    {
+      "key": "api/invoices/paymentMethod/PAYPAL",
+      "value": "PayPal"
+    },
+    {
+      "key": "api/invoices/paymentMethod/PAYMENTSLIP",
+      "value": "Rechnung"
+    },
+    {
+      "key": "api/invoices/table/option",
+      "value": "Artikel"
+    },
+    {
+      "key": "api/invoices/table/units",
+      "value": "Menge"
+    },
+    {
+      "key": "api/invoices/table/rowTotal",
+      "value": "Betrag in CHF"
+    },
+    {
+      "key": "api/invoices/table/donation",
+      "value": "Spende"
+    },
+    {
+      "key": "api/invoices/table/discount",
+      "value": "Ermässigung"
+    },
+    {
+      "key": "api/invoices/table/total",
+      "value": "Gesamtbetrag"
+    },
+    {
+      "key": "api/invoices/option/Goodie/NOTEBOOK/1",
+      "value": "Notizbuch"
+    },
+    {
+      "key": "api/invoices/option/Goodie/NOTEBOOK/other",
+      "value": "Notizbücher"
+    },
+    {
+      "key": "api/invoices/option/Goodie/TOTEBAG/1",
+      "value": "Tasche"
+    },
+    {
+      "key": "api/invoices/option/Goodie/TOTEBAG/other",
+      "value": "Taschen"
+    },
+    {
+      "key": "api/invoices/option/Goodie/TABLEBOOK/1",
+      "value": "Buch «Republik bei Stromausfall»"
+    },
+    {
+      "key": "api/invoices/option/Goodie/TABLEBOOK/other",
+      "value": "Bücher «Republik bei Stromausfall»"
+    },
+    {
+      "key": "api/invoices/option/Goodie/MASK/1",
+      "value": "Republik-Maske"
+    },
+    {
+      "key": "api/invoices/option/Goodie/MASK/other",
+      "value": "Republik-Masken"
+    },
+    {
+      "key": "api/invoices/option/MembershipType/ABO/1",
+      "value": "Abo und Mitgliedschaft"
+    },
+    {
+      "key": "api/invoices/option/MembershipType/ABO/other",
+      "value": "Abo und Mitgliedschaften"
+    },
+    {
+      "key": "api/invoices/option/MembershipType/BENEFACTOR_ABO/1",
+      "value": "Gönner-Mitgliedschaft"
+    },
+    {
+      "key": "api/invoices/option/MembershipType/BENEFACTOR_ABO/other",
+      "value": "Gönner-Mitgliedschaften"
+    },
+    {
+      "key": "api/invoices/option/MembershipType/MONTHLY_ABO/1",
+      "value": "Monats-Abo"
+    },
+    {
+      "key": "api/invoices/option/MembershipType/MONTHLY_ABO/other",
+      "value": "Monats-Abos"
+    },
+    {
+      "key": "api/invoices/option/MembershipType/ABO_GIVE_MONTHS/1",
+      "value": "Monats-Abo als Geschenk für {interval}"
+    },
+    {
+      "key": "api/invoices/option/MembershipType/ABO_GIVE_MONTHS/other",
+      "value": "Monats-Abos als Geschenk für {interval}"
+    },
+    {
+      "key": "api/invoices/option/interval/year/periods/1",
+      "value": "ein Jahr"
+    },
+    {
+      "key": "api/invoices/option/interval/year/periods/other",
+      "value": "{count} Jahre"
+    },
+    {
+      "key": "api/invoices/option/interval/month/periods/1",
+      "value": "einen Monat"
+    },
+    {
+      "key": "api/invoices/option/interval/month/periods/other",
+      "value": "{count} Monate"
+    },
+    {
+      "key": "api/invoices/option/interval/week/periods/1",
+      "value": "eine Woche"
+    },
+    {
+      "key": "api/invoices/option/interval/week/count/other",
+      "value": "{count} Wochen"
+    },
+    {
+      "key": "api/invoices/option/interval/day/periods/1",
+      "value": "einen Tag"
+    },
+    {
+      "key": "api/invoices/option/interval/day/periods/other",
+      "value": "{count} Tage"
+    },
+    {
+      "key": "api/invoices/option/MembershipType/withPeriod/meta",
+      "value": "#{sequenceNumber}\n{period}"
     }
   ]
 }

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1952,11 +1952,19 @@
     },
     {
       "key": "api/invoices/PAID/meta",
-      "value": "Datum: {date}\nBelegnummer: {reference}\nZahlungsmittel: {paymentMethod}"
+      "value": "Datum: {date}\nBelegnummer: {reference}\nZahlungsart: {paymentMethod}"
     },
     {
       "key": "api/invoices/meta",
-      "value": "Datum: {date}\nRechnungsnummer: {reference}\nZahlungsmittel: {paymentMethod}"
+      "value": "Datum: {date}\nRechnungsnummer: {reference}\nZahlungsart: {paymentMethod}"
+    },
+    {
+      "key": "api/invoices/creditor/PROJECT_R",
+      "value": "{address}\n\nwww.republik.ch\nkontakt@republik.ch"
+    },
+    {
+      "key": "api/invoices/creditor",
+      "value": "{address}"
     },
     {
       "key": "api/invoices/paymentMethod/STRIPE",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12445,22 +12445,22 @@ svg-parser@^2.0.4:
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
-svgpath@^2.2.3:
+svgpath@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/svgpath/-/svgpath-2.3.0.tgz#efc76705deab6bd1774e9f0ed038bb661b5e4d23"
   integrity sha512-N/4UDu3Y2ICik0daMmFW1tplw0XPs1nVIEVYkTiQfj9/JQZeEtAKaSYwheCwje1I4pQ5r22fGpoaNIvGgsyJyg==
 
-swissqrbill@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/swissqrbill/-/swissqrbill-2.1.0.tgz#6f6a9b800179c78bb867ca48091cc41de70c2476"
-  integrity sha512-+blw1vs6WPyBJS6tWE03YcYU/h9/7Kp+i/V9QoRpRHMkUBZW4kmhqu/TGODQ/N/1Dljqhta1pcjhX7EXIdXpNw==
+swissqrbill@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/swissqrbill/-/swissqrbill-2.3.0.tgz#0f04014c1a53575336ba38a3bea3ef4d60f79c36"
+  integrity sha512-ySgH7KTKi+9sqgePRceofumBKUXKAQxfWV9oHWYkePInVzYiOBrcJndvnWlcEkN7MqVskRcnR8zG/LDu9Qz3Bw==
   dependencies:
     "@schoero/qrcode" "^1.4.5"
     blob-stream "^0.1.3"
     iban "0.0.14"
     pdfkit "^0.11.0"
     svg-parser "^2.0.4"
-    svgpath "^2.2.3"
+    svgpath "^2.3.0"
 
 symbol-observable@^1.0.4:
   version "1.2.0"


### PR DESCRIPTION
This Pull Request can generate an invoice or receipt. [It includes a "Swiss QR Bill" if applicable](https://github.com/orbiting/backends/pull/552).

<img width="814" alt="Bildschirmfoto 2021-01-28 um 06 41 52" src="https://user-images.githubusercontent.com/331800/106095342-f2d1e380-6133-11eb-8c16-b1633a55d7d0.png">

Using a scoped access token (`INVOICE`) and HR-ID, API will provide an invoice or receipt via URL as PDF if token and HR-ID eventually belong to same user. It requires a payment to be in status `PAID` or `WAITING`. Example: `/invoices/[HR-ID].pdf?token=[Access Token]`

PDFs are generated on the fly and neither cached nor stored. Over time, contents of a payment slip might change, i. e. a user updates their address.

GraphQL returns a payment slip URL on `PledgePayment.invoiceUrl` if user holds roles `admin` or `supporter`: Example:

```gql
{
  me {
    pledges {
      payments {
        invoiceUrl
      }
    }
  }
}
```