### PR TITLE
refactor: Clean-up url prefixing and mdast node processing

### DIFF
--- a/packages/assets/lib/urlPrefixing.js
+++ b/packages/assets/lib/urlPrefixing.js
@@ -23,6 +23,10 @@ const createRepoIdMatcher = (repoId) => (string) => {
   return !!(string?.indexOf(`/${repoId}/`) >= 0)
 }
 
+const isDataUrl = (string) => {
+  return !!string?.startsWith('data:')
+}
+
 const isHttpUrl = (string) => {
   return !!string?.startsWith('http')
 }
@@ -45,6 +49,12 @@ const isProxyUrl = (string) => {
 
 module.exports = {
   authenticate,
+  createRepoIdMatcher,
+  isDataUrl,
+  isHttpUrl,
+  isImagePath,
+  hasOriginalKeyHash,
+  isProxyUrl,
 
   createRepoUrlPrefixer: (repoId, isPublic = false) => {
     if (!repoId) {

--- a/packages/assets/lib/urlPrefixing.u.jest.js
+++ b/packages/assets/lib/urlPrefixing.u.jest.js
@@ -1,36 +1,116 @@
-process.env.ASSETS_SERVER_BASE_URL = 'http://example.com'
+process.env.ASSETS_SERVER_BASE_URL = 'http://domain.tld'
+process.env.AWS_S3_BUCKET = 'some-bucket'
+process.env.ASSETS_HMAC_KEY = 'foobar'
 
-const { createRepoUrlPrefixer, unprefixUrl } = require('./urlPrefixing')
-const repo = 'exampleRepo'
+const {
+  createRepoUrlPrefixer,
+  createRepoUrlUnprefixer,
+  createProxyUrlPrefixer,
+} = require('./urlPrefixing')
+const repoId = 'repo-namespace/repo-name'
 
-test('createRepoUrlPrefixer', () => {
-  expect(() => createRepoUrlPrefixer()).toThrow()
-  expect(() => createRepoUrlPrefixer('')).toThrow()
-  expect(() => createRepoUrlPrefixer(repo)).not.toThrow()
+describe('createRepoUrlPrefixer()', () => {
+  it('throws when repoId arg is bad', () => {
+    expect(() => createRepoUrlPrefixer()).toThrow()
+    expect(() => createRepoUrlPrefixer('')).toThrow()
+  })
+
+  it('does not throw when repoId arg is ok', () => {
+    expect(() => createRepoUrlPrefixer(repoId)).not.toThrow()
+  })
+
+  it('does not throw when repoId arg is ok', () => {
+    expect(() => createRepoUrlPrefixer(repoId)).not.toThrow()
+  })
+
+  it('prefixes url', () => {
+    const url = 'images/asdf.jpg?test=true'
+    const prefix = createRepoUrlPrefixer(repoId)
+    const prefixedUrl = prefix(url)
+
+    expect(prefixedUrl).toMatch(url)
+    expect(prefixedUrl).toMatch(/^http/)
+    expect(prefixedUrl.indexOf('#originalURL')).toBeTruthy()
+  })
+
+  it('passes through url', () => {
+    const url = 'asdf.jpg'
+    const prefix = createRepoUrlPrefixer(repoId)
+    expect(url).toBe(prefix(url))
+  })
 })
 
-test('skip url prefixing', () => {
-  const url = 'asdf.jpg'
-  const prefixUrl = createRepoUrlPrefixer(repo)
-  expect(url).toBe(prefixUrl(url))
+describe('createRepoUrlUnprefixer', () => {
+  it('throws when repoId arg is bad', () => {
+    expect(() => createRepoUrlUnprefixer()).toThrow()
+    expect(() => createRepoUrlUnprefixer('')).toThrow()
+  })
+
+  it('does not throw when repoId arg is ok', () => {
+    expect(() => createRepoUrlUnprefixer(repoId)).not.toThrow()
+  })
+
+  it('restores original url', () => {
+    const url =
+      'http://domain.tld/repo-namespace/repo-name/images/asdf.jpg#originalURL=images%2Fasdf.jpg'
+    const unprefix = createRepoUrlUnprefixer(repoId)
+    expect(unprefix(url)).toBe('images/asdf.jpg')
+  })
+
+  it('restores original url when domain is foreign', () => {
+    const url =
+      'http://foobar.tld/path/repo-namespace/repo-name/images/asdf.jpg#originalURL=images%2Fasdf.jpg'
+    const unprefix = createRepoUrlUnprefixer(repoId)
+    expect(unprefix(url)).toBe('images/asdf.jpg')
+  })
+
+  it('pass through when #originalURL contains no "images/"', () => {
+    const url =
+      'http://domain.tld/repo-namespace/repo-name/images/asdf.jpg#originalURL=some%2Fpath'
+    const unprefix = createRepoUrlUnprefixer(repoId)
+    expect(unprefix(url)).toBe(url)
+  })
+
+  it('pass through when repoId does not match', () => {
+    const url =
+      'http://domain.tld/repo-namespace/some-other-repo/images/asdf.jpg#originalURL=images%2Fasdf.jpg'
+    const unprefix = createRepoUrlUnprefixer(repoId)
+    expect(unprefix(url)).toBe(url)
+  })
 })
 
-test('url prefixing and unprefixing', () => {
-  const url = 'images/asdf.jpg'
-  const prefixUrl = createRepoUrlPrefixer(repo)
-  expect(url).toBe(unprefixUrl(prefixUrl(url)))
-})
+describe('createProxyUrlPrefixer', () => {
+  it('returns proxy url', () => {
+    const url = 'http://random.example.tld/some/random/url'
+    const expectedUrl =
+      'http://domain.tld/proxy?originalURL=http%3A%2F%2Frandom.example.tld%2Fsome%2Frandom%2Furl&mac=71b96262b20ef3f976e16b2029d687b9cc30c434c9864c415ce9b305c8a76a72'
+    const proxy = createProxyUrlPrefixer()
+    expect(proxy(url)).toBe(expectedUrl)
+  })
 
-test('oneway', () => {
-  const url = 'images/asdf.jpg?test=true'
-  const prefixUrl = createRepoUrlPrefixer(repo, true)
-  const newUrl = prefixUrl(url)
-  expect(newUrl).toMatch(url)
-  expect(-1).toBe(newUrl.indexOf('#'))
-  expect(newUrl).toBe(unprefixUrl(newUrl))
-})
+  it('returns proxy url with complex url', () => {
+    const url = 'https://random.example.tld/some/random/url?foo=bar#hans-joerg'
+    const expectedUrl =
+      'http://domain.tld/proxy?originalURL=https%3A%2F%2Frandom.example.tld%2Fsome%2Frandom%2Furl%3Ffoo%3Dbar%23hans-joerg&mac=0644439067949a004bdce732ea566ac3ad987aaf5c05cab794f92fa84c9a7cd3'
+    const proxy = createProxyUrlPrefixer()
+    expect(proxy(url)).toBe(expectedUrl)
+  })
 
-test('originalURL', () => {
-  const url = 'http://host.ch/images/asdf.jpg#originalURL=test'
-  expect(unprefixUrl(url)).toBe('test')
+  it('passes through url if data', () => {
+    const url = 'data:image/png;base64,iVBORw0KGgoAAAANSUxxx'
+    const proxy = createProxyUrlPrefixer()
+    expect(proxy(url)).toBe(url)
+  })
+
+  it('passes through url if proxy', () => {
+    const url = 'http://domain.tld/proxy?originalURL=123&mac=123'
+    const proxy = createProxyUrlPrefixer()
+    expect(proxy(url)).toBe(url)
+  })
+
+  it('passes through url does not start with "http"', () => {
+    const url = 'images/asdf.jpg?test=true'
+    const proxy = createProxyUrlPrefixer()
+    expect(proxy(url)).toBe(url)
+  })
 })

--- a/packages/documents/graphql/resolvers/Document.js
+++ b/packages/documents/graphql/resolvers/Document.js
@@ -5,7 +5,7 @@ const {
   processMembersOnlyZonesInContent,
   processRepoImageUrlsInContent,
   processRepoImageUrlsInMeta,
-  processImageUrlsInContent,
+  processEmbedImageUrlsInContent,
   processEmbedsInContent,
   processNodeModifiersInContent,
 } = require('../../lib/process')
@@ -79,7 +79,7 @@ module.exports = {
       if (shouldDeliverWebP(webp, context.req)) {
         await Promise.all([
           processRepoImageUrlsInContent(doc.content, addWebpSuffix),
-          processImageUrlsInContent(doc.content, addWebpSuffix),
+          processEmbedImageUrlsInContent(doc.content, addWebpSuffix),
         ])
       }
 
@@ -164,7 +164,7 @@ module.exports = {
         if (shouldAddWebpSuffix) {
           await Promise.all([
             processRepoImageUrlsInContent(node, addWebpSuffix),
-            processImageUrlsInContent(node, addWebpSuffix),
+            processEmbedImageUrlsInContent(node, addWebpSuffix),
           ])
         }
 

--- a/packages/documents/graphql/resolvers/Document.js
+++ b/packages/documents/graphql/resolvers/Document.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto')
+const Promise = require('bluebird')
 const { contentUrlResolver, metaUrlResolver } = require('../../lib/resolve')
 const {
   processMembersOnlyZonesInContent,
@@ -56,7 +57,7 @@ module.exports = {
         .join('/')
     )
   },
-  content(doc, { urlPrefix, searchString, webp }, context, info) {
+  async content(doc, { urlPrefix, searchString, webp }, context, info) {
     // we only do auto slugging when in a published documents context
     // - this is easiest detectable by _all being present from documents resolver
     // - alt check info.path for documents / document being the root
@@ -76,8 +77,10 @@ module.exports = {
       )
 
       if (shouldDeliverWebP(webp, context.req)) {
-        processRepoImageUrlsInContent(doc.content, addWebpSuffix)
-        processImageUrlsInContent(doc.content, addWebpSuffix)
+        await Promise.all([
+          processRepoImageUrlsInContent(doc.content, addWebpSuffix),
+          processImageUrlsInContent(doc.content, addWebpSuffix),
+        ])
       }
 
       processMembersOnlyZonesInContent(doc.content, context.user)
@@ -85,7 +88,7 @@ module.exports = {
     }
     return doc.content
   },
-  meta(doc, { urlPrefix, searchString, webp }, context, info) {
+  async meta(doc, { urlPrefix, searchString, webp }, context, info) {
     const meta = getMeta(doc)
     if (doc._all) {
       metaUrlResolver(
@@ -98,7 +101,7 @@ module.exports = {
       )
 
       if (shouldDeliverWebP(webp, context.req)) {
-        processRepoImageUrlsInMeta(doc.content, addWebpSuffix)
+        await processRepoImageUrlsInMeta(doc.content, addWebpSuffix)
       }
     }
     return meta
@@ -157,11 +160,14 @@ module.exports = {
 
       const shouldAddWebpSuffix = shouldDeliverWebP(webp, context.req)
 
-      const idsFromNodes = nodes.map((node) => {
+      const idsFromNodes = await Promise.map(nodes, async (node) => {
         if (shouldAddWebpSuffix) {
-          processRepoImageUrlsInContent(node, addWebpSuffix)
-          processImageUrlsInContent(node, addWebpSuffix)
+          await Promise.all([
+            processRepoImageUrlsInContent(node, addWebpSuffix),
+            processImageUrlsInContent(node, addWebpSuffix),
+          ])
         }
+
         processMembersOnlyZonesInContent(node, context.user)
         processNodeModifiersInContent(node, context.user)
 
@@ -236,9 +242,9 @@ module.exports = {
 
     return getDocuments(doc, args, context, info)
   },
-  embeds(doc, { types = [] }, context, info) {
+  async embeds(doc, { types = [] }, context, info) {
     const embeds = []
-    processEmbedsInContent(doc.content, (embed) => {
+    await processEmbedsInContent(doc.content, (embed) => {
       if (!types.length || types.includes(embed.__typename)) {
         embeds.push(embed)
       }

--- a/packages/documents/lib/process.js
+++ b/packages/documents/lib/process.js
@@ -1,79 +1,113 @@
 const visit = require('unist-util-visit')
+
 const {
   Roles: { userIsInRoles },
 } = require('@orbiting/backend-modules-auth')
+const {
+  imageKeys: embedImageKeys,
+} = require('@orbiting/backend-modules-embeds')
 
 const modifiers = require('./modifiers')
 
 const { DOCUMENTS_RESTRICT_TO_ROLES } = process.env
 
-const processRepoImageUrlsInContent = (mdast, fn) => {
-  visit(mdast, 'image', (node) => {
-    node.url = fn(node.url)
-  })
-  visit(mdast, 'zone', (node) => {
-    if (node.data?.formatLogo) {
-      node.data.formatLogo = fn(node.data.formatLogo)
-    }
-  })
+const processRepoImageUrlsInContent = async (mdast, fn) => {
+  const fns = []
+
+  visit(mdast, 'image', (node) =>
+    fns.push(async () => {
+      node.url = await fn(node.url)
+    }),
+  )
+  visit(mdast, 'zone', (node) =>
+    fns.push(async () => {
+      if (node.data?.formatLogo) {
+        node.data.formatLogo = await fn(node.data.formatLogo)
+      }
+    }),
+  )
+
+  return Promise.all(fns.map((fn) => fn()))
 }
 
-const processRepoImageUrlsInMeta = (mdast, fn) => {
+const processRepoImageUrlsInMeta = async (mdast, fn) => {
+  const fns = []
+
   if (mdast.meta) {
     Object.keys(mdast.meta).forEach((key) => {
       if (key.match(/image/i)) {
-        mdast.meta[key] = fn(mdast.meta[key])
+        fns.push(async () => {
+          mdast.meta[key] = await fn(mdast.meta[key])
+        })
       }
     })
     const series = mdast.meta.series
     if (series && Array.isArray(series.episodes)) {
       if (series.logo) {
-        series.logo = fn(series.logo)
+        fns.push(async () => {
+          series.logo = await fn(series.logo)
+        })
       }
       if (series.logoDark) {
-        series.logoDark = fn(series.logoDark)
+        fns.push(async () => {
+          series.logoDark = await fn(series.logoDark)
+        })
       }
       series.episodes.forEach((episode) => {
         if (episode.image) {
-          episode.image = fn(episode.image)
+          fns.push(async () => {
+            episode.image = await fn(episode.image)
+          })
         }
       })
     }
   }
+
+  return Promise.all(fns.map((fn) => fn()))
 }
 
-const {
-  imageKeys: embedImageKeys,
-} = require('@orbiting/backend-modules-embeds')
+const processImageUrlsInContent = async (mdast, fn) => {
+  const fns = []
 
-const processImageUrlsInContent = (mdast, fn) => {
   visit(mdast, 'zone', (node) => {
     if (node.data && node.identifier.indexOf('EMBED') > -1) {
       for (const key of embedImageKeys) {
         if (node.data[key]) {
-          node.data[key] = fn(node.data[key])
+          fns.push(async () => {
+            node.data[key] = await fn(node.data[key])
+          })
         }
       }
       if (typeof node.data.src === 'object') {
         for (const key of embedImageKeys) {
           if (node.data.src && node.data.src[key]) {
-            node.data.src[key] = fn(node.data.src[key])
+            fns.push(async () => {
+              node.data.src[key] = await fn(node.data.src[key])
+            })
           }
         }
       }
     }
   })
+
+  return Promise.all(fns.map((fn) => fn()))
 }
 
-const processEmbedsInContent = (mdast, fn) => {
+const processEmbedsInContent = async (mdast, fn) => {
+  const fns = []
+
   visit(mdast, 'zone', (node) => {
     if (node.data && node.identifier.indexOf('EMBED') > -1) {
-      const result = fn(node.data)
-      if (result !== undefined) {
-        node.data = result
-      }
+      fns.push(async () => {
+        const result = await fn(node.data)
+        if (result !== undefined) {
+          node.data = result
+        }
+      })
     }
   })
+
+  return Promise.all(fns.map((fn) => fn()))
 }
 
 const processMembersOnlyZonesInContent = (mdast, user) => {

--- a/packages/documents/lib/process.js
+++ b/packages/documents/lib/process.js
@@ -66,7 +66,7 @@ const processRepoImageUrlsInMeta = async (mdast, fn) => {
   return Promise.all(fns.map((fn) => fn()))
 }
 
-const processImageUrlsInContent = async (mdast, fn) => {
+const processEmbedImageUrlsInContent = async (mdast, fn) => {
   const fns = []
 
   visit(mdast, 'zone', (node) => {
@@ -140,7 +140,7 @@ module.exports = {
   processMembersOnlyZonesInContent,
   processRepoImageUrlsInContent,
   processRepoImageUrlsInMeta,
-  processImageUrlsInContent,
+  processEmbedImageUrlsInContent,
   processEmbedsInContent,
   processNodeModifiersInContent,
 }

--- a/packages/embeds/lib/fetchAndStore.js
+++ b/packages/embeds/lib/fetchAndStore.js
@@ -1,8 +1,8 @@
 const moment = require('moment')
 const {
-  createUrlPrefixer,
+  createProxyUrlPrefixer,
 } = require('@orbiting/backend-modules-assets/lib/urlPrefixing')
-const proxyUrl = createUrlPrefixer()
+const proxyUrl = createProxyUrlPrefixer()
 const Redlock = require('redlock')
 const debug = require('debug')('embeds:lib:fetchAndStore')
 const twitter = require('./twitter')

--- a/packages/publikator/graphql/resolvers/Commit.js
+++ b/packages/publikator/graphql/resolvers/Commit.js
@@ -6,7 +6,7 @@ const {
     process: {
       processRepoImageUrlsInContent,
       processRepoImageUrlsInMeta,
-      processImageUrlsInContent,
+      processEmbedImageUrlsInContent,
     },
   },
 } = require('@orbiting/backend-modules-documents')
@@ -50,7 +50,7 @@ module.exports = {
     await Promise.all([
       processRepoImageUrlsInContent(mdast, prefix),
       processRepoImageUrlsInMeta(mdast, prefix),
-      processImageUrlsInContent(mdast, proxy),
+      processEmbedImageUrlsInContent(mdast, proxy),
     ])
 
     return {

--- a/packages/publikator/graphql/resolvers/Commit.js
+++ b/packages/publikator/graphql/resolvers/Commit.js
@@ -1,5 +1,5 @@
 const {
-  lib: { createRepoUrlPrefixer, createUrlPrefixer },
+  lib: { createRepoUrlPrefixer, createProxyUrlPrefixer },
 } = require('@orbiting/backend-modules-assets')
 const {
   lib: {
@@ -44,13 +44,14 @@ module.exports = {
 
     const { mdast } = await context.loaders.Commit.byIdMdast.load(commit.id)
 
-    const prefixRepoUrl = createRepoUrlPrefixer(repoId, publicAssets)
-    processRepoImageUrlsInContent(mdast, prefixRepoUrl)
-    processRepoImageUrlsInMeta(mdast, prefixRepoUrl)
+    const prefix = createRepoUrlPrefixer(repoId, publicAssets)
+    const proxy = createProxyUrlPrefixer()
 
-    // prefix embed image's urls
-    const prefixUrl = createUrlPrefixer(publicAssets)
-    processImageUrlsInContent(mdast, prefixUrl)
+    await Promise.all([
+      processRepoImageUrlsInContent(mdast, prefix),
+      processRepoImageUrlsInMeta(mdast, prefix),
+      processImageUrlsInContent(mdast, proxy),
+    ])
 
     return {
       id: Buffer.from(`repo:${commit.repoId}:${commit.id}`).toString('base64'),

--- a/packages/publikator/graphql/resolvers/_mutations/commit.js
+++ b/packages/publikator/graphql/resolvers/_mutations/commit.js
@@ -1,13 +1,13 @@
 const debug = require('debug')('publikator:mutation:commit')
 const sharp = require('sharp')
-const visit = require('unist-util-visit')
 const dataUriToBuffer = require('data-uri-to-buffer')
 const Promise = require('bluebird')
+const fetch = require('isomorphic-unfetch')
 
 const MDAST = require('@orbiting/remark-preset')
 const {
   lib: {
-    unprefixUrl,
+    createRepoUrlUnprefixer,
     Repo: { maybeUploadImage },
   },
 } = require('@orbiting/backend-modules-assets')
@@ -28,56 +28,57 @@ const {
   },
 } = require('@orbiting/backend-modules-documents')
 
-// const { ASSETS_SERVER_BASE_URL } = process.env
-
 const generateImageData = async (blob) => {
   const meta = await sharp(blob).metadata()
   const suffix = meta.format
   const hash = hashObject(blob)
   const path = `images/${hash}.${suffix}`
-  const imageUrl = `${path}?size=${meta.width}x${meta.height}`
   return {
-    image: {
-      path,
-      hash,
-      blob,
-    },
-    imageUrl,
+    blob,
+    hash,
+    path,
+    meta,
   }
 }
 
-const extractImage = async (url, images) => {
-  if (url) {
-    try {
-      const blob = dataUriToBuffer(url)
-      const { image, imageUrl } = await generateImageData(blob)
-      images.push(image)
-      return imageUrl
-    } catch (e) {
-      debug('ignoring image node with url:' + url)
-    }
+const maybeFetchToBlob = async (url) => {
+  if (!url.match(/^https?:/) || !url.match(/originalURL=/)) {
+    // check if maybe republik URL?
+    return false
   }
-  return url
+
+  return fetch(url)
+    .then((r) => r.buffer())
+    .then(generateImageData)
 }
 
-/* const isFromDifferentRepo = (url, repoId) =>
-  url &&
-  url.startsWith(`${ASSETS_SERVER_BASE_URL}/github/`) &&
-  !url.includes(repoId) */
-
-/* const importFromRepo = async (url, images, repoId) => {
-  if (isFromDifferentRepo(url, repoId)) {
-    try {
-      const blob = await fetch(url).then((result) => result.buffer())
-      const { image, imageUrl } = await generateImageData(blob)
-      images.push(image)
-      return imageUrl
-    } catch (e) {
-      console.warn('failed to transfer image', repoId, url, e)
-    }
+const maybeDataUriToBlob = async (url) => {
+  if (!url.match(/^data:/)) {
+    return false
   }
-  return url
-} */
+
+  return generateImageData(dataUriToBuffer(url))
+}
+
+const createImageUrlHandler = (repoId) => {
+  const unprefix = createRepoUrlUnprefixer(repoId)
+
+  return async (url) => {
+    const unprefixedUrl = unprefix(url)
+
+    const image =
+      (await maybeFetchToBlob(unprefixedUrl)) ||
+      (await maybeDataUriToBlob(unprefixedUrl))
+
+    if (!image) {
+      return unprefixedUrl
+    }
+
+    await maybeUploadImage(repoId, image)
+
+    return `${image.path}?size=${image.meta.width}x${image.meta.height}`
+  }
+}
 
 module.exports = async (_, args, context) => {
   const { user, t, pgdb, pubsub } = context
@@ -114,146 +115,13 @@ module.exports = async (_, args, context) => {
       await tx.publikator.repos.insert({ id: repoId, meta: { isTemplate } })
     }
 
-    // extract repo images
-    const images = []
-    const promises = []
+    const imageUrlHandler = createImageUrlHandler(repoId)
 
-    // @TODO: Import images from another repo (same owner)
-    /* visit(mdast, 'image', async (node) => {
-      promises.push(
-        (async () => {
-          node.url = await importFromRepo(node.url, images, repoId)
-        })(),
-      )
-    })
-    visit(mdast, 'zone', (node) => {
-      if (node.data?.formatLogo) {
-        promises.push(
-          (async () => {
-            node.data.formatLogo = await importFromRepo(
-              node.data.formatLogo,
-              images,
-              repoId,
-            )
-          })(),
-        )
-      }
-    })
-    if (mdast.meta) {
-      promises.push(
-        ...Object.keys(mdast.meta).map(async (key) => {
-          if (key.match(/image/i)) {
-            mdast.meta[key] = await importFromRepo(
-              mdast.meta[key],
-              images,
-              repoId,
-            )
-          }
-        }),
-      )
-
-      const series = mdast.meta.series
-      if (series && Array.isArray(series.episodes)) {
-        if (series.logo) {
-          promises.push(
-            (async () => {
-              series.logo = await importFromRepo(series.logo, images, repoId)
-            })(),
-          )
-        }
-        if (series.logoDark) {
-          promises.push(
-            (async () => {
-              series.logoDark = await importFromRepo(
-                series.logoDark,
-                images,
-                repoId,
-              )
-            })(),
-          )
-        }
-        series.episodes.forEach((episode) => {
-          if (episode.image) {
-            promises.push(
-              (async () => {
-                episode.image = await importFromRepo(
-                  episode.image,
-                  images,
-                  repoId,
-                )
-              })(),
-            )
-          }
-        })
-      }
-    } */
-
-    // reverse asset url prefixing
-    // repo images
-    processRepoImageUrlsInContent(mdast, unprefixUrl)
-    processRepoImageUrlsInMeta(mdast, unprefixUrl)
-    // embeds
-    processImageUrlsInContent(mdast, unprefixUrl)
-
-    visit(mdast, 'image', async (node) => {
-      promises.push(
-        (async () => {
-          node.url = await extractImage(node.url, images)
-        })(),
-      )
-    })
-    visit(mdast, 'zone', (node) => {
-      if (node.data?.formatLogo) {
-        promises.push(
-          (async () => {
-            node.data.formatLogo = await extractImage(
-              node.data.formatLogo,
-              images,
-            )
-          })(),
-        )
-      }
-    })
-
-    if (mdast.meta) {
-      promises.push(
-        ...Object.keys(mdast.meta).map(async (key) => {
-          if (key.match(/image/i)) {
-            mdast.meta[key] = await extractImage(mdast.meta[key], images)
-          }
-        }),
-      )
-
-      const series = mdast.meta.series
-      if (series && Array.isArray(series.episodes)) {
-        if (series.logo) {
-          promises.push(
-            (async () => {
-              series.logo = await extractImage(series.logo, images)
-            })(),
-          )
-        }
-        if (series.logoDark) {
-          promises.push(
-            (async () => {
-              series.logoDark = await extractImage(series.logoDark, images)
-            })(),
-          )
-        }
-        series.episodes.forEach((episode) => {
-          if (episode.image) {
-            promises.push(
-              (async () => {
-                episode.image = await extractImage(episode.image, images)
-              })(),
-            )
-          }
-        })
-      }
-    }
-
-    await Promise.all(promises)
-    await Promise.map(images, (image) => maybeUploadImage(repoId, image))
+    await Promise.all([
+      processRepoImageUrlsInContent(mdast, imageUrlHandler),
+      processRepoImageUrlsInMeta(mdast, imageUrlHandler),
+      processImageUrlsInContent(mdast, imageUrlHandler),
+    ])
 
     mdast.meta = {}
 

--- a/packages/publikator/graphql/resolvers/_mutations/commit.js
+++ b/packages/publikator/graphql/resolvers/_mutations/commit.js
@@ -7,6 +7,9 @@ const fetch = require('isomorphic-unfetch')
 const MDAST = require('@orbiting/remark-preset')
 const {
   lib: {
+    isDataUrl,
+    isHttpUrl,
+    hasOriginalKeyHash,
     createRepoUrlUnprefixer,
     Repo: { maybeUploadImage },
   },
@@ -42,8 +45,7 @@ const generateImageData = async (blob) => {
 }
 
 const maybeFetchToBlob = async (url) => {
-  if (!url.match(/^https?:/) || !url.match(/originalURL=/)) {
-    // check if maybe republik URL?
+  if (!isHttpUrl(url) || !hasOriginalKeyHash(url)) {
     return false
   }
 
@@ -53,7 +55,7 @@ const maybeFetchToBlob = async (url) => {
 }
 
 const maybeDataUriToBlob = async (url) => {
-  if (!url.match(/^data:/)) {
+  if (!isDataUrl(url)) {
     return false
   }
 

--- a/packages/publikator/graphql/resolvers/_mutations/commit.js
+++ b/packages/publikator/graphql/resolvers/_mutations/commit.js
@@ -26,7 +26,7 @@ const {
     process: {
       processRepoImageUrlsInContent,
       processRepoImageUrlsInMeta,
-      processImageUrlsInContent,
+      processEmbedImageUrlsInContent,
     },
   },
 } = require('@orbiting/backend-modules-documents')
@@ -122,7 +122,7 @@ module.exports = async (_, args, context) => {
     await Promise.all([
       processRepoImageUrlsInContent(mdast, imageUrlHandler),
       processRepoImageUrlsInMeta(mdast, imageUrlHandler),
-      processImageUrlsInContent(mdast, imageUrlHandler),
+      processEmbedImageUrlsInContent(mdast, imageUrlHandler),
     ])
 
     mdast.meta = {}


### PR DESCRIPTION
This Pull Request updates url prefixing and mdast node processing.

Mdast node processing becomes asynchrounsly (`packages/documents/lib/process.js`). It allows to fetch and upload images in process section while comitting.

Mdast node processing is now only code aware what nodes to alter and how. This also makes for a more readable `packages/publikator/graphql/resolvers/_mutations/commit.js`.