### PR TITLE
fix(mail) remove golden pin from benefactor payment and pledge mail

### DIFF
--- a/packages/mail/templates/payment_successful_benefactor.html
+++ b/packages/mail/templates/payment_successful_benefactor.html
@@ -80,8 +80,7 @@
                     <p>
                       Um uns für Ihre besonders grosse Unterstützung ein kleines
                       bisschen zu revanchieren, schicken wir Ihnen postwendend
-                      das Gönnerpaket mit Manifest, dem exklusiven
-                      Republik-Anstecker in Gold sowie einer signierten Ausgabe
+                      das Gönnerpaket mit Manifest und einer signierten Ausgabe
                       von Constantin Seibts Buch «<a
                         href="https://keinundaber.ch/de/literary-work/deadline/"
                         >Deadline – Wie man besser schreibt</a

--- a/packages/mail/templates/payment_successful_benefactor.txt
+++ b/packages/mail/templates/payment_successful_benefactor.txt
@@ -21,10 +21,9 @@ sich mit Ihren Kolleginnen und Kollegen in der Verlagsetage austauschen.
 {{/if}}
 
 Um uns für Ihre besonders grosse Unterstützung ein kleines bisschen zu
-revanchieren, schicken wir Ihnen postwendend das Gönnerpaket mit Manifest, dem
-exklusiven Republik-Anstecker in Gold sowie einer signierten Ausgabe von
-Constantin Seibts Buch «Deadline – Wie man besser schreibt
-https://keinundaber.ch/de/literary-work/deadline/ » zu.
+revanchieren, schicken wir Ihnen postwendend das Gönnerpaket mit Manifest und
+einer signierten Ausgabe von Constantin Seibts Buch «Deadline – Wie man besser
+schreibt https://keinundaber.ch/de/literary-work/deadline/ » zu.
 
 {{#if goodies_count}}
 

--- a/packages/mail/templates/pledge_benefactor.html
+++ b/packages/mail/templates/pledge_benefactor.html
@@ -77,8 +77,7 @@
                     <p>
                       Um uns für Ihre besonders grosse Unterstützung ein kleines
                       bisschen zu revanchieren, schicken wir Ihnen postwendend
-                      das Gönner-Paket mit Manifest, dem exklusiven
-                      Republik-Anstecker in Gold sowie einer signierten Ausgabe
+                      das Gönner-Paket mit Manifest und einer signierten Ausgabe
                       von Constantin Seibts Buch «<a
                         href="https://keinundaber.ch/de/literary-work/deadline/"
                         >Deadline – Wie man besser schreibt</a

--- a/packages/mail/templates/pledge_benefactor.txt
+++ b/packages/mail/templates/pledge_benefactor.txt
@@ -21,10 +21,9 @@ Hier finden Sie die Gebrauchsanleitung {{link_manual}} , die die wichtigsten
 davon klärt.
 
 Um uns für Ihre besonders grosse Unterstützung ein kleines bisschen zu
-revanchieren, schicken wir Ihnen postwendend das Gönner-Paket mit Manifest, dem
-exklusiven Republik-Anstecker in Gold sowie einer signierten Ausgabe von
-Constantin Seibts Buch «Deadline – Wie man besser schreibt
-https://keinundaber.ch/de/literary-work/deadline/ » zu.
+revanchieren, schicken wir Ihnen postwendend das Gönner-Paket mit Manifest und
+einer signierten Ausgabe von Constantin Seibts Buch «Deadline – Wie man besser
+schreibt https://keinundaber.ch/de/literary-work/deadline/ » zu.
 
 {{/if}}
 


### PR DESCRIPTION
* golden pins are not sent via mail anymore so it's removed from mail templates 