### PR TITLE
fix(statistics): Favor relative date over date range or absolute date

### DIFF
--- a/packages/statistics/script/matomo/index.js
+++ b/packages/statistics/script/matomo/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 require('@orbiting/backend-modules-env').config()
 
-const debug = require('debug')('statistics:script:determineIndex')
+const debug = require('debug')('statistics:script:matomo:index')
 const moment = require('moment')
 const yargs = require('yargs')
 


### PR DESCRIPTION
[yargs breaking change](https://github.com/yargs/yargs/blob/master/CHANGELOG.md#1700-2021-05-02) applies coerce before validation, thus all date fields are set.

Fix favors relative date over range or absolut date. If not set, relative date is falsy.