### PR TITLE
feat(publikator): Add base migrations

### DIFF
--- a/packages/migrations/migrations/20210201080354-base.js
+++ b/packages/migrations/migrations/20210201080354-base.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/publikator/migrations/sqls'
+const file = '20210201080354-base'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/publikator/migrations/sqls/20210201080354-base-down.sql
+++ b/packages/publikator/migrations/sqls/20210201080354-base-down.sql
@@ -6,6 +6,7 @@ TRUNCATE public."notifyTableChangeQueue";
 ALTER TABLE public."notifyTableChangeQueue"
   ALTER COLUMN "id" TYPE uuid USING id::uuid;
 DROP TABLE publikator.milestones;
+DROP DOMAIN IF EXISTS "milestoneScopeDomain";
 DROP TABLE publikator.commits;
 DROP TABLE publikator.repos;
 DROP SCHEMA publikator;

--- a/packages/publikator/migrations/sqls/20210201080354-base-down.sql
+++ b/packages/publikator/migrations/sqls/20210201080354-base-down.sql
@@ -1,0 +1,8 @@
+DROP TRIGGER IF EXISTS trigger_publikator_commits_notify_change
+  ON publikator.commits;
+DROP TRIGGER IF EXISTS trigger_publikator_repos_notify_change
+  ON publikator.repos;
+DROP TABLE publikator.milestones;
+DROP TABLE publikator.commits;
+DROP TABLE publikator.repos;
+DROP SCHEMA publikator;

--- a/packages/publikator/migrations/sqls/20210201080354-base-down.sql
+++ b/packages/publikator/migrations/sqls/20210201080354-base-down.sql
@@ -2,6 +2,9 @@ DROP TRIGGER IF EXISTS trigger_publikator_commits_notify_change
   ON publikator.commits;
 DROP TRIGGER IF EXISTS trigger_publikator_repos_notify_change
   ON publikator.repos;
+TRUNCATE public."notifyTableChangeQueue";
+ALTER TABLE public."notifyTableChangeQueue"
+  ALTER COLUMN "id" TYPE uuid USING id::uuid;
 DROP TABLE publikator.milestones;
 DROP TABLE publikator.commits;
 DROP TABLE publikator.repos;

--- a/packages/publikator/migrations/sqls/20210201080354-base-up.sql
+++ b/packages/publikator/migrations/sqls/20210201080354-base-up.sql
@@ -1,0 +1,56 @@
+CREATE SCHEMA publikator;
+
+CREATE TABLE publikator.repos (
+  id text PRIMARY KEY,
+  meta jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "currentPhase" text,
+  "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "updatedAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "archivedAt" timestamp with time zone
+);
+
+CREATE TABLE publikator.commits (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  "repoId" text NOT NULL REFERENCES publikator.repos(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  hash text,
+  "parentIds" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "parentHashes" jsonb,
+  message text,
+  content text,
+  meta jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "userId" uuid REFERENCES users(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  author jsonb,
+  "createdAt" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX "commits_repoId_hash_idx" ON publikator.commits("repoId" text_ops,hash text_ops);
+
+CREATE TABLE publikator.milestones (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  "repoId" text NOT NULL REFERENCES publikator.repos(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  scope text NOT NULL DEFAULT 'milestone'::text,
+  "commitId" uuid NOT NULL REFERENCES publikator.commits(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  name text NOT NULL,
+  meta jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "userId" uuid REFERENCES users(id) ON DELETE SET NULL ON UPDATE CASCADE,
+  author jsonb,
+  "createdAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "scheduledAt" timestamp with time zone,
+  "publishedAt" timestamp with time zone,
+  "revokedAt" timestamp with time zone
+);
+
+-- change id::uuid to id::text as publikator.repos.id is text
+ALTER TABLE "public"."notifyTableChangeQueue" ALTER COLUMN "id" TYPE text;
+
+-- notify_table_change() executed on INSERT, UPDATE, CHANGE of
+-- "publikator.repos"
+CREATE TRIGGER trigger_publikator_repos_notify_change
+  AFTER INSERT OR UPDATE OR DELETE ON publikator.repos
+  FOR EACH ROW EXECUTE PROCEDURE notify_table_change();
+
+-- notify_table_change() executed on INSERT, UPDATE, CHANGE of
+-- "publikator.commits"
+CREATE TRIGGER trigger_publikator_commits_notify_change
+  AFTER INSERT OR UPDATE OR DELETE ON publikator.commits
+  FOR EACH ROW EXECUTE PROCEDURE notify_table_change();

--- a/packages/publikator/migrations/sqls/20210201080354-base-up.sql
+++ b/packages/publikator/migrations/sqls/20210201080354-base-up.sql
@@ -41,7 +41,8 @@ CREATE TABLE publikator.milestones (
 );
 
 -- change id::uuid to id::text as publikator.repos.id is text
-ALTER TABLE "public"."notifyTableChangeQueue" ALTER COLUMN "id" TYPE text;
+ALTER TABLE public."notifyTableChangeQueue"
+  ALTER COLUMN "id" TYPE text;
 
 -- notify_table_change() executed on INSERT, UPDATE, CHANGE of
 -- "publikator.repos"

--- a/packages/publikator/migrations/sqls/20210201080354-base-up.sql
+++ b/packages/publikator/migrations/sqls/20210201080354-base-up.sql
@@ -25,10 +25,20 @@ CREATE TABLE publikator.commits (
 
 CREATE UNIQUE INDEX "commits_repoId_hash_idx" ON publikator.commits("repoId" text_ops,hash text_ops);
 
+CREATE DOMAIN "milestoneScopeDomain" AS TEXT
+  CONSTRAINT "milestoneScopeDomainCheck"
+    CHECK(
+      VALUE IN (
+        'milestone',
+        'publication',
+        'prepublication'
+      )
+    );
+
 CREATE TABLE publikator.milestones (
   id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
   "repoId" text NOT NULL REFERENCES publikator.repos(id) ON DELETE CASCADE ON UPDATE CASCADE,
-  scope text NOT NULL DEFAULT 'milestone'::text,
+  scope "milestoneScopeDomain" NOT NULL DEFAULT 'milestone'::"milestoneScopeDomain",
   "commitId" uuid NOT NULL REFERENCES publikator.commits(id) ON DELETE RESTRICT ON UPDATE CASCADE,
   name text NOT NULL,
   meta jsonb NOT NULL DEFAULT '{}'::jsonb,


### PR DESCRIPTION
Includes schema for repos, commits and milestones, adds triggers and
alters notifyTableChangeQueue to accept ids as text (instead of uuids)