### PR TITLE
fix(republik-crowdfundings): Reactivate cancelled but active subscription

### DIFF
--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/reactivateMembership.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/reactivateMembership.js
@@ -71,13 +71,9 @@ module.exports = async (_, args, context) => {
 
       let newSubscription
       if (subscription.status === 'active') {
-        // https://stripe.com/docs/subscriptions/canceling-pausing#reactivating-canceled-subscriptions
         newSubscription = await reactivateSubscription({
           id: membership.subscriptionId,
-          item: {
-            id: subscription.items.data[0].id,
-            plan: membershipType.name,
-          },
+          item_id: subscription.items.data[0].id,
           companyId: membershipType.companyId,
           pgdb: transaction,
         })

--- a/packages/republik-crowdfundings/lib/payments/stripe/reactivateSubscription.js
+++ b/packages/republik-crowdfundings/lib/payments/stripe/reactivateSubscription.js
@@ -1,6 +1,6 @@
 const getClients = require('./clients')
 
-module.exports = async ({ id, item, companyId, pgdb }) => {
+module.exports = async ({ id, item_id, companyId, pgdb }) => {
   const { accounts } = await getClients(pgdb)
 
   const account = accounts.find((a) => a.company.id === companyId)
@@ -8,7 +8,9 @@ module.exports = async ({ id, item, companyId, pgdb }) => {
     throw new Error(`could not find account for companyId: ${companyId}`)
   }
 
+  // https://stripe.com/docs/billing/subscriptions/cancel#reactivating-canceled-subscriptions
   return account.stripe.subscriptions.update(id, {
-    items: [{ ...item }],
+    cancel_at_period_end: false,
+    items: [{ id: item_id }],
   })
 }


### PR DESCRIPTION
This Pull Request fixes a regression introduced in #522: Mutation `reactivateMembership` did no reactive cancelled but still active subscriptions.

API version 2018-02-28 or younger require `cancel_at_period_end` parameter to reactive a cancelled (but active) subscription.

Before #522 we used API version 2017-12-14 which "[any parameter sent to the Update Subscription API would automatically reactivate a subscription.](https://stripe.com/docs/billing/subscriptions/cancel#reactivating-canceled-subscriptions)"