### PR TITLE
fix(republik): Delete portrait asset after db tx

### DIFF
--- a/packages/assets/lib/Portrait.js
+++ b/packages/assets/lib/Portrait.js
@@ -3,6 +3,7 @@ const checkEnv = require('check-env')
 const S3 = require('./s3')
 const querystring = require('querystring')
 const sharp = require('sharp')
+const debug = require('debug')('assets:lib:Portrait')
 
 checkEnv(['ASSETS_SERVER_BASE_URL'])
 
@@ -51,6 +52,9 @@ const upload = async (portrait, dry = false) => {
   const query = querystring.stringify({
     size: `${meta.width}x${meta.height}`,
   })
+
+  debug('upload: %o', { AWS_S3_BUCKET, portraitPath })
+
   return `${ASSETS_SERVER_BASE_URL}/s3/${AWS_S3_BUCKET}/${portraitPath}?${query}`
 }
 
@@ -59,6 +63,7 @@ const del = (portraitUrl) => {
     return
   }
   const [, bucket, path] = new RegExp(/.*?s3\/(.*?)\/(.*?)\?/).exec(portraitUrl)
+  debug('del: %o', { bucket, path })
   return S3.del({ bucket, path })
 }
 

--- a/packages/republik/graphql/resolvers/_mutations/updateMe.js
+++ b/packages/republik/graphql/resolvers/_mutations/updateMe.js
@@ -40,21 +40,18 @@ const MAX_PHONE_NUMBER_LENGTH = 20 // 20 (15 digits but let's give 5 spaces for 
 const MAX_FIRSTNAME_LENGTH = 32
 const MAX_LASTNAME_LENGTH = 32
 
-const createEnsureStringLengthForProfile = (values, t) => (
-  key,
-  translationKey,
-  max,
-  min = 0,
-) =>
-  ensureStringLength(values[key], {
-    min,
-    max,
-    error: t(`profile/generic/${min > 0 ? 'notInRange' : 'tooLong'}`, {
-      key: t(translationKey),
-      max,
+const createEnsureStringLengthForProfile =
+  (values, t) =>
+  (key, translationKey, max, min = 0) =>
+    ensureStringLength(values[key], {
       min,
-    }),
-  })
+      max,
+      error: t(`profile/generic/${min > 0 ? 'notInRange' : 'tooLong'}`, {
+        key: t(translationKey),
+        max,
+        min,
+      }),
+    })
 
 module.exports = async (_, args, context) => {
   const { pgdb, req, user: me, t, mail } = context
@@ -212,16 +209,6 @@ module.exports = async (_, args, context) => {
     }
   }
 
-  let portraitUrl = portrait === null ? null : undefined
-
-  if (portrait) {
-    portraitUrl = await Portrait.upload(portrait)
-    await Portrait.del(me._raw.portraitUrl)
-  } else if (portrait === null && me._raw.portraitUrl) {
-    await Portrait.del(me._raw.portraitUrl)
-    portraitUrl = null
-  }
-
   if (username !== undefined && username !== null) {
     await checkUsername(username, me, pgdb)
   }
@@ -247,6 +234,14 @@ module.exports = async (_, args, context) => {
       throw new Error(t('api/pgpPublicKey/invalid'))
     }
   }
+
+  // {portrait} is an argument, which can either contain a a b64 encoded image,
+  // be null or undefined.
+  // If image is provided, we'll attempt to upload it and update portraitUrl
+  // If null is set, we will delete current image after Postgres transaction
+  // If undefined is set, we won't tinker with portrait URL
+  const portraitUrl =
+    (portrait && (await Portrait.upload(portrait))) || portrait
 
   const transaction = await pgdb.transactionBegin()
   const now = new Date()
@@ -326,15 +321,29 @@ module.exports = async (_, args, context) => {
     await transaction.transactionCommit()
 
     const updatedUser = await pgdb.public.users.findOne({ id: me.id })
+
+    if (
+      me._raw.portraitUrl &&
+      updatedUser.portraitUrl !== me._raw.portraitUrl
+    ) {
+      await Portrait.del(me._raw.portraitUrl)
+    }
+
     await mail.updateMergeFields({ user: updatedUser })
 
     return transformUser(updatedUser)
   } catch (e) {
     await transaction.transactionRollback()
+
+    if (portraitUrl) {
+      await Portrait.del(portraitUrl)
+    }
+
     console.log('updateMe', e)
     if (e.translated) {
       throw e
     }
+
     throw new Error(t('api/unexpected'))
   }
 }


### PR DESCRIPTION
If `checkUsername` or database transaction failed, current portrait was deleted but new portrait never linked. It will delete new portrait if transaction failed as to not have any dead files.