### PR TITLE
Prevent cursor bloating and stabilize cursor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -347,9 +347,6 @@ STRIPE_SECRET_KEY_REPUBLIK=
 # search
 #############
 
-# Track search requests. Default is false
-#SEARCH_TRACK=true
-
 # Listener processing changes in Postgres tables and posting to ElasticSearch
 SEARCH_PG_LISTENER=true
 

--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -412,11 +412,27 @@ const search = async (__, args, context, info) => {
 
   debug('options', JSON.stringify(options))
 
+  /**
+   * {filterObj} is a shorthand for adding items to {filterArray}.
+   *
+   * Here we iterate through {filterObj} props, transform them into a
+   * filter item (key, value, not) and append them to {filterArray}. It
+   * will no append a filter item if present already.
+   */
   Object.keys(filterObj).forEach((key) => {
-    filterArray.push({
-      key,
-      value: filterObj[key],
-    })
+    const value = filterObj[key]
+    const not = false
+
+    const hasFilter = !!filterArray.find(
+      (f) =>
+        f.key === key &&
+        JSON.stringify(f.value) === JSON.stringify(value) &&
+        f.not === not,
+    )
+
+    if (!hasFilter) {
+      filterArray.push({ key, value, not })
+    }
   })
 
   const filter = reduceFilters(filterArray)

--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -314,7 +314,7 @@ const parseOptions = (options) => {
   try {
     return JSON.parse(Buffer.from(options, 'base64').toString())
   } catch (e) {
-    console.info('failed to parse options:', options, e)
+    console.warn('failed to parse options:', options, e)
   }
   return {}
 }
@@ -392,11 +392,13 @@ const search = async (__, args, context, info) => {
     withoutChildren = withoutContent && !hasFieldRequested('children', info)
   }
 
-  const options = after
-    ? { ...args, ...parseOptions(after) }
-    : before
-    ? { ...args, ...parseOptions(before) }
-    : args
+  /**
+   * If cursors {after} (1) or {before} (2) are provided, their contents
+   * replace options provided: Changing search term or {first} won't have
+   * any effect.
+   */
+  const options =
+    (after && parseOptions(after)) || (before && parseOptions(before)) || args
 
   const {
     search,

--- a/packages/search/lib/utils.js
+++ b/packages/search/lib/utils.js
@@ -12,13 +12,6 @@ const getDateTime = () =>
   new Date().toISOString().slice(0, -5).replace(/[^\d]/g, '-')
 
 /**
- * @example "2018-05-24"
- * @return {String} [description]
- */
-const getDate = () =>
-  new Date().toISOString().slice(0, -14).replace(/[^\d]/g, '-')
-
-/**
  * @param  {String} name An index name without prefix
  * @param  {String} type Operation, like "read", "write"
  * @return {String}      An alias name for an index
@@ -32,13 +25,6 @@ const getIndexAlias = (name, type) =>
  */
 const getDateTimeIndex = (name) =>
   [ES_INDEX_PREFIX, name, getDateTime()].filter(Boolean).join('-')
-
-/**
- * @param  {String} name An index name without prefix
- * @return {String}      An index name with a date
- */
-const getDateIndex = (name) =>
-  [ES_INDEX_PREFIX, name, getDate()].filter(Boolean).join('-')
 
 /**
  * A filter to remove nodes from an mdast with a predicate. Will remove a node
@@ -93,7 +79,6 @@ const mdastContentToString = (mdast) =>
 module.exports = {
   getIndexAlias,
   getDateTimeIndex,
-  getDateIndex,
   mdastFilter,
   mdastContentToString,
 }


### PR DESCRIPTION
This Pull Request fixes a but which lead to bloated pagination cursors. Each page appended same `SearchInputFilter` to cursor again and again.

It also stabilizes cursors be ignore other options (e.g. different search term) once a cursor is provided.

It further removes tracking of search requests. Once designated to improve search results eventually, that feature was abanonded soon after its release and it got never reinstated.