### PR TITLE
fix(publikator): Disable dataloader cache but keep batching 

### DIFF
--- a/packages/mail/lib/sendMailTemplate.js
+++ b/packages/mail/lib/sendMailTemplate.js
@@ -228,10 +228,15 @@ if (SG_FONT_STYLES) {
 //  fromName: 'Jefferson',
 //  subject: 'dear friend',
 //  templateName: 'MANDRIL TEMPLATE',
-//  globalMergeVars: {
+//  globalMergeVars: [{
 //    name: 'VARNAME',
 //    content: 'replaced with this'
-//  }
+//  }],
+//  attachments: [{
+//    type: 'application/pdf',
+//    name: 'SOMETHING.pdf',
+//    content: '<base64 encoded content>'
+//  }]
 // })
 module.exports = async (mail, context, log) => {
   // sanitize

--- a/packages/publikator/loaders/Commit.ts
+++ b/packages/publikator/loaders/Commit.ts
@@ -84,14 +84,17 @@ export default module.exports = function (context: GraphqlContext) {
   }
 
   return {
-    byId: createDataLoader(async (ids: readonly string[]) => {
-      const commitIds = ids.filter(v4)
-      return (
-        (commitIds.length &&
-          (await commits.find({ id: commitIds }, { fields }))) ||
-        []
-      )
-    }),
+    byId: createDataLoader(
+      async (ids: readonly string[]) => {
+        const commitIds = ids.filter(v4)
+        return (
+          (commitIds.length &&
+            (await commits.find({ id: commitIds }, { fields }))) ||
+          []
+        )
+      }, 
+      { cache: false }
+    ),
     byIdMarkdown: createDataLoader(async (ids: readonly string[]) =>
       getTransformedContentByIds(
         ids,
@@ -101,6 +104,7 @@ export default module.exports = function (context: GraphqlContext) {
         }),
         'markdown',
       ),
+      { cache: false },
     ),
     byIdMdast: createDataLoader(async (ids: readonly string[]) =>
       getTransformedContentByIds(
@@ -111,6 +115,7 @@ export default module.exports = function (context: GraphqlContext) {
         }),
         'mdast',
       ),
+      { cache: false }
     ),
     byRepoId: createDataLoader(
       (ids: readonly string[]) =>
@@ -118,7 +123,7 @@ export default module.exports = function (context: GraphqlContext) {
           { repoId: ids },
           { fields, orderBy: { createdAt: 'desc' } },
         ),
-      null,
+      { cache: false },
       (key, rows) => rows.filter((row) => row.repoId === key),
     ),
     byRepoIdLatest: createDataLoader(
@@ -134,7 +139,7 @@ export default module.exports = function (context: GraphqlContext) {
           `,
           { ids },
         ),
-      null,
+      { cache: false },
       (key, rows) => rows.find((row) => row.repoId === key),
     ),
   }

--- a/packages/publikator/loaders/Milestone.ts
+++ b/packages/publikator/loaders/Milestone.ts
@@ -5,7 +5,7 @@ import { GraphqlContext } from '@orbiting/backend-modules-types'
 
 interface Milestone {
   id: string
-  scope: 'publication' | 'prepublication' | 'milestone'
+  scope: MilestoneScope
   repoId: string
   commitId: string
   name: string
@@ -18,6 +18,8 @@ interface Milestone {
   revokedAt?: Date
 }
 
+type MilestoneScope = 'publication' | 'prepublication' | 'milestone'
+
 interface MilestoneAuthor {
   name: string
   email: string
@@ -29,7 +31,7 @@ export default module.exports = function (context: GraphqlContext) {
     byRepoId: createDataLoader(
       (ids: readonly string[]) =>
         milestones.find({ repoId: ids }, { orderBy: { createdAt: 'asc' } }),
-      null,
+      { cache: false },
       (key, rows) => rows.filter((row) => row.repoId === key),
     ),
     Publication: {
@@ -43,7 +45,7 @@ export default module.exports = function (context: GraphqlContext) {
             },
             { orderBy: { createdAt: 'asc' } },
           ),
-        null,
+        { cache: false },
         (key, rows) => rows.filter((row) => row.repoId === key),
       ),
     },

--- a/packages/publikator/loaders/Repo.ts
+++ b/packages/publikator/loaders/Repo.ts
@@ -15,8 +15,10 @@ interface Repo {
 export default module.exports = function (context: GraphqlContext) {
   const repos: PgTable<Repo> = context.pgdb.publikator.repos
   return {
-    byId: createDataLoader(function (ids: readonly string[]) {
-      return repos.find({ id: ids }, { orderBy: { updatedAt: 'desc' } })
-    }),
+    byId: createDataLoader(
+      (ids: readonly string[]) =>
+        repos.find({ id: ids }, { orderBy: { updatedAt: 'desc' } }),
+      { cache: false },
+    ),
   }
 }


### PR DESCRIPTION
Subscriptions do not pair well with dataloaders. A dataloader is instantiated on subscribe event and kept until subscribtion ends – including in-memory response cache.

While regular request complete in a bearable amount of time, subscription may last for hours and hence an in-memory cache.

As a trade-off solution, this commit disables cache for dataloaders in publikator/loaders (but keeps batching functionality).