### PR TITLE
Improve search ranking

### DIFF
--- a/packages/publikator/lib/Document.js
+++ b/packages/publikator/lib/Document.js
@@ -153,11 +153,16 @@ const prepareMetaForPublish = async ({
   // and not having to touch the series key
   let seriesEpisodes
   if (typeof docMeta.series === 'object') {
-    seriesEpisodes = docMeta.series.episodes.map((e) => {
-      if (e.publishDate === '') {
-        e.publishDate = null
-      }
-    })
+    seriesEpisodes = {
+      title: docMeta.series.title,
+      episodes: docMeta.series.episodes.map((episode) => {
+        if (episode.publishDate === '') {
+          episode.publishDate = null
+        }
+
+        return episode
+      }),
+    }
   }
 
   // transform docMeta

--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -111,7 +111,6 @@ const createShould = function (
           query: getSimpleQueryStringQuery(searchTerm),
           fields,
           default_operator: 'AND',
-          analyzer: 'german',
         },
       }
 

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -38,40 +38,30 @@ module.exports = {
   search: {
     termFields: {
       'meta.title': {
-        boost: 2,
         highlight: {
           number_of_fragments: 0,
         },
       },
       'meta.shortTitle': {
-        boost: 2,
         highlight: {
           number_of_fragments: 0,
         },
       },
+      'resolved.meta.dossier.meta.title': {},
+      'resolved.meta.format.meta.title': {},
+      'resolved.meta.section.meta.title': {},
+      'meta.seriesEpisodes.title': {},
       'meta.description': {
-        boost: 2,
         highlight: {
           number_of_fragments: 0,
         },
       },
-      'meta.creditsString': {
-        boost: 3,
-      },
+      'meta.creditsString': { boost: 2 },
       contentString: {
         highlight: {
           boundary_scanner_locale: 'de-CH',
           fragment_size: 300,
         },
-      },
-      'resolved.meta.dossier.meta.title': {
-        boost: 3,
-      },
-      'resolved.meta.format.meta.title': {
-        boost: 3,
-      },
-      'resolved.meta.section.meta.title': {
-        boost: 3,
       },
     },
     functionScore: (query) => ({

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -202,6 +202,19 @@ module.exports = {
         filter: ['german_normalization', 'lowercase', 'asciifolding'],
       },
     },
+    filter: {
+      german_stemmer: {
+        type: 'stemmer',
+        language: 'light_german',
+      },
+    },
+    analyzer: {
+      german_with_stopwords: {
+        // @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/analysis-lang-analyzer.html#german-analyzer
+        tokenizer: 'standard',
+        filter: ['lowercase', 'german_normalization', 'german_stemmer'],
+      },
+    },
   },
   mapping: {
     [type]: {
@@ -237,14 +250,7 @@ module.exports = {
                       properties: {
                         title: {
                           type: 'text',
-                          analyzer: 'german',
-                          fields: {
-                            keyword: {
-                              type: 'keyword',
-                              normalizer: 'republik_strict',
-                              ignore_above: 256,
-                            },
-                          },
+                          analyzer: 'german_with_stopwords',
                         },
                         description: {
                           type: 'text',
@@ -266,14 +272,7 @@ module.exports = {
                       properties: {
                         title: {
                           type: 'text',
-                          analyzer: 'german',
-                          fields: {
-                            keyword: {
-                              type: 'keyword',
-                              normalizer: 'republik_strict',
-                              ignore_above: 256,
-                            },
-                          },
+                          analyzer: 'german_with_stopwords',
                         },
                         description: {
                           type: 'text',
@@ -295,14 +294,7 @@ module.exports = {
                       properties: {
                         title: {
                           type: 'text',
-                          analyzer: 'german',
-                          fields: {
-                            keyword: {
-                              type: 'keyword',
-                              normalizer: 'republik_strict',
-                              ignore_above: 256,
-                            },
-                          },
+                          analyzer: 'german_with_stopwords',
                         },
                         description: {
                           type: 'text',
@@ -339,10 +331,6 @@ module.exports = {
               analyzer: 'standard',
               store: true,
             },
-            keyword: {
-              type: 'keyword',
-              ignore_above: 256,
-            },
           },
         },
         content: {
@@ -358,11 +346,11 @@ module.exports = {
             },
             title: {
               type: 'text',
-              analyzer: 'german',
+              analyzer: 'german_with_stopwords',
             },
             shortTitle: {
               type: 'text',
-              analyzer: 'german',
+              analyzer: 'german_with_stopwords',
             },
             description: {
               type: 'text',
@@ -383,7 +371,6 @@ module.exports = {
             slug: {
               type: 'text',
               ...keywordPartial,
-              analyzer: 'german',
             },
             path: {
               type: 'text',
@@ -394,15 +381,15 @@ module.exports = {
             },
             creditsString: {
               type: 'text',
-              analyzer: 'german',
+              analyzer: 'german_with_stopwords',
             },
             credits: {
               ...mdastPartial,
             },
             authors: {
               type: 'text',
+              analyzer: 'german_with_stopwords',
               ...keywordPartial,
-              analyzer: 'german',
             },
             dossier: {
               type: 'keyword',
@@ -441,20 +428,20 @@ module.exports = {
                     },
                     label: {
                       type: 'text',
-                      ...keywordPartial,
+                      analyzer: 'german_with_stopwords',
                     },
                     publishDate: {
                       type: 'date',
                     },
                     title: {
                       type: 'text',
-                      ...keywordPartial,
+                      analyzer: 'german_with_stopwords',
                     },
                   },
                 },
                 title: {
                   type: 'text',
-                  ...keywordPartial,
+                  analyzer: 'german_with_stopwords',
                 },
               },
             },

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -1,8 +1,3 @@
-const {
-  meta: { getWordsPerMinute },
-} = require('@orbiting/backend-modules-documents/lib')
-const { MIDDLE_DURATION_MINS } = require('../Documents')
-
 const keywordPartial = {
   fields: {
     keyword: {
@@ -77,38 +72,13 @@ module.exports = {
           weight: 2,
         },
         {
-          filter: {
-            match: {
-              'meta.isSeriesMaster': true,
+          // decay, via "scale" reducing relative "weight" from 1 to 0.5
+          linear: {
+            '__sort.date': {
+              offset: '90d',
+              scale: '275d',
             },
           },
-          weight: 20,
-        },
-        {
-          filter: {
-            match: {
-              'meta.isSeriesEpisode': true,
-            },
-          },
-          weight: 10,
-        },
-        {
-          filter: {
-            range: {
-              'contentString.count': {
-                gte: getWordsPerMinute() * MIDDLE_DURATION_MINS,
-              },
-            },
-          },
-          weight: 5,
-        },
-        {
-          filter: {
-            match: {
-              'meta.template': 'editorialNewsletter',
-            },
-          },
-          weight: 0.1,
         },
       ],
     }),

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -196,12 +196,6 @@ module.exports = {
     },
   },
   analysis: {
-    normalizer: {
-      republik_strict: {
-        type: 'custom',
-        filter: ['german_normalization', 'lowercase', 'asciifolding'],
-      },
-    },
     filter: {
       german_stemmer: {
         type: 'stemmer',

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -68,12 +68,13 @@ module.exports = {
       query,
       functions: [
         {
+          // push primary templates
           filter: {
             terms: {
-              'meta.template': ['format', 'section', 'dossier', 'page'],
+              'meta.template': ['article', 'format', 'dossier'],
             },
           },
-          weight: 20,
+          weight: 2,
         },
         {
           filter: {


### PR DESCRIPTION
This is a non-breaking change.

- Refrain from boosting whenever possible.
- Indexes headlines (title, short title and similar) with stopwords.
- Series or long-reads won't over-power results anymore.
- Instead of demoting newsletter we boost "primary" templates: articles, formats and dossier.
- Includes series title in fields searched

Fixes https://github.com/orbiting/backends/issues/492