### PR TITLE
Index document zones

### DIFF
--- a/packages/documents/graphql/resolvers/DocumentZone.js
+++ b/packages/documents/graphql/resolvers/DocumentZone.js
@@ -1,0 +1,14 @@
+const getDocuments = require('./_queries/documents')
+
+module.exports = {
+  document: async (zone, args, context, info) => {
+    const { repoId, commitId } = zone
+
+    return getDocuments(
+      undefined,
+      { first: 1, repoId, commitId },
+      context,
+      info,
+    ).then((docCon) => docCon.nodes[0])
+  },
+}

--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -141,6 +141,16 @@ type DocumentNodeConnection {
   totalCount: Int!
 }
 
+type DocumentZone {
+  id: ID!
+  hash: String!
+  identifier: String!
+  data: JSON!
+  text: String
+  node: JSON!
+  document: Document
+}
+
 type DocumentConnection {
   nodes: [Document!]!
   pageInfo: DocumentPageInfo!

--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -10,6 +10,7 @@ const {
   schema: documentSchema,
   addRelatedDocs,
 } = require('../../../lib/Documents')
+const { schema: documentZoneSchema } = require('../../../lib/DocumentZones')
 const {
   filterReducer,
   getFilterValue,
@@ -27,9 +28,12 @@ const { v4: uuid } = require('uuid')
 const indices = require('../../../lib/indices')
 const { getIndexAlias } = require('../../../lib/utils')
 
-const reduceFilters = filterReducer([documentSchema])
-const createElasticFilter = elasticFilterBuilder([documentSchema])
-const schemaAggregations = extractAggs([documentSchema])
+const reduceFilters = filterReducer([documentSchema, documentZoneSchema])
+const createElasticFilter = elasticFilterBuilder([
+  documentSchema,
+  documentZoneSchema,
+])
+const schemaAggregations = extractAggs([documentSchema, documentZoneSchema])
 
 const getFieldList = require('@orbiting/graphql-list-fields')
 

--- a/packages/search/graphql/resolvers/_queries/search.js
+++ b/packages/search/graphql/resolvers/_queries/search.js
@@ -27,9 +27,9 @@ const { v4: uuid } = require('uuid')
 const indices = require('../../../lib/indices')
 const { getIndexAlias } = require('../../../lib/utils')
 
-const reduceFilters = filterReducer(documentSchema)
-const createElasticFilter = elasticFilterBuilder(documentSchema)
-const schemaAggregations = extractAggs(documentSchema)
+const reduceFilters = filterReducer([documentSchema])
+const createElasticFilter = elasticFilterBuilder([documentSchema])
+const schemaAggregations = extractAggs([documentSchema])
 
 const getFieldList = require('@orbiting/graphql-list-fields')
 

--- a/packages/search/graphql/schema-types.js
+++ b/packages/search/graphql/schema-types.js
@@ -28,6 +28,7 @@ input DateRangeInput {
 
 enum SearchTypes {
   Document
+  DocumentZone
   Comment
   User
 }
@@ -88,7 +89,7 @@ type SearchNode {
   score: Float
 }
 
-union SearchEntity = Document | Comment | User
+union SearchEntity = Document | DocumentZone | Comment | User
 
 type SearchHighlight {
   path: String!

--- a/packages/search/lib/DocumentZones.js
+++ b/packages/search/lib/DocumentZones.js
@@ -1,0 +1,201 @@
+const crypto = require('crypto')
+const visit = require('unist-util-visit')
+const Promise = require('bluebird')
+const debug = require('debug')('search:lib:DocumentZones')
+
+const { mdastToString } = require('@orbiting/backend-modules-utils')
+
+const { getIndexAlias, mdastFilter } = require('./utils')
+const { termEntry } = require('./schema')
+const { termCriteriaBuilder } = require('./filters')
+
+const indexType = 'DocumentZone'
+const indexRef = {
+  index: getIndexAlias(indexType.toLowerCase(), 'write'),
+  type: indexType,
+}
+
+const schema = {
+  // special value to indicate this schemas index type
+  __type: indexType,
+  id: { criteria: termCriteriaBuilder('_id') },
+  type: termEntry('__type'),
+  documentZoneIdentifier: termEntry('identifier'),
+  documentZoneDataType: termEntry('data.type'),
+}
+
+const shouldIndexNode = (node) =>
+  node.type === 'zone' && ['CHART'].includes(node.identifier)
+
+const findNodes = (elasticDoc) => {
+  const nodes = []
+
+  visit(elasticDoc.content, 'zone', (node) => {
+    if (shouldIndexNode(node)) {
+      nodes.push(node)
+    }
+  })
+
+  return nodes
+}
+
+const getZoneHash = (node) =>
+  crypto.createHash('md5').update(JSON.stringify(node)).digest('hex')
+
+const getZoneId = (repoId, commitId, hash) =>
+  Buffer.from(`${repoId}/${commitId}/${hash}`).toString('base64')
+
+const getElasticDoc = (repoId, commitId, documentId, state, date, node) => {
+  const hash = getZoneHash(node)
+  const id = getZoneId(repoId, commitId, hash)
+
+  const { identifier } = node
+
+  return {
+    __type: indexType,
+    __state: {
+      published: !!state?.published,
+      prepublished: !!state?.prepublished,
+    },
+    __sort: { date },
+    id,
+    repoId,
+    commitId,
+    documentId,
+    hash,
+    identifier,
+    node,
+    data: node?.data || {},
+    text:
+      mdastToString(mdastFilter(node, (n) => n.type === 'code')).trim() || '',
+  }
+}
+
+const switchState = async function (elastic, state, repoId, commitId) {
+  debug('switchState', { state, repoId, commitId })
+  const queries = []
+  const painless = []
+
+  if (state.published === true || state.published === false) {
+    queries.push({ term: { '__state.published': state.published } })
+    painless.push('ctx._source.__state.published = params.state.published')
+  }
+
+  if (state.prepublished === true || state.prepublished === false) {
+    queries.push({ term: { '__state.prepublished': state.prepublished } })
+    painless.push(
+      'ctx._source.__state.prepublished = params.state.prepublished',
+    )
+  }
+
+  const source = painless.join(';')
+
+  await elastic.updateByQuery({
+    ...indexRef,
+    refresh: true,
+    body: {
+      query: {
+        bool: {
+          must: [{ term: { repoId } }],
+          should: queries,
+          must_not: [{ term: { commitId } }],
+        },
+      },
+      script: {
+        lang: 'painless',
+        source,
+        params: {
+          state: {
+            published: !state.published,
+            prepublished: !state.prepublished,
+          },
+        },
+      },
+    },
+  })
+
+  await elastic.updateByQuery({
+    ...indexRef,
+    refresh: true,
+    body: {
+      query: {
+        bool: {
+          must: [{ term: { repoId } }, { term: { commitId } }],
+        },
+      },
+      script: {
+        lang: 'painless',
+        source,
+        params: {
+          state: {
+            published: !!state.published,
+            prepublished: !!state.prepublished,
+          },
+        },
+      },
+    },
+  })
+}
+
+const createPublish = (elastic, elasticDoc) => {
+  const {
+    id: documentId,
+    commitId,
+    meta: { repoId, publishDate },
+  } = elasticDoc
+
+  return {
+    insert: async (desiredState) => {
+      const inserts = await Promise.map(findNodes(elasticDoc), async (node) => {
+        const documentZoneElasticDoc = getElasticDoc(
+          repoId,
+          commitId,
+          documentId,
+          desiredState,
+          publishDate,
+          node,
+        )
+
+        return elastic.index({
+          ...indexRef,
+          id: documentZoneElasticDoc.id,
+          body: documentZoneElasticDoc,
+        })
+      })
+
+      return inserts.length
+    },
+    after: async (desiredState) => {
+      await switchState(elastic, desiredState, repoId, commitId)
+    },
+  }
+}
+
+const unpublish = async (elastic, repoId) => {
+  const painless = [
+    'ctx._source.__state.published = false',
+    'ctx._source.__state.prepublished = false',
+  ]
+
+  await elastic.updateByQuery({
+    ...indexRef,
+    refresh: true,
+    body: {
+      query: {
+        bool: {
+          must: [{ term: { repoId } }],
+        },
+      },
+      script: {
+        lang: 'painless',
+        source: painless.join(';'),
+      },
+    },
+  })
+}
+
+module.exports = {
+  schema,
+  createPublish,
+  unpublish,
+}

--- a/packages/search/lib/aggregations.js
+++ b/packages/search/lib/aggregations.js
@@ -1,80 +1,93 @@
-const termsAggBuilder = (fieldPath) => (key, { filter } = {}) => ({
-  [`terms/${key}`]: {
-    filter: filter || { match_all: {} },
-    aggs: {
-      terms: {
+const termsAggBuilder =
+  (fieldPath) =>
+  (key, { filter } = {}) => ({
+    [`terms/${key}`]: {
+      filter: filter || { match_all: {} },
+      aggs: {
         terms: {
-          field: fieldPath,
-          min_doc_count: 0,
-        },
-      },
-    },
-  },
-})
-
-const valueCountAggBuilder = (fieldPath) => (key, { filter } = {}) => ({
-  [`valueCount/${key}`]: {
-    filter: filter || { match_all: {} },
-    aggs: {
-      count: {
-        value_count: {
-          field: fieldPath,
-        },
-      },
-    },
-  },
-})
-
-const trueCountAggBuilder = (fieldPath) => (key, { filter } = {}) => ({
-  [`trueCount/${key}`]: {
-    filter: {
-      bool: {
-        must: [
-          filter || { match_all: {} },
-          {
-            term: {
-              [fieldPath]: true,
-            },
+          terms: {
+            field: fieldPath,
+            min_doc_count: 0,
           },
-        ],
-      },
-    },
-  },
-})
-
-const existsCountAggBuilder = (fieldPath) => (key, { filter } = {}) => ({
-  [`existsCount/${key}`]: {
-    filter: {
-      bool: {
-        must: [
-          filter || { match_all: {} },
-          {
-            exists: {
-              field: fieldPath,
-            },
-          },
-        ],
-      },
-    },
-  },
-})
-
-const rangeAggBuilder = (fieldPath) => (key, { filter, ranges } = {}) => ({
-  [`range/${key}`]: {
-    filter: filter || { match_all: {} },
-    aggs: {
-      ranges: {
-        range: {
-          field: fieldPath,
-          ranges,
         },
       },
     },
-  },
-})
+  })
 
-const extractAggs = (schema) =>
-  Object.keys(schema).reduce((aggs, key) => {
+const valueCountAggBuilder =
+  (fieldPath) =>
+  (key, { filter } = {}) => ({
+    [`valueCount/${key}`]: {
+      filter: filter || { match_all: {} },
+      aggs: {
+        count: {
+          value_count: {
+            field: fieldPath,
+          },
+        },
+      },
+    },
+  })
+
+const trueCountAggBuilder =
+  (fieldPath) =>
+  (key, { filter } = {}) => ({
+    [`trueCount/${key}`]: {
+      filter: {
+        bool: {
+          must: [
+            filter || { match_all: {} },
+            {
+              term: {
+                [fieldPath]: true,
+              },
+            },
+          ],
+        },
+      },
+    },
+  })
+
+const existsCountAggBuilder =
+  (fieldPath) =>
+  (key, { filter } = {}) => ({
+    [`existsCount/${key}`]: {
+      filter: {
+        bool: {
+          must: [
+            filter || { match_all: {} },
+            {
+              exists: {
+                field: fieldPath,
+              },
+            },
+          ],
+        },
+      },
+    },
+  })
+
+const rangeAggBuilder =
+  (fieldPath) =>
+  (key, { filter, ranges } = {}) => ({
+    [`range/${key}`]: {
+      filter: filter || { match_all: {} },
+      aggs: {
+        ranges: {
+          range: {
+            field: fieldPath,
+            ranges,
+          },
+        },
+      },
+    },
+  })
+
+const extractAggs = (schemas) => {
+  const keys = schemas.map((schema) => Object.keys(schema)).flat()
+
+  return keys.reduce((aggs, key) => {
+    const schema = schemas.find((schema) => !!schema[key])
     const schemaEntry = schema[key]
     if (schemaEntry.agg) {
       return {
@@ -84,6 +97,7 @@ const extractAggs = (schema) =>
     }
     return aggs
   }, {})
+}
 
 module.exports = {
   termsAggBuilder,

--- a/packages/search/lib/indices/documentzones.js
+++ b/packages/search/lib/indices/documentzones.js
@@ -1,0 +1,128 @@
+const type = 'DocumentZone'
+
+module.exports = {
+  type,
+  name: type.toLowerCase(),
+  search: {
+    termFields: {
+      text: {
+        highlight: {
+          number_of_fragments: 0,
+        },
+      },
+    },
+    filter: {
+      default: () => ({
+        bool: {
+          must: [{ term: { __type: type } }],
+        },
+      }),
+    },
+    rolebasedFilter: {
+      // Default filter
+      default: () => ({
+        bool: {
+          must: [{ term: { '__state.published': true } }],
+        },
+      }),
+
+      // Adopted filter when role "editor" is present
+      editor: ({ ignorePrepublished } = {}) => {
+        const should = [
+          // published
+          {
+            bool: {
+              must: [
+                { term: { '__state.published': true } },
+                { term: { '__state.prepublished': true } },
+              ],
+            },
+          },
+        ]
+
+        if (!ignorePrepublished) {
+          should.push({
+            bool: {
+              must: [
+                { term: { '__state.published': false } },
+                { term: { '__state.prepublished': true } },
+              ],
+            },
+          })
+        }
+
+        return {
+          bool: {
+            must: [{ bool: { should } }],
+          },
+        }
+      },
+    },
+  },
+  analysis: {
+    filter: {
+      german_stemmer: {
+        type: 'stemmer',
+        language: 'light_german',
+      },
+    },
+    analyzer: {
+      german_with_stopwords: {
+        // @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/analysis-lang-analyzer.html#german-analyzer
+        tokenizer: 'standard',
+        filter: ['lowercase', 'german_normalization', 'german_stemmer'],
+      },
+    },
+  },
+  mapping: {
+    [type]: {
+      dynamic: false,
+      properties: {
+        __type: {
+          type: 'keyword',
+        },
+        __state: {
+          properties: {
+            published: {
+              type: 'boolean',
+            },
+            prepublished: {
+              type: 'boolean',
+            },
+          },
+        },
+        __sort: {
+          properties: {
+            date: {
+              type: 'date',
+            },
+          },
+        },
+        repoId: {
+          type: 'keyword',
+        },
+        commitId: {
+          type: 'keyword',
+        },
+        identifier: {
+          // CHART, FIGURE, ...
+          type: 'keyword',
+        },
+        text: {
+          // stringified(node)
+          type: 'text',
+          analyzer: 'german_with_stopwords',
+        },
+        data: {
+          // node.data
+          properties: {
+            // CHART node.data.type
+            type: {
+              type: 'keyword',
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/packages/search/lib/indices/documentzones.js
+++ b/packages/search/lib/indices/documentzones.js
@@ -104,6 +104,9 @@ module.exports = {
         commitId: {
           type: 'keyword',
         },
+        versionName: {
+          type: 'keyword',
+        },
         identifier: {
           // CHART, FIGURE, ...
           type: 'keyword',

--- a/packages/search/lib/indices/index.js
+++ b/packages/search/lib/indices/index.js
@@ -1,6 +1,7 @@
 const dict = {
   comments: require('./comments'),
   documents: require('./documents'),
+  documentzones: require('./documentzones'),
   users: require('./users'),
   repos: require('./repos'),
 }

--- a/packages/search/lib/indices/index.js
+++ b/packages/search/lib/indices/index.js
@@ -7,7 +7,7 @@ const dict = {
 
 const list = []
 
-for (let key in dict) {
+for (const key in dict) {
   list.push(dict[key])
 }
 

--- a/packages/search/lib/inserts/documentzone.js
+++ b/packages/search/lib/inserts/documentzone.js
@@ -1,0 +1,110 @@
+const Promise = require('bluebird')
+
+const {
+  document: getDocument,
+} = require('@orbiting/backend-modules-publikator/graphql/resolvers/Commit')
+
+const createCache = require('../../lib/cache')
+const { getElasticDoc } = require('../Documents')
+const { createPublish } = require('../DocumentZones')
+
+const loaderBuilders = {
+  ...require('@orbiting/backend-modules-publikator/loaders'),
+}
+
+const getContext = (payload) => {
+  const loaders = {}
+  const context = {
+    ...payload,
+    loaders,
+  }
+  Object.keys(loaderBuilders).forEach((key) => {
+    loaders[key] = loaderBuilders[key](context)
+  })
+  return context
+}
+
+module.exports = {
+  before: () => {},
+  insert: async ({ indexName, type: indexType, elastic, pgdb, redis }) => {
+    const stats = { [indexType]: { added: 0, total: 0 } }
+    const statsInterval = setInterval(() => {
+      console.log(indexName, stats)
+    }, 1 * 1000)
+
+    const context = getContext({ pgdb, redis })
+
+    const repos = await pgdb.publikator.repos.find(
+      {
+        // id: 'republik/pae-article-beitrag-mit-chart',
+        archivedAt: null,
+      },
+      { orderBy: { updatedAt: 'desc' } },
+    )
+
+    await Promise.map(
+      repos,
+      async function mapRepo(repo) {
+        const { id: repoId } = repo
+
+        const milestones = await context.loaders.Milestone.byRepoId.load(repoId)
+        const publications = milestones.filter((p) =>
+          ['publication', 'prepublication'].includes(p.scope),
+        )
+        const hasPrepublication = !!publications.find(
+          (p) => p.scope === 'prepublication' && p.publishedAt && !p.revokedAt,
+        )
+
+        await Promise.each(publications, async (publication) => {
+          const {
+            commitId,
+            name: versionName,
+            scope,
+            scheduledAt,
+            publishedAt,
+            revokedAt,
+          } = publication
+
+          const doc = await getDocument(
+            { id: commitId, repoId },
+            { publicAssets: true },
+            context,
+          )
+
+          doc.content.meta = {
+            ...doc.content.meta,
+            repoId,
+            publishDate: publishedAt || scheduledAt,
+          }
+
+          const elasticDoc = getElasticDoc({
+            doc,
+            commitId,
+            versionName,
+          })
+
+          const zones = createPublish(elastic, elasticDoc)
+
+          const isPublished = publishedAt && !revokedAt
+          const isPrepublished = scope === 'prepublication' && isPublished
+
+          const inserts = await zones.insert({
+            published: hasPrepublication
+              ? !isPrepublished && isPublished
+              : isPublished,
+            prepublished: hasPrepublication ? isPrepublished : isPublished,
+          })
+
+          stats[indexType].added += inserts
+        })
+      },
+      { concurrency: 10 },
+    )
+
+    clearInterval(statsInterval)
+
+    console.log(indexName, stats)
+  },
+  after: () => {},
+  final: async ({ redis }) => createCache(redis).invalidate(),
+}

--- a/packages/search/lib/inserts/documentzone.js
+++ b/packages/search/lib/inserts/documentzone.js
@@ -35,10 +35,7 @@ module.exports = {
     const context = getContext({ pgdb, redis })
 
     const repos = await pgdb.publikator.repos.find(
-      {
-        // id: 'republik/pae-article-beitrag-mit-chart',
-        archivedAt: null,
-      },
+      { archivedAt: null },
       { orderBy: { updatedAt: 'desc' } },
     )
 

--- a/packages/search/lib/inserts/index.js
+++ b/packages/search/lib/inserts/index.js
@@ -7,7 +7,7 @@ const dict = {
 
 const list = []
 
-for (let key in dict) {
+for (const key in dict) {
   list.push(dict[key])
 }
 

--- a/packages/search/lib/inserts/index.js
+++ b/packages/search/lib/inserts/index.js
@@ -1,6 +1,7 @@
 const dict = {
   comment: require('./comment'),
   document: require('./document'),
+  documentzone: require('./documentzone'),
   repo: require('./repo'),
   user: require('./user'),
 }


### PR DESCRIPTION
This Pull Request indexes document zones and makes them somewhat searchable.

In this iteration, it only indexes zones with identifier `CHART`.

Zones are stringified – that is title, lead, credits –, and these strings are searchable.

New filters:
- `{ key: "type" value:"DocumentZone" }`: returns zones
- `{ key: "documentZoneIdentifier" value:"CHART" }`: returns all charts
- `{ key: "documentZoneDataType" value:"Bar" }`: returns all bar charts

Document zones are indexed upon publish.

(Search entity, aggregations)

![giphy](https://user-images.githubusercontent.com/331800/125633447-a107fc5d-2ffc-495e-b91d-9c6acc568e2f.gif)
