### PR TITLE
ElasticSearch 7 compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,11 @@ version: '3.4'
 services:
   elastic:
     # in order to get elastic to work, see https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.10
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
     container_name: elasticsearch
     environment:
       - cluster.routing.allocation.disk.threshold_enabled=false
       - 'ES_JAVA_OPTS=-Xms1024m -Xmx1024m'
-      - xpack.graph.enabled=false
-      - xpack.ml.enabled=false
-      - xpack.monitoring.enabled=false
-      - xpack.security.enabled=false
-      - xpack.watcher.enabled=false
       - ELASTIC_PASSWORD=elastic
       - 'discovery.type=single-node'
       - TAKE_FILE_OWNERSHIP=true
@@ -25,7 +20,7 @@ services:
       - 9200:9200
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:6.8.10
+    image: docker.elastic.co/kibana/kibana-oss:7.10.2
     container_name: kibana
     ports:
       - 5601:5601

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - ./docker-data/redis:/data:delegated
 
   postgres:
-    image: postgres:12.4
+    image: postgres:12.7
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:

--- a/packages/base/lib/Elasticsearch.js
+++ b/packages/base/lib/Elasticsearch.js
@@ -3,7 +3,6 @@ const { Client } = require('@elastic/elasticsearch')
 const connect = () =>
   new Client({
     node: process.env.ELASTIC_URL || 'http://elastic:elastic@localhost:9200',
-    apiVersion: '6.8',
   })
 
 const disconnect = (client) => client.close()

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -20,7 +20,7 @@
     "link": "yarn link"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^6.8.7",
+    "@elastic/elasticsearch": "^7.13.0",
     "apollo-modules-node": "^0.1.4",
     "apollo-server": "^2.15.1",
     "apollo-server-core": "^2.15.1",

--- a/packages/publikator/graphql/resolvers/_queries/reposSearch.js
+++ b/packages/publikator/graphql/resolvers/_queries/reposSearch.js
@@ -61,12 +61,13 @@ module.exports = async (__, args, context) => {
     context,
   )
 
-  const hasNextPage = first > 0 && body.hits.total > from + first
-  const hasPreviousPage = from > 0
-
   const {
-    hits: { hits },
+    hits: { total, hits },
   } = body
+  const totalCount = Number.isFinite(total?.value) ? total.value : total
+
+  const hasNextPage = first > 0 && totalCount > from + first
+  const hasPreviousPage = from > 0
 
   const repos = hits.length
     ? await context.pgdb.publikator.repos.find({ id: hits.map((n) => n._id) })
@@ -75,7 +76,7 @@ module.exports = async (__, args, context) => {
   const data = {
     nodes: repos,
     aggregations: body.aggregations,
-    totalCount: body.hits.total,
+    totalCount,
     pageInfo: {
       hasNextPage,
       endCursor: hasNextPage

--- a/packages/publikator/lib/cache/search.ts
+++ b/packages/publikator/lib/cache/search.ts
@@ -115,6 +115,7 @@ const find = async (args: any, { elastic }: GraphqlContext) => {
     index: utils.getIndexAlias('repo', 'read'),
     from: args.from,
     size: args.first,
+    track_total_hits: true,
     body: {
       ...getSort(args),
       ...getSourceFilter(),

--- a/packages/publikator/lib/cache/search.ts
+++ b/packages/publikator/lib/cache/search.ts
@@ -37,7 +37,7 @@ const getSort = (args: any) => {
 
 const getSourceFilter = () => ({
   _source: {
-    exclude: ['*'],
+    excludes: ['*'],
   },
 })
 

--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -432,6 +432,7 @@ const search = async (__, args, context, info) => {
     index: indicesList.map(({ name }) => getIndexAlias(name, 'read')),
     from,
     size: first,
+    track_total_hits: true,
     body: createQuery(
       search,
       filter,

--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -455,13 +455,16 @@ const search = async (__, args, context, info) => {
     cache.set(query, result, options)
   }
 
-  const hasNextPage = first > 0 && result.hits.total > from + first
+  const { total } = result.hits
+  const totalCount = Number.isFinite(total?.value) ? total.value : total
+
+  const hasNextPage = first > 0 && totalCount > from + first
   const hasPreviousPage = from > 0
 
   const response = {
     nodes: result.hits.hits.map(mapHit),
     aggregations: mapAggregations(result, t),
-    totalCount: result.hits.total,
+    totalCount,
     pageInfo: {
       hasNextPage,
       endCursor: hasNextPage
@@ -503,7 +506,7 @@ const search = async (__, args, context, info) => {
 
   if (!recursive && SEARCH_TRACK) {
     const took = cacheHIT ? 0 : result.took
-    const total = result.hits.total
+    const total = totalCount
     const hits = result.hits.hits.map((hit) => _.omit(hit, '_source'))
     const aggs = result.aggregations
 

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -723,9 +723,12 @@ const isPathUsed = async function (elastic, path, repoId) {
     },
   })
 
-  debug('findUsedPath', { path, repoId, total: body.hits.total })
+  const total = body.hits.total
+  const totalCount = Number.isFinite(total?.value) ? total.value : total
 
-  return !!body.hits.total
+  debug('findUsedPath', { path, repoId, totalCount })
+
+  return totalCount > 0
 }
 
 const findPublished = async function (elastic, repoId) {

--- a/packages/search/lib/filters.js
+++ b/packages/search/lib/filters.js
@@ -11,54 +11,57 @@ const termCriteriaBuilder = (fieldName) => (value, options) => ({
   },
 })
 
-const hasCriteriaBuilder = (fieldName) => (value, { filter, not = false }) => ({
-  clause: not || !value ? 'must_not' : 'must',
-  filter: [
-    filter || { match_all: {} },
-    {
-      exists: {
-        field: fieldName,
-      },
-    },
-  ],
-})
-
-const dateRangeCriteriaBuilder = (fieldName) => (
-  range,
-  { filter, not = false },
-) => ({
-  clause: not ? 'must_not' : 'must',
-  filter: [
-    filter || { match_all: {} },
-    {
-      range: {
-        [fieldName]: {
-          ...(range.from ? { gte: range.from } : {}),
-          ...(range.to ? { lte: range.to } : {}),
+const hasCriteriaBuilder =
+  (fieldName) =>
+  (value, { filter, not = false }) => ({
+    clause: not || !value ? 'must_not' : 'must',
+    filter: [
+      filter || { match_all: {} },
+      {
+        exists: {
+          field: fieldName,
         },
       },
-    },
-  ],
-})
+    ],
+  })
 
-const rangeCriteriaBuilder = (fieldName) => (value, { filter, ranges }) => {
-  const range = ranges.find((range) => range.key === value.toLowerCase())
-
-  return {
-    clause: 'must',
+const dateRangeCriteriaBuilder =
+  (fieldName) =>
+  (range, { filter, not = false }) => ({
+    clause: not ? 'must_not' : 'must',
     filter: [
       filter || { match_all: {} },
       {
         range: {
           [fieldName]: {
-            gte: range.from || undefined,
-            lte: range.to || undefined,
+            ...(range.from ? { gte: range.from } : {}),
+            ...(range.to ? { lte: range.to } : {}),
           },
         },
       },
     ],
+  })
+
+const rangeCriteriaBuilder =
+  (fieldName) =>
+  (value, { filter, ranges }) => {
+    const range = ranges.find((range) => range.key === value.toLowerCase())
+
+    return {
+      clause: 'must',
+      filter: [
+        filter || { match_all: {} },
+        {
+          range: {
+            [fieldName]: {
+              gte: range.from || undefined,
+              lte: range.to || undefined,
+            },
+          },
+        },
+      ],
+    }
   }
-}
 
 // converts a filter array (with generic value as string) to a (typed) filter obj
 // adds a type filter if the schema implies it and no type filter
@@ -171,7 +174,7 @@ const elasticFilterBuilder = (schema) => (filterInput) => {
       boolFilter[created.clause] = [
         ...(boolFilter[created.clause] || []),
         created.filter,
-      ]
+      ].flat()
 
       return boolFilter
     }, {}),

--- a/packages/search/lib/pullElasticsearch.js
+++ b/packages/search/lib/pullElasticsearch.js
@@ -96,6 +96,7 @@ module.exports = async ({
               ...mapping,
             },
             settings: {
+              number_of_shards: 5,
               analysis,
               // Disable refresh_interval to allow speedier bulk operations
               refresh_interval: -1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,18 +661,15 @@
   dependencies:
     chalk "^4.0.0"
 
-"@elastic/elasticsearch@^6.8.7":
-  version "6.8.8"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-6.8.8.tgz#363d332d4de3a3ee5420ac0ced2eb4bfadf04548"
-  integrity sha512-51Jp3ZZ0oPqYPNlPG58XJ773MqJBx91rGNWCgVvy2UtxjxHsExAJooesOyLcoADnW0Dhyxu6yB8tziHnmyl8Vw==
+"@elastic/elasticsearch@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz#6dcf511dfa91187e22c81e54f41f4bd0fd96b4d6"
+  integrity sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==
   dependencies:
-    debug "^4.1.1"
-    decompress-response "^4.2.0"
-    into-stream "^5.1.0"
-    ms "^2.1.1"
-    once "^1.4.0"
-    pump "^3.0.0"
-    secure-json-parse "^2.1.0"
+    debug "^4.3.1"
+    hpagent "^0.1.1"
+    ms "^2.1.3"
+    secure-json-parse "^2.4.0"
 
 "@eslint/eslintrc@^0.4.1":
   version "0.4.1"
@@ -6185,14 +6182,6 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-from2@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
-  integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "^2.0.0"
-
 fs-capacitor@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-2.0.4.tgz#5a22e72d40ae5078b4fe64fe4d08c0d3fc88ad3c"
@@ -6958,6 +6947,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
+hpagent@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-0.1.1.tgz#66f67f16e5c7a8b59a068e40c2658c2c749ad5e2"
+  integrity sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ==
+
 hpkp@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/hpkp/-/hpkp-2.0.0.tgz#10e142264e76215a5d30c44ec43de64dee6d1672"
@@ -7291,14 +7285,6 @@ internmap@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
   integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
-
-into-stream@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-5.1.1.tgz#f9a20a348a11f3c13face22763f2d02e127f4db8"
-  integrity sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==
-  dependencies:
-    from2 "^2.3.0"
-    p-is-promise "^3.0.0"
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -9192,7 +9178,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1:
+ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -9723,11 +9709,6 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-
-p-is-promise@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-3.0.0.tgz#58e78c7dfe2e163cf2a04ff869e7c1dba64a5971"
-  integrity sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==
 
 p-limit@3.1.0, p-limit@^3.0.2:
   version "3.1.0"
@@ -11262,7 +11243,7 @@ scroll-into-view@^1.9.7:
   resolved "https://registry.yarnpkg.com/scroll-into-view/-/scroll-into-view-1.15.0.tgz#9e6733bd74680349d6e5c49ddde6a09d9309fadf"
   integrity sha512-Ytbg8O1GlN8vOOZMPDOrjXixAFXZ4oJklxHkYREqdUFYo+a8qVuPX16U3nRkifKnM8kkvY9sOy7EL30HaeW07Q==
 
-secure-json-parse@^2.1.0:
+secure-json-parse@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.4.0.tgz#5aaeaaef85c7a417f76271a4f5b0cc3315ddca85"
   integrity sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==


### PR DESCRIPTION
This Pull Request allows us to use ElasticSearch 7.

Major change: In ElasticSearch 6, `hits.total` is an integer. In ElasticSearch 7, `hits.total` [is an object](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/breaking-changes-7.0.html#hits-total-now-object-search-response), returning document count as `value` and `relation` of count. We use `track_total_hits` flag [to get an accurate (but "costly") document count](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-your-data.html#track-total-hits).

Bugfix: We may have passed a filter array containing objects and arrays with objects. While ElasticSearch prior to version 7 was lenient on this, version 7 isn't anymore and will throw a parsing exception.

Fixes #616