### PR TITLE
simplify discussion path logic and resolve actual path in graphql

### DIFF
--- a/packages/discussions/graphql/resolvers/Discussion/path.js
+++ b/packages/discussions/graphql/resolvers/Discussion/path.js
@@ -1,0 +1,3 @@
+const { getDiscussionPath } = require('../../../lib/Notifications')
+
+module.exports = getDiscussionPath

--- a/packages/discussions/lib/Notifications.js
+++ b/packages/discussions/lib/Notifications.js
@@ -33,7 +33,11 @@ const getDiscussionPath = (discussion) => {
   //   in that case we don't want to rewrite the path
   // - in all other cases, mainly template article,
   //   we rewrite to /dialog with the discussion id
-  if (discussion.repoId && !discussion.path.match(/\/diskussion$/) && discussion.path.match(/^\/[0-9]{4}\/[0-9]{2}\/[0-9]{2}\//)) {
+  if (
+    discussion.repoId &&
+    !discussion.path.match(/\/diskussion$/) &&
+    discussion.path.match(/^\/[0-9]{4}\/[0-9]{2}\/[0-9]{2}\//)
+  ) {
     return `/dialog?t=article&id=${discussion.id}`
   }
   return discussion.path

--- a/packages/discussions/lib/Notifications.js
+++ b/packages/discussions/lib/Notifications.js
@@ -33,7 +33,7 @@ const getDiscussionPath = (discussion) => {
   //   in that case we don't want to rewrite the path
   // - in all other cases, mainly template article,
   //   we rewrite to /dialog with the discussion id
-  if (discussion.repoId && !discussion.path.match(/\/diskussion$/)) {
+  if (discussion.repoId && !discussion.path.match(/\/diskussion$/) && discussion.path.match(/^\/[0-9]{4}\/[0-9]{2}\/[0-9]{2}\//)) {
     return `/dialog?t=article&id=${discussion.id}`
   }
   return discussion.path

--- a/packages/discussions/lib/slack.js
+++ b/packages/discussions/lib/slack.js
@@ -19,7 +19,7 @@ if (!FRONTEND_BASE_URL) {
 }
 
 const getCommentLink = async (comment, discussion, context) => {
-  const discussionUrl = await getDiscussionUrl(discussion, context)
+  const discussionUrl = getDiscussionUrl(discussion)
   return `${discussionUrl}${
     discussionUrl.indexOf('?') === -1 ? '?' : '&'
   }focus=${comment.id}`


### PR DESCRIPTION
SQL Update Needed:
```
UPDATE "public"."discussions" SET "path"='/dialog?t=general' WHERE "id"='ec6ba678-8eb2-45e0-97fa-20d3a4d58b64';
```

Changes
- move general path to DB
- simplify logic and make it more performant, no more document loading
- resolve `Discussion.path` to the actual frontend path used

<img width="1209" alt="Screenshot 2021-05-04 at 14 42 04" src="https://user-images.githubusercontent.com/410211/117004904-ec30aa80-ace6-11eb-884d-ae12889d0294.png">
