### PR TITLE
fix(republik-crowdfundings): Throw error if payment_intent fails

### DIFF
--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/reactivateMembership.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/reactivateMembership.js
@@ -86,6 +86,7 @@ module.exports = async (_, args, context) => {
             pledgeId: membership.pledgeId,
             membershipId,
           },
+          errIfIncomplete: true,
           pgdb: transaction,
         })
 

--- a/packages/republik-crowdfundings/graphql/resolvers/_mutations/reactivateMembership.js
+++ b/packages/republik-crowdfundings/graphql/resolvers/_mutations/reactivateMembership.js
@@ -1,24 +1,24 @@
 const { Roles } = require('@orbiting/backend-modules-auth')
-const getSubscription = require('../../../lib/payments/stripe/getSubscription')
-const createSubscription = require('../../../lib/payments/stripe/createSubscription')
-const reactivateSubscription = require('../../../lib/payments/stripe/reactivateSubscription')
-const slack = require('@orbiting/backend-modules-republik/lib/slack')
-const createCache = require('../../../lib/cache')
 const { sendMailTemplate } = require('@orbiting/backend-modules-mail')
+const slack = require('@orbiting/backend-modules-republik/lib/slack')
+
+const { throwError } = require('../../../lib/payments/stripe/Errors')
+const createCache = require('../../../lib/cache')
+const createSubscription = require('../../../lib/payments/stripe/createSubscription')
+const getSubscription = require('../../../lib/payments/stripe/getSubscription')
+const reactivateSubscription = require('../../../lib/payments/stripe/reactivateSubscription')
 
 module.exports = async (_, args, context) => {
   const {
     pgdb,
-    req,
     user: me,
     t,
     mail: { enforceSubscriptions },
   } = context
-  const transaction = await pgdb.transactionBegin()
   const now = new Date()
+  const { id: membershipId } = args
+  const transaction = await pgdb.transactionBegin()
   try {
-    const { id: membershipId } = args
-
     const membership = await transaction
       .query(
         `
@@ -170,7 +170,6 @@ module.exports = async (_, args, context) => {
     return newMembership
   } catch (e) {
     await transaction.transactionRollback()
-    console.info('transaction rollback', { req: req._log(), args, error: e })
-    throw e
+    throwError(e, { membershipId, t, kind: 'reactivateMembership' })
   }
 }

--- a/packages/republik-crowdfundings/lib/payments/stripe/Errors.js
+++ b/packages/republik-crowdfundings/lib/payments/stripe/Errors.js
@@ -10,4 +10,30 @@ class RequiresPaymentMethodError extends Error {
   }
 }
 
+const throwError = (e, { pledgeId, membershipId, t, kind }) => {
+  if (e.type === 'StripeCardError') {
+    const translatedError = t('api/pay/stripe/' + e.code)
+    if (translatedError) {
+      console.warn(e, { pledgeId, membershipId, kind })
+      throw new Error(translatedError)
+    } else {
+      console.warn('translation not found for stripe error', {
+        pledgeId,
+        kind,
+        e,
+      })
+      throw new Error(e.message)
+    }
+  }
+
+  if (e.name === 'RequiresPaymentMethodError') {
+    console.warn(e, { pledgeId, membershipId, kind })
+    throw new Error(t('api/pay/stripe/card_declined'))
+  }
+
+  console.error(e, { pledgeId, membershipId, kind })
+  throw new Error(t('api/unexpected'))
+}
+
 module.exports.RequiresPaymentMethodError = RequiresPaymentMethodError
+module.exports.throwError = throwError

--- a/packages/republik-crowdfundings/lib/payments/stripe/createSubscription.js
+++ b/packages/republik-crowdfundings/lib/payments/stripe/createSubscription.js
@@ -10,6 +10,7 @@ module.exports = async ({
   userId,
   companyId,
   platformPaymentMethodId, // optional
+  errIfIncomplete, // optional
   metadata,
   pgdb,
   clients: _clients, // optional
@@ -29,19 +30,34 @@ module.exports = async ({
   const clients = _clients || (await getClients(pgdb))
   const { stripe } = clients.accountForCompanyId(companyId)
 
-  if (!platformPaymentMethodId) {
-    debug('subscribe user with default payment method %o', {
-      customer: customer.id,
-    })
-    return stripe.subscriptions.create({
-      customer: customer.id,
-      items: [{ plan }],
-      metadata,
-      expand: ['latest_invoice', 'latest_invoice.payment_intent'],
-    })
+  const subscription = {
+    customer: customer.id,
+    items: [{ plan }],
+    metadata,
+    expand: ['latest_invoice', 'latest_invoice.payment_intent'],
   }
 
-  const paymentMethodId = await getPaymentMethodForCompany({
+  if (errIfIncomplete) {
+    // If errIfIncomplete is false, a subscripton might be created but status
+    // set to incomplete e.g. if payment_intent requires another payment
+    // method or payment_intent requires action.
+    //
+    // "Use error_if_incomplete if you want Stripe to return an HTTP 402 status
+    // code if a subscription’s first invoice cannot be paid. For example, if a
+    // payment method requires 3DS authentication due to SCA regulation and
+    // further user action is needed, this parameter does not create a
+    // subscription and returns an error instead."
+    //
+    // @see https://stripe.com/docs/api/subscriptions/create#create_subscription-payment_behavior
+    subscription.payment_behavior = 'error_if_incomplete'
+  }
+
+  if (!platformPaymentMethodId) {
+    debug('subscribe user with default payment method %o', subscription)
+    return stripe.subscriptions.create(subscription)
+  }
+
+  subscription.default_payment_method = await getPaymentMethodForCompany({
     userId,
     companyId,
     platformPaymentMethodId,
@@ -50,12 +66,6 @@ module.exports = async ({
     t,
   }).then((pm) => pm.id)
 
-  debug('subscribe with payment method %o', { paymentMethodId })
-  return stripe.subscriptions.create({
-    customer: customer.id,
-    default_payment_method: paymentMethodId,
-    items: [{ plan }],
-    metadata,
-    expand: ['latest_invoice', 'latest_invoice.payment_intent'],
-  })
+  debug('subscribe with payment method %o', subscription)
+  return stripe.subscriptions.create(subscription)
 }

--- a/packages/republik-crowdfundings/lib/payments/stripe/payPledge.js
+++ b/packages/republik-crowdfundings/lib/payments/stripe/payPledge.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('crowdfundings:lib:payments:stripe:payPledge')
 
-const { RequiresPaymentMethodError } = require('./Errors')
+const { RequiresPaymentMethodError, throwError } = require('./Errors')
 
 const createCustomer = require('./createCustomer')
 const createCharge = require('./createCharge')
@@ -30,31 +30,6 @@ module.exports = (args) => {
       throwError(e, { ...args, kind: 'paymentIntent' })
     })
   }
-}
-
-const throwError = (e, { pledgeId, t, kind }) => {
-  if (e.type === 'StripeCardError') {
-    const translatedError = t('api/pay/stripe/' + e.code)
-    if (translatedError) {
-      console.warn(e, { pledgeId, kind })
-      throw new Error(translatedError)
-    } else {
-      console.warn('translation not found for stripe error', {
-        pledgeId,
-        kind,
-        e,
-      })
-      throw new Error(e.message)
-    }
-  }
-
-  if (e.name === 'RequiresPaymentMethodError') {
-    console.warn(e, { pledgeId, kind })
-    throw new Error(t('api/pay/stripe/card_declined'))
-  }
-
-  console.error(e, { pledgeId, kind })
-  throw new Error(t('api/unexpected'))
 }
 
 const payWithSource = async ({

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -203,6 +203,10 @@
       "value": "Während der Bearbeitung der Karte ist ein Fehler aufgetreten."
     },
     {
+      "key": "api/pay/stripe/subscription_payment_intent_requires_action",
+      "value": "Ihre Kreditkarte lässt sich nicht dazu verwenden, um ein Monats-Abo zu reaktivieren. Bitte melden Sie sich bei kontakt@republik.ch"
+    },
+    {
       "key": "api/paypal/deny",
       "value": "Die Zahlung ist leider fehlgeschlagen. Bitte wählen Sie ein anderes Zahlungsmittel, um Ihre Bestellung abzuschliessen."
     },


### PR DESCRIPTION
This Pull Requests enforces [no deferred payment confirmation (e.g. 3DS) when reactivating a subscription](https://github.com/orbiting/backends/commit/aebcf99a0f5ce8861ed4de5a9ede9d1a084fb109). 

It also handles reactivation errors similar to errors while paying a pledge.