### PR TITLE
fix(republik-crowdfundings): Ensure toCents returns an integer value

### DIFF
--- a/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
+++ b/packages/republik-crowdfundings/lib/scheduler/payments/parseCamt053.ts
@@ -309,7 +309,7 @@ function isDebitCardPayment(creditEntry: CreditEntry) {
 function toCents(s: Amount): AmountInCents {
   const n = parseFloat(s)
   if (isNaN(n)) throw new Error(`Amount is not a number: ${n}`)
-  return (n * 100) as AmountInCents
+  return Math.round(n * 100) as AmountInCents
 }
 
 function matchDebitor(


### PR DESCRIPTION
Co-authored-by: Sharon Funke <fuenkchen@users.noreply.github.com>

Fixes

```
importPayments(): postfinance sync failed with the following error:
invalid input syntax for type integer: "7040.000000000001"
```