### PR TITLE
Add perk to share access with debater role

### DIFF
--- a/packages/access/lib/grants.js
+++ b/packages/access/lib/grants.js
@@ -190,9 +190,16 @@ const claim = async (voucherCode, payload, user, t, pgdb, redis, mail) => {
     })
   }
 
+  const hasAddedMemberRole = await membershipsLib.addMemberRole(
+    grant,
+    recipient,
+    pgdb,
+  )
+
   const subscribeToEditorialNewsletters =
+    campaign.config?.subscribeToEditorialNewsletters ||
     perks.some(({ settings }) => !!settings.subscribeToEditorialNewsletters) ||
-    (await membershipsLib.addMemberRole(grant, recipient, pgdb))
+    hasAddedMemberRole
 
   await mail.enforceSubscriptions({
     userId: recipient.id,
@@ -310,10 +317,16 @@ const request = async (granter, campaignId, payload, t, pgdb, redis, mail) => {
       eventsLib.log(grant, `perk.${name}`, pgdb)
     })
   }
+  const hasAddedMemberRole = await membershipsLib.addMemberRole(
+    grant,
+    granter,
+    pgdb,
+  )
 
   const subscribeToEditorialNewsletters =
+    campaign.config?.subscribeToEditorialNewsletters ||
     perks.some(({ settings }) => !!settings.subscribeToEditorialNewsletters) ||
-    (await membershipsLib.addMemberRole(grant, granter, pgdb))
+    hasAddedMemberRole
 
   await mail.enforceSubscriptions({
     userId: grant.granter.id,

--- a/packages/access/lib/grants.js
+++ b/packages/access/lib/grants.js
@@ -63,7 +63,7 @@ const grantPerks = async (grant, recipient, campaign, t, pgdb, redis, mail) =>
       }
 
       const settings = perk[name]
-      const result = await perks[name].give(
+      const { eventLogExtend, ...result } = await perks[name].give(
         campaign,
         grant,
         recipient,
@@ -80,8 +80,7 @@ const grantPerks = async (grant, recipient, campaign, t, pgdb, redis, mail) =>
         recipient: recipient.id,
         settings,
       })
-
-      return { name, settings, result }
+      return { name, settings, eventLogExtend, result }
     },
     { concurrency: 1 },
   )
@@ -311,10 +310,12 @@ const request = async (granter, campaignId, payload, t, pgdb, redis, mail) => {
     grant.perks = {}
 
     await Promise.map(perks, (perk) => {
-      const { name, ...other } = perk
+      const { name, eventLogExtend, ...other } = perk
       grant.perks[perk.name] = other
 
-      eventsLib.log(grant, `perk.${name}`, pgdb)
+      const event = `perk.${name}${eventLogExtend || ''}`
+
+      eventsLib.log(grant, event, pgdb)
     })
   }
   const hasAddedMemberRole = await membershipsLib.addMemberRole(

--- a/packages/access/lib/memberships.js
+++ b/packages/access/lib/memberships.js
@@ -27,7 +27,7 @@ const addMemberRole = async (grant, user, pgdb) => {
   if (!hasMembership) {
     return await addRole(grant, user, pgdb, 'member')
   } else {
-    await eventsLib.log(grant, 'user.active.membership', pgdb)
+    await eventsLib.log(grant, 'recipient.active.membership', pgdb)
   }
 
   return false

--- a/packages/access/lib/memberships.js
+++ b/packages/access/lib/memberships.js
@@ -52,6 +52,22 @@ const removeMemberRole = async (grant, user, findFn, pgdb) => {
   return false
 }
 
+const addRole = async (grant, user, pgdb, role) => {
+  debug(`add ${role} role`, { grant: grant.id, user: user.id })
+
+  if (!Roles.userHasRole(user, role)) {
+    await Roles.addUserToRole(user.id, role, pgdb)
+    await eventsLib.log(grant, `role.${role}.add`, pgdb)
+
+    debug(`role "${role}" was missing, added`, user.id)
+
+    return true
+  } else {
+    await eventsLib.log(grant, `role.${role}.present`, pgdb)
+  }
+  return false
+}
+
 const findGiftableMemberships = async (pgdb) =>
   pgdb.query(`
     SELECT
@@ -75,5 +91,6 @@ const findGiftableMemberships = async (pgdb) =>
 module.exports = {
   addMemberRole,
   removeMemberRole,
+  addRole,
   findGiftableMemberships,
 }

--- a/packages/access/lib/memberships.js
+++ b/packages/access/lib/memberships.js
@@ -5,20 +5,29 @@ const { hasUserActiveMembership } = require('@orbiting/backend-modules-utils')
 
 const eventsLib = require('./events')
 
-const addMemberRole = async (grant, user, pgdb) => {
-  debug('addMemberRole', { grant: grant.id, user: user.id })
+const addRole = async (grant, user, pgdb, role) => {
+  debug(`add ${role} role`, { grant: grant.id, user: user.id })
 
-  const hasMembership = await hasUserActiveMembership(user, pgdb)
+  if (!Roles.userHasRole(user, role)) {
+    await Roles.addUserToRole(user.id, role, pgdb)
+    await eventsLib.log(grant, `role.${role}.add`, pgdb)
 
-  if (!hasMembership && !Roles.userHasRole(user, 'member')) {
-    await Roles.addUserToRole(user.id, 'member', pgdb)
-    await eventsLib.log(grant, 'role.add', pgdb)
-
-    debug('role "member" was missing, added', user.id)
+    debug(`role "${role}" was missing, added`, user.id)
 
     return true
   } else {
-    await eventsLib.log(grant, 'role.present', pgdb)
+    await eventsLib.log(grant, `role.${role}.present`, pgdb)
+  }
+  return false
+}
+
+const addMemberRole = async (grant, user, pgdb) => {
+  const hasMembership = await hasUserActiveMembership(user, pgdb)
+
+  if (!hasMembership) {
+    return await addRole(grant, user, pgdb, 'member')
+  } else {
+    await eventsLib.log(grant, 'user.active.membership', pgdb)
   }
 
   return false
@@ -40,31 +49,15 @@ const removeMemberRole = async (grant, user, findFn, pgdb) => {
     Roles.userHasRole(user, 'member')
   ) {
     await Roles.removeUserFromRole(user.id, 'member', pgdb)
-    await eventsLib.log(grant, 'role.remove', pgdb)
+    await eventsLib.log(grant, 'role.member.remove', pgdb)
 
     debug('role "member" unwarranted, removing', user.id)
 
     return true
   } else {
-    await eventsLib.log(grant, 'role.keep', pgdb)
+    await eventsLib.log(grant, 'role.member.keep', pgdb)
   }
 
-  return false
-}
-
-const addRole = async (grant, user, pgdb, role) => {
-  debug(`add ${role} role`, { grant: grant.id, user: user.id })
-
-  if (!Roles.userHasRole(user, role)) {
-    await Roles.addUserToRole(user.id, role, pgdb)
-    await eventsLib.log(grant, `role.${role}.add`, pgdb)
-
-    debug(`role "${role}" was missing, added`, user.id)
-
-    return true
-  } else {
-    await eventsLib.log(grant, `role.${role}.present`, pgdb)
-  }
   return false
 }
 

--- a/packages/access/lib/perks/accessWithRole.js
+++ b/packages/access/lib/perks/accessWithRole.js
@@ -1,24 +1,12 @@
 const debug = require('debug')('access:lib:perks:accessWithRole')
 
-const { hasUserActiveMembership } = require('@orbiting/backend-modules-utils')
 const { addRole } = require('../memberships')
 
 const give = async (campaign, grant, recipient, settings, t, pgdb) => {
   if (grant.revokedAt) {
-    throw new Error(t('api/access/perk/giftMembership/grantRevoked/error'))
+    throw new Error(t('api/access/perk/accessWithRole/grantRevoked/error'))
   }
 
-  if (grant.granter.id === recipient.id) {
-    throw new Error(t('api/access/perk/giftMembership/selfClaim/error'))
-  }
-
-  const hasActiveMembership = await hasUserActiveMembership(recipient, pgdb)
-
-  if (hasActiveMembership) {
-    throw new Error(
-      t('api/access/perk/giftMembership/hasActiveMembership/error'),
-    )
-  }
   const isRoleAdded = await addRole(grant, recipient, pgdb, settings.role)
 
   if (isRoleAdded) {
@@ -29,6 +17,7 @@ const give = async (campaign, grant, recipient, settings, t, pgdb) => {
     return {
       recipient: recipient.id,
       addedRole: settings.role,
+      eventLogExtend: `.${settings.role}`,
     }
   }
 

--- a/packages/access/lib/perks/accessWithRole.js
+++ b/packages/access/lib/perks/accessWithRole.js
@@ -1,0 +1,38 @@
+const debug = require('debug')('access:lib:perks:accessWithRole')
+
+const { hasUserActiveMembership } = require('@orbiting/backend-modules-utils')
+const { addRole } = require('../memberships')
+
+const give = async (campaign, grant, recipient, settings, t, pgdb) => {
+  if (grant.revokedAt) {
+    throw new Error(t('api/access/perk/giftMembership/grantRevoked/error'))
+  }
+
+  if (grant.granter.id === recipient.id) {
+    throw new Error(t('api/access/perk/giftMembership/selfClaim/error'))
+  }
+
+  const hasActiveMembership = await hasUserActiveMembership(recipient, pgdb)
+
+  if (hasActiveMembership) {
+    throw new Error(
+      t('api/access/perk/giftMembership/hasActiveMembership/error'),
+    )
+  }
+  const isRoleAdded = await addRole(grant, recipient, pgdb, settings.role)
+
+  if (isRoleAdded) {
+    debug('give', {
+      recipient: recipient.id,
+      addedRole: settings.role,
+    })
+    return {
+      recipient: recipient.id,
+      addedRole: settings.role,
+    }
+  }
+
+  return {}
+}
+
+module.exports = { give }

--- a/packages/access/lib/perks/index.js
+++ b/packages/access/lib/perks/index.js
@@ -1,3 +1,4 @@
 module.exports = {
   giftMembership: require('./giftMembership'),
+  accessWithRole: require('./accessWithRole'),
 }

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1199,6 +1199,10 @@
       "value": "Sie können diese Mitgliedschaft nicht auf Ihr eigenes Konto einlösen."
     },
     {
+      "key": "api/access/perk/accessWithRole/grantRevoked/error",
+      "value": "Ihr Gutscheincode ist leider ungültig. Da hat sich vielleicht ein Vertipper eingeschlichen, oder der Gutscheincode ist bereits abgelaufen."
+    },
+    {
       "key": "api/access/resolvers/AccessGrant/status/invalidated",
       "value": "nicht mehr gültig"
     },


### PR DESCRIPTION
Can be tested on love
* for editors, supporters and admins a new access campaign should appear at `/teilen``
* after granting access recipient should receive invitation mail, after claiming access, granter should receive confirmation mail
* the role `debater` should be added to recipient

When deploying we need to execute the an SQL statement to add suitable access campaign, can be reviewed as well :)
```
INSERT INTO "accessCampaigns"("title","description","grantPeriodInterval","emailFollowup","beginAt","endAt","constraints","createdAt","updatedAt","grantClaimableInterval","config")
VALUES
('Autorinnen im Dialog 🦄','Abonnement teilen, um externen Autoren einen 21-tägigen Zugriff und die Möglichkeit zu geben, aktiv am Dialog teilzunehmen.','21 days','7 days','2021-06-28 08:30:00+00','2050-01-01 00:00:00+00','[{"limitSlots": {"slots": 100}}, {"limitRevokedSlots": {"slots": 100}}, {"recipientInNoSlot": {}}, {"requireRole": {"roles": ["editor", "supporter", "admin"]}}]',now(),now(),'30 days','{"perks": [{"accessWithRole": {"role": "debater"}}], "emails": [{"party": "recipient", "enabled": true, "template": "invitation"}, {"party": "granter", "enabled": true, "template": "claim_notice"}, {"party": "recipient", "enabled": false, "template": "onboarding"}, {"party": "recipient", "enabled": false, "template": "expired"}, {"party": "recipient", "enabled": false, "template": "followup"}]}');
```