### PR TITLE
changes to MailchimpInterface

### DIFF
--- a/packages/mail/MailchimpInterface.js
+++ b/packages/mail/MailchimpInterface.js
@@ -91,6 +91,14 @@ const MailchimpInterface = ({ logger }) => {
         throw new NewsletterMemberMailError({ error, email })
       }
     },
+    /* 
+    MailChimp differs between archiving and permanently deleting members
+    For further reference see API docs: 
+      - archiving: https://mailchimp.com/developer/marketing/api/list-members/archive-list-member/
+      - deleting: https://mailchimp.com/developer/marketing/api/list-members/delete-list-member/
+    And more information about the differences of unsubscribe, archive and delete:
+    https://www.chimpanswers.com/cleaning-your-mailchimp-audience/
+    */
     async archiveMember(email) {
       debug(`archiving ${email}`)
       const url = this.buildMembersApiUrl(email)

--- a/packages/mail/MailchimpInterface.js
+++ b/packages/mail/MailchimpInterface.js
@@ -91,10 +91,26 @@ const MailchimpInterface = ({ logger }) => {
         throw new NewsletterMemberMailError({ error, email })
       }
     },
-    async deleteMember(email) {
+    async archiveMember(email) {
+      debug(`archiving ${email}`)
       const url = this.buildMembersApiUrl(email)
       try {
         const response = await this.fetchAuthenticated('DELETE', url)
+        if (response.status >= MINIMUM_HTTP_RESPONSE_STATUS_ERROR) {
+          debug(`could not delete member: ${email}`)
+          return null
+        }
+        return true
+      } catch (error) {
+        logger.error(`mailchimp -> exception: ${error.message}`)
+        throw new NewsletterMemberMailError({ error, email })
+      }
+    },
+    async deleteMember(email) {
+      debug(`deleting ${email}`)
+      const url = this.buildMembersApiUrl(email) + '/actions/delete-permanent'
+      try {
+        const response = await this.fetchAuthenticated('POST', url)
         if (response.status >= MINIMUM_HTTP_RESPONSE_STATUS_ERROR) {
           debug(`could not delete member: ${email}`)
           return null

--- a/packages/mail/lib/moveNewsletterSubscriptions.js
+++ b/packages/mail/lib/moveNewsletterSubscriptions.js
@@ -10,17 +10,14 @@ module.exports = async ({ user, newEmail }) => {
 
   const mailchimp = MailchimpInterface({ logger })
   const member = await mailchimp.getMember(oldEmail)
-  if (
-    member &&
-    member.status !== MailchimpInterface.MemberStatus.Unsubscribed
-  ) {
+  if (member) {
     // archive oldEmail
     await mailchimp.archiveMember(oldEmail)
-    // subscribe newEmail
+    // subscribe newEmail with old member status and interests
     await mailchimp.updateMember(newEmail, {
       email_address: newEmail,
-      status_if_new: MailchimpInterface.MemberStatus.Subscribed,
-      status: MailchimpInterface.MemberStatus.Subscribed,
+      status_if_new: member.status,
+      status: member.status,
       interests: member.interests,
     })
     return true

--- a/packages/mail/lib/moveNewsletterSubscriptions.js
+++ b/packages/mail/lib/moveNewsletterSubscriptions.js
@@ -14,11 +14,8 @@ module.exports = async ({ user, newEmail }) => {
     member &&
     member.status !== MailchimpInterface.MemberStatus.Unsubscribed
   ) {
-    // unsubscribe oldEmail
-    await mailchimp.updateMember(oldEmail, {
-      email_address: oldEmail,
-      status: MailchimpInterface.MemberStatus.Unsubscribed,
-    })
+    // archive oldEmail
+    await mailchimp.archiveMember(oldEmail)
     // subscribe newEmail
     await mailchimp.updateMember(newEmail, {
       email_address: newEmail,


### PR DESCRIPTION
solves #276

Changes are as follows and can be tested on love
- added new method to MailchimpInterface to permanently delete member in Mailchimp
- if a user is deleted, the corresponding email address will be deleted (instead of archived) in Mailchimp
- if two users are merged, the old email address will be archived (instead of unsubscribed) in Mailchimp
- if the email address of a user is changed, the old email address will be archived (instead of unsubscribed) in Mailchimp