### PR TITLE
fix(invoices): Harden reference parsing

### DIFF
--- a/packages/invoices/lib/paymentslip.ts
+++ b/packages/invoices/lib/paymentslip.ts
@@ -234,7 +234,7 @@ export function getReference(hrid: string, pretty?: boolean): string {
 export function getHrId(string: string): string | null {
   const [reference, hrid] =
     string
-      .replace(/[^A-Za-z0-9]/g, '')
+      .replace(/[^A-Z0-9]/gi, '')
       .match(/RF\d\d0{0,11}HRID([A-Z0-9]{6})/i) || []
 
   if (!reference) {

--- a/packages/invoices/lib/paymentslip.ts
+++ b/packages/invoices/lib/paymentslip.ts
@@ -1,7 +1,7 @@
 import { PDF, data as BillData } from 'swissqrbill'
 import {
   generate as generateReference,
-  validate as validateReference
+  validate as validateReference,
 } from 'node-iso11649'
 
 import { Context } from '@orbiting/backend-modules-types'
@@ -226,13 +226,16 @@ export function getReference(hrid: string, pretty?: boolean): string {
   }
 
   return generateReference({
-    reference: `HRID${hrid}`,
-    pretty
+    reference: `HRID${hrid.toUpperCase()}`,
+    pretty,
   })
 }
 
 export function getHrId(string: string): string | null {
-  const [reference, hrid] = string.replace(/[^A-Za-z0-9]/g, '').match(/RF\d\d0{0,11}HRID([A-Za-z0-9]{6})/) || []
+  const [reference, hrid] =
+    string
+      .replace(/[^A-Za-z0-9]/g, '')
+      .match(/RF\d\d0{0,11}HRID([A-Z0-9]{6})/i) || []
 
   if (!reference) {
     return null
@@ -242,7 +245,7 @@ export function getHrId(string: string): string | null {
     return null
   }
 
-  return hrid
+  return hrid.toUpperCase()
 }
 
 export async function generate(payment: PaymentResolved): Promise<Buffer> {

--- a/packages/republik-crowdfundings/lib/scheduler/payments/fixtures/camt053mitteilung.xml
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/fixtures/camt053mitteilung.xml
@@ -293,6 +293,83 @@
           MITTEILUNGEN: Referenz: RF96 HRID EEEE EE Foobar
         </AddtlNtryInf>
       </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">60.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <RvslInd>false</RvslInd>
+        <Sts>BOOK</Sts>
+        <BookgDt>
+          <Dt>2021-01-28</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2021-01-28</Dt>
+        </ValDt>
+        <AcctSvcrRef>0281300386593266</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>ICDT</Cd>
+              <SubFmlyCd>BOOK</SubFmlyCd>
+            </Fmly>
+          </Domn>
+        </BkTxCd>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>0281300386593266</AcctSvcrRef>
+            </Refs>
+            <Amt Ccy="CHF">60.00</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>GIRO AUS KONTO FOOBAR MOBILE CH0909000000809999999 HANS MUSTERMANN MITTEILUNGEN: RF65 HRID FFFF FF</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">240.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <BookgDt>
+          <Dt>2020-09-18</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2020-09-18</Dt>
+        </ValDt>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>RCDT</Cd>
+              <SubFmlyCd>ATXN</SubFmlyCd>
+            </Fmly>
+          </Domn>
+        </BkTxCd>
+        <NtryDtls>
+          <Btch>
+            <NbOfTxs>1</NbOfTxs>
+          </Btch>
+          <TxDtls>
+            <RmtInf>
+              <Ustrd>lorem ipsum abonnement: rf34 hrid g</Ustrd>
+              <Ustrd>ggg gg</Ustrd>
+            </RmtInf>
+            <RltdPties>
+              <Dbtr>
+                <Nm>Pierre Spring</Nm>
+                <PstlAdr>
+                  <StrtNm>Strasse</StrtNm>
+                  <BldgNb>123</BldgNb>
+                  <PstCd>1700</PstCd>
+                  <TwnNm>Fribourg</TwnNm>
+                  <Ctry>CH</Ctry>
+                </PstlAdr>
+              </Dbtr>
+            </RltdPties>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>
+          MITTEILUNGEN: lorem ipsum heidiland rf34 hrid g ggg gg
+        </AddtlNtryInf>
+      </Ntry>
     </Stmt>
   </BkToCstmrStmt>
 </Document>

--- a/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
@@ -45,7 +45,7 @@ type TransactionDetails = {
       CdtrRefInf?: {
         Ref?: string
       }
-    } 
+    }
   }
 }
 
@@ -250,23 +250,26 @@ function getMitteilung(
   transactionDetails?: TransactionDetails,
 ): string | null {
   const creditorReference = transactionDetails?.RmtInf?.Strd?.CdtrRefInf?.Ref
-  const referenceHrId = creditorReference && paymentslip.getHrId(creditorReference)
+  const referenceHrId =
+    creditorReference && paymentslip.getHrId(creditorReference)
 
   if (referenceHrId) return referenceHrId
 
   let remittanceInformation = transactionDetails?.RmtInf?.Ustrd
-  if (!remittanceInformation) {
-    return null
-  }
 
   if (Array.isArray(remittanceInformation)) {
     remittanceInformation = remittanceInformation.join(' ')
   }
 
   return (
-    paymentslip.getHrId(remittanceInformation) ||
-    remittanceInformation?.match(/\b([A-Za-z0-9]{6})\b/)?.[1] ||
-    avisierungstext.match(/.*?MITTEILUNGEN:.*?\s([A-Za-z0-9]{6})(\s.*?|$)/)?.[1] ||
+    (remittanceInformation && paymentslip.getHrId(remittanceInformation)) ||
+    (avisierungstext && paymentslip.getHrId(avisierungstext)) ||
+    (remittanceInformation &&
+      remittanceInformation?.match(/\b([A-Za-z0-9]{6})\b/)?.[1]) ||
+    (avisierungstext &&
+      avisierungstext.match(
+        /.*?MITTEILUNGEN:.*?\s([A-Za-z0-9]{6})(\s.*?|$)/,
+      )?.[1]) ||
     null
   )
 }

--- a/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
@@ -262,14 +262,11 @@ function getMitteilung(
   }
 
   return (
-    (remittanceInformation && paymentslip.getHrId(remittanceInformation)) ||
-    (avisierungstext && paymentslip.getHrId(avisierungstext)) ||
-    (remittanceInformation &&
-      remittanceInformation?.match(/\b([A-Za-z0-9]{6})\b/)?.[1]) ||
-    (avisierungstext &&
-      avisierungstext.match(
-        /.*?MITTEILUNGEN:.*?\s([A-Za-z0-9]{6})(\s.*?|$)/,
-      )?.[1]) ||
+    paymentslip.getHrId(remittanceInformation || avisierungstext) ||
+    remittanceInformation?.match(/\b([A-Za-z0-9]{6})\b/)?.[1] ||
+    avisierungstext.match(
+      /.*?MITTEILUNGEN:.*?\s([A-Za-z0-9]{6})(\s.*?|$)/,
+    )?.[1] ||
     null
   )
 }

--- a/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.u.jest.ts
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.u.jest.ts
@@ -59,6 +59,8 @@ describe('parseCamt053():', () => {
     expect(paymentEntries[3].mitteilung).toEqual('CCCCCC')
     expect(paymentEntries[4].mitteilung).toEqual(null)
     expect(paymentEntries[5].mitteilung).toEqual('EEEEEE')
+    expect(paymentEntries[6].mitteilung).toEqual('FFFFFF')
+    expect(paymentEntries[7].mitteilung).toEqual('GGGGGG')
   })
 
   it('returns the reference for the sanned cash deposit', async () => {


### PR DESCRIPTION
This Pull Request hardens reference using case-insensitive search and checking `avisierungstext` if no remittance information is available.