### PR TITLE
Mailbox queries, cookie SameSite=None and "pageini"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ packages/publikator/seeds/seeds.json
 .vim
 .idea/
 local
+data/
 
 # files generated from typescript
 packages/auth/index.js

--- a/packages/auth/express/auth.js
+++ b/packages/auth/express/auth.js
@@ -56,7 +56,7 @@ exports.configure = ({
       cookie: {
         domain,
         maxAge: maxAge,
-        sameSite: dev || 'none',
+        sameSite: !dev && 'none',
         secure: !dev,
       },
     }),

--- a/packages/auth/express/auth.js
+++ b/packages/auth/express/auth.js
@@ -56,6 +56,7 @@ exports.configure = ({
       cookie: {
         domain,
         maxAge: maxAge,
+        sameSite: dev || 'none',
         secure: !dev,
       },
     }),

--- a/packages/auth/loaders/User.ts
+++ b/packages/auth/loaders/User.ts
@@ -27,6 +27,16 @@ module.exports = (context: any) => {
         .find({ id: ids })
         .then((users) => users.map((u) => transformUser(u))),
     ),
+    byEmail: createDataLoader(
+      (emails: readonly string[]) =>
+        users.find({ email: emails }).then((users) => users.map(transformUser)),
+      null,
+      (key, rows) =>
+        rows.find((row) => {
+          if (!row) return
+          return row._raw.email.toLowerCase() === key.toLowerCase()
+        }),
+    ),
     byIdOrEmail: createDataLoader(
       async (values: readonly string[]) => {
         const ids = values.filter(isUuid)

--- a/packages/mailbox/README.md
+++ b/packages/mailbox/README.md
@@ -1,0 +1,92 @@
+# @orbiting/backend-modules-mailbox
+
+Query mailbox index and mailLog table at once
+
+## API
+
+### Queries
+
+- `mailbox`
+- `User.mailbox`
+
+Example
+
+```gql
+query recentMails {
+  mailbox {
+    nodes {
+      date
+      subject
+    }
+  }
+}
+```
+
+```gql
+query recentUserMails {
+  user(slug:"peter.parker") {
+    mailbox {
+      nodes {
+        date
+        subject
+      }
+    }
+  }
+}
+```
+
+### Arguments
+
+- `first`: Number, amount of nodes to return
+- (`last`: _not implemented_)
+- `before`: String, nodes before a cursor
+- `after`: String, nodes after a cursor
+- `filters.hasError`: Boolean, filter, only list nodes with mailing errors
+- `filters.email`: String, filter, only list nodes with specified email address
+
+Example:
+
+```gql
+query manyRecentEmails {
+  mailbox(first: 100, filters: { hasError: true }) {
+    totalCount
+    nodes {
+      date
+    }
+  }
+}
+```
+
+### Response
+
+Returns a `MailboxConnection`. Contains `totalCount`, `pageInfo` and `nodes` array.
+
+- `totalCount`: Number, total amount of nodes search yielded
+- `pageInfo.hasNextPage`: Boolean, indicates whether more nodes are available looking forward
+- `pageInfo.hasPreviousPage`: Boolean, indicates whether more nodes are available looking backward
+- `pageInfo.endCursor`: String, reference to last node in `nodes` array
+- `pageInfo.startCursor`: String, reference to first node in `nodes` array
+
+`nodes` array returns an array of `MailboxRecord`. It contains the following properties:
+
+- `id`: String, an identifier
+- `type`: String, type of email
+- `template`: String, name of template used (_mailLog_ only)
+- `date`: Date as ISO string, when email was sent
+- `status`: String, whether email was sent (_mailLog_ only)
+- `error`: String, whether an error occured while sending email (_mailLog_ only)
+- `from`: `MailboxAddress`, sender
+- `to`: Array of `MailboxAddress`, recipients
+- `cc`: Array of `MailboxAddress`, additional recipients
+- `bcc`: Array of `MailboxAddress`, hidden additional recipients
+- `subject`: String, email subject
+- `html`: String, email contents (`mailbox` only)
+- `links`: Array of `MailboxLink`, related links e.g. content on mandrill
+
+A `MailboxAddress` object contains following properties:
+
+- `id`: String, an identifer
+- `address`: String, an email address
+- `name`: String, a label e.g. "Peter Parker"
+- `user`: `User` retrievable via email address
+

--- a/packages/mailbox/graphql/index.js
+++ b/packages/mailbox/graphql/index.js
@@ -1,0 +1,3 @@
+const { loadModule, addTypes } = require('apollo-modules-node')
+const { graphql: scalars } = require('@orbiting/backend-modules-scalars')
+module.exports = addTypes(loadModule(__dirname), [scalars])

--- a/packages/mailbox/graphql/resolvers/MailboxAddress.js
+++ b/packages/mailbox/graphql/resolvers/MailboxAddress.js
@@ -1,6 +1,3 @@
 module.exports = {
-  user: ({ address }, args, { loaders }) => {
-    console.log(address)
-    return loaders.User.byEmail.load(address)
-  },
+  user: ({ address }, args, { loaders }) => loaders.User.byEmail.load(address),
 }

--- a/packages/mailbox/graphql/resolvers/MailboxAddress.js
+++ b/packages/mailbox/graphql/resolvers/MailboxAddress.js
@@ -1,0 +1,6 @@
+module.exports = {
+  user: ({ address }, args, { loaders }) => {
+    console.log(address)
+    return loaders.User.byEmail.load(address)
+  },
+}

--- a/packages/mailbox/graphql/resolvers/User.js
+++ b/packages/mailbox/graphql/resolvers/User.js
@@ -1,0 +1,13 @@
+const { Roles } = require('@orbiting/backend-modules-auth')
+
+const { getConnection } = require('../../lib/search')
+
+module.exports = {
+  async mailbox(user, args, { elastic, pgdb, user: me }) {
+    if (!Roles.userIsInRoles(me, ['admin', 'supporter'])) {
+      return null
+    }
+
+    return getConnection(user, args, { elastic, pgdb })
+  },
+}

--- a/packages/mailbox/graphql/resolvers/_queries/mailbox.js
+++ b/packages/mailbox/graphql/resolvers/_queries/mailbox.js
@@ -1,0 +1,9 @@
+const { Roles } = require('@orbiting/backend-modules-auth')
+
+const { getConnection } = require('../../../lib/search')
+
+module.exports = async (_, args, { elastic, pgdb, user: me }) => {
+  Roles.ensureUserIsInRoles(me, ['admin', 'supporter'])
+
+  return getConnection(undefined, args, { elastic, pgdb })
+}

--- a/packages/mailbox/graphql/schema-types.js
+++ b/packages/mailbox/graphql/schema-types.js
@@ -1,0 +1,61 @@
+module.exports = `
+
+input MailboxFiltersInput {
+  hasError: Boolean
+  email: String
+}
+
+type MailboxRecord {
+  id: ID!
+  type: String
+  template: String
+  date: DateTime!
+  status: String
+  error: String
+  from: MailboxAddress
+  to: [MailboxAddress!]
+  cc: [MailboxAddress!]
+  bcc: [MailboxAddress!]
+  subject: String
+  html: String
+  links: [MailboxLink!]
+}
+
+type MailboxAddress {
+  id: ID!
+  address: String!
+  name: String
+  user: User
+}
+
+type MailboxLink {
+  id: ID!
+  type: String!
+  label: String!
+  url: String!
+}
+
+type MailboxConnection {
+  totalCount: Int!
+  pageInfo: MailboxPageInfo!
+  nodes: [MailboxRecord!]!
+}
+
+type MailboxPageInfo {
+  hasNextPage: Boolean!
+  endCursor: String
+  hasPreviousPage: Boolean!
+  startCursor: String
+}
+
+extend type User {
+  mailbox(
+    first: Int
+    last: Int
+    before: String
+    after: String
+    filters: MailboxFiltersInput
+  ): MailboxConnection
+}
+
+`

--- a/packages/mailbox/graphql/schema.js
+++ b/packages/mailbox/graphql/schema.js
@@ -1,0 +1,17 @@
+module.exports = `
+
+schema {
+  query: queries
+}
+
+type queries {
+  mailbox(
+    first: Int
+    last: Int
+    before: String
+    after: String
+    filters: MailboxFiltersInput
+  ): MailboxConnection
+}
+
+`

--- a/packages/mailbox/index.js
+++ b/packages/mailbox/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  graphql: require('./graphql'),
+}

--- a/packages/mailbox/lib/common.js
+++ b/packages/mailbox/lib/common.js
@@ -1,0 +1,13 @@
+const getAddress = ({ name, address }) => ({
+  id: address,
+  address,
+  name,
+})
+
+const getAddresses = (values) =>
+  values?.filter(({ address }) => !!address).map(getAddress)
+
+module.exports = {
+  getAddress,
+  getAddresses,
+}

--- a/packages/mailbox/lib/index.js
+++ b/packages/mailbox/lib/index.js
@@ -1,0 +1,40 @@
+/**
+ * Helper functions to walk mailbox backup directory, read files and check
+ * messages.
+ */
+
+const klaw = require('klaw')
+const fse = require('fs-extra')
+const path = require('path')
+
+const PATH = './data/mailbox'
+
+const createFilesIterator = async () => {
+  try {
+    const stat = await fse.stat(PATH)
+
+    if (!stat.isDirectory()) {
+      throw new Error(`${PATH} is not a directory`)
+    }
+
+    return klaw(PATH)
+  } catch (e) {
+    console.warn(e.message)
+  }
+}
+
+const maybeReadMessage = async (filePath) => {
+  if (path.basename(filePath) === 'message.json') {
+    const message = await fse.readJSON(filePath)
+    const { headerLines, ...rest } = message
+
+    return rest
+  }
+
+  return false
+}
+
+module.exports = {
+  createFilesIterator,
+  maybeReadMessage,
+}

--- a/packages/mailbox/lib/mailbox.js
+++ b/packages/mailbox/lib/mailbox.js
@@ -1,0 +1,138 @@
+/**
+ * Set of function to handle queries to mailbox index in ElasticSearch
+ */
+const { getIndexAlias } = require('@orbiting/backend-modules-search/lib/utils')
+const { getAddress, getAddresses } = require('./common')
+
+const replaceCharset = (string) =>
+  string.replace(/charset=([A-Za-z0-9-]+)/g, 'charset=utf-8')
+
+const toHtml = (text) => `
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body style="font-family: monospace, monospace;">
+  ${text.replace(/\n/g, '<br>')}
+</body>
+</html>
+`
+
+const toBase64 = (string) => Buffer.from(string).toString('base64')
+
+const createShouldEmail = (email) => ({
+  bool: {
+    should: [
+      // in
+      { term: { 'from.value.address.keyword': email } },
+      // out
+      { term: { 'to.value.address.keyword': email } },
+      { term: { 'cc.value.address.keyword': email } },
+      { term: { 'bcc.value.address.keyword': email } },
+    ],
+  },
+})
+
+const createMustNotMatchAll = () => ({
+  bool: {
+    must_not: { match_all: {} },
+  },
+})
+
+const createQuery = ({ user = {}, filters = {} }, { after, before } = {}) => {
+  const sort =
+    (after?.date && { range: { date: { lt: after.date } } }) ||
+    (before?.date && { range: { date: { gt: before.date } } })
+
+  const mustUserEmail = user?.email && createShouldEmail(user.email)
+  const mustHaveError = filters?.hasError && createMustNotMatchAll()
+  const mustEmail = filters?.email && createShouldEmail(filters.email)
+
+  return {
+    bool: {
+      must: [sort, mustUserEmail, mustHaveError, mustEmail].filter(Boolean),
+    },
+  }
+}
+
+const createSort = ({ after, before }) => [
+  { date: (after && 'desc') || (before && 'asc') || 'desc' },
+]
+
+const toRecords = ({ _id, _source }) => ({
+  id: _id,
+  type: 'mailbox',
+  template: null,
+  date: _source.date,
+  status: 'sent',
+  error: null,
+  from: getAddress(_source.from?.value?.[0]),
+  to: getAddresses(_source.to?.value),
+  cc: getAddresses(_source.cc?.value),
+  bcc: getAddresses(_source.bcc?.value),
+  subject: _source.subject,
+  html:
+    (_source.html && toBase64(replaceCharset(_source.html))) ||
+    (_source.text && toBase64(toHtml(_source.text))),
+  links: null,
+})
+
+const count = async ({ user, filters }, elastic) => {
+  try {
+    const { statusCode, body } = await elastic.search({
+      index: getIndexAlias('mail', 'read'),
+      body: {
+        size: 0,
+        track_total_hits: true,
+        query: createQuery({ user, filters }),
+      },
+    })
+
+    const total = (statusCode === 200 && body.hits.total) || 0
+    const count = Number.isFinite(total.value) ? total.value : total
+
+    return count
+  } catch (e) {
+    console.warn(e.message)
+  }
+
+  return 0
+}
+
+const find = async ({ user, size, filters }, { after, before }, elastic) => {
+  try {
+    const { statusCode, body } = await elastic.search({
+      index: getIndexAlias('mail', 'read'),
+      body: {
+        size,
+        query: createQuery({ user, filters }, { after, before }),
+        sort: createSort({ after, before }),
+        _source: [
+          'html',
+          'text',
+          'subject',
+          'date',
+          'from.value',
+          'to.value',
+          'cc.value',
+          'bcc.value',
+        ],
+      },
+    })
+
+    if (statusCode !== 200) {
+      throw Error('query failed')
+    }
+
+    return body.hits.hits.map(toRecords)
+  } catch (e) {
+    console.warn(e.message)
+  }
+
+  return []
+}
+
+module.exports = {
+  count,
+  find,
+}

--- a/packages/mailbox/lib/maillog.js
+++ b/packages/mailbox/lib/maillog.js
@@ -1,0 +1,136 @@
+/**
+ * Set of function to handle queries to mailLob table in Postgres
+ */
+const moment = require('moment')
+
+const { getAddress, getAddresses } = require('./common')
+
+const getStatus = (row) =>
+  row.mandrillLastEvent?.msg?.state ||
+  row.result?.status ||
+  row.status?.toLowerCase()
+
+const getError = (row) =>
+  row.mandrillLastEvent?.msg?.diag ||
+  row.mandrillLastEvent?.msg?.bounce_description ||
+  row.result?.reject_reason ||
+  row.result?.error ||
+  row.error?.message ||
+  row.error?.meta?.error?.type ||
+  row.error?.meta?.response
+
+const getLinks = (row) => {
+  return [
+    row.createdAt > moment().subtract(30, 'days') &&
+      row.result &&
+      row.result._id && {
+        id: row.result._id,
+        label: 'Content on Mandrill',
+        url: [
+          'https://mandrillapp.com/activity/content?id=',
+          moment(row.createdAt).format('YYYYMMDD'),
+          '_',
+          row.result._id,
+        ].join(''),
+      },
+  ].filter(Boolean)
+}
+
+const createCondition = (
+  { user = {}, filters = {} },
+  { after, before } = {},
+) => {
+  const sort =
+    (after?.date && { 'createdAt <': after.date }) ||
+    (before?.date && { 'createdAt >': before.date }) ||
+    {}
+
+  const mustUserIdOrEmail = user?.id &&
+    user?.email && {
+      or: [{ userId: user.id }, { userId: null, email: user.email }],
+    }
+
+  const mustHaveError = filters?.hasError && {
+    or: [
+      { "\"mandrillLastEvent\"->'msg'->>'diag' !=": null },
+      { "\"mandrillLastEvent\"->'msg'->>'bounce_description' !=": null },
+      { "result->>'reject_reason' !=": null },
+      { "result->>'error' !=": null },
+      { "error->>'message' !=": null },
+      { "error->'meta'->'error'->>'type' !=": null },
+      { "error->'meta'->>'response' !=": null },
+    ],
+  }
+
+  const mustEmail = filters?.email && { email: filters.email }
+
+  const and = [mustUserIdOrEmail, mustHaveError, mustEmail].filter(Boolean)
+
+  return {
+    ...sort,
+    and,
+  }
+}
+
+const createOrderBy = ({ after, before }) => ({
+  createdAt: (after && 'desc') || (before && 'asc') || 'desc',
+})
+
+const toRecords = (row) => {
+  const message = row.info?.message
+
+  return {
+    id: row.id,
+    type: row.type,
+    template: row.info?.template,
+    date: row.createdAt.toISOString(),
+    status: getStatus(row),
+    error: getError(row),
+    from:
+      message &&
+      getAddress({
+        name: message.from_name,
+        address: message.from_email,
+      }),
+    to: row.email && getAddresses([{ address: row.email }]),
+    cc: null,
+    bcc: null,
+    html: null,
+    subject: message?.subject,
+    links: getLinks(row),
+  }
+}
+
+const count = async ({ user, filters }, pgdb) => {
+  try {
+    const count = await pgdb.public.mailLog.count(
+      createCondition({ user, filters }),
+    )
+
+    return count
+  } catch (e) {
+    console.warn(e.message)
+  }
+
+  return 0
+}
+
+const find = async ({ user, size, filters }, { after, before }, pgdb) => {
+  try {
+    const nodes = await pgdb.public.mailLog.find(
+      createCondition({ user, filters }, { after, before }),
+      { orderBy: createOrderBy({ after, before }), limit: size },
+    )
+
+    return nodes.map(toRecords)
+  } catch (e) {
+    console.warn(e.message)
+  }
+
+  return []
+}
+
+module.exports = {
+  count,
+  find,
+}

--- a/packages/mailbox/lib/search.js
+++ b/packages/mailbox/lib/search.js
@@ -1,0 +1,81 @@
+/**
+ * Lib to search mailbox and mailLog
+ */
+const {
+  paginate: { pageini },
+} = require('@orbiting/backend-modules-utils')
+
+const { descending } = require('d3-array')
+const Promise = require('bluebird')
+
+const mailbox = require('./mailbox')
+const maillog = require('./maillog')
+
+/**
+ * Returns a "connection" object with data nodes, pagination info and total
+ * count of nodes
+ */
+const getConnection = (user, args, { elastic, pgdb }) => {
+  const countFn = async (args) => {
+    const { after, before } = args
+
+    const filters = after?.filters || before?.filters || args.filters || {}
+
+    const counts = await Promise.all([
+      mailbox.count({ user, filters }, elastic),
+      maillog.count({ user, filters }, pgdb),
+    ])
+
+    return counts.reduce((acc, count) => acc + count, 0)
+  }
+
+  const nodesFn = async (args) => {
+    const { after, before } = args
+
+    const size = after?.first || before?.first || args.first || 10
+    const filters = after?.filters || before?.filters || args.filters || {}
+
+    const nodes = await Promise.all([
+      await mailbox.find({ user, size, filters }, { after, before }, elastic),
+      await maillog.find({ user, size, filters }, { after, before }, pgdb),
+    ])
+
+    return nodes
+      .flat()
+      .sort((a, b) => descending(a.date, b.date))
+      .slice(0, size)
+  }
+
+  const pageInfoFn = (args, payload) => {
+    const { after, before } = args
+    const { nodes } = payload
+
+    const first = after?.first || before?.first || args.first || 10
+    const count =
+      (after?.count && after.count + nodes.length) ||
+      (before?.count && before.count - nodes.length) ||
+      nodes.length
+
+    if (!nodes.length) {
+      return {
+        hasNextPage: false,
+        end: null,
+        hasPreviousPage: false,
+        start: null,
+      }
+    }
+
+    return {
+      hasNextPage: count < payload.totalCount,
+      end: { first, date: nodes[nodes.length - 1].date, count },
+      hasPreviousPage: count > first,
+      start: { first, date: nodes[0].date, count },
+    }
+  }
+
+  return pageini(args, countFn, nodesFn, pageInfoFn)
+}
+
+module.exports = {
+  getConnection,
+}

--- a/packages/mailbox/package.json
+++ b/packages/mailbox/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@orbiting/backend-modules-mailbox",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Query mailbox and maillog data at once",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/orbiting/backends.git"
+  },
+  "author": "Patrick Venetz <patrick.venetz@republik.ch>",
+  "license": "AGPL-3.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/orbiting/backends/issues"
+  },
+  "homepage": "https://github.com/orbiting/backends#readme",
+  "dependencies": {
+    "bluebird": "^3.7.2",
+    "body-parser": "^1.19.0",
+    "debug": "^4.1.1",
+    "fs-extra": "^10.0.0",
+    "imapflow": "^1.0.66",
+    "klaw": "^3.0.0",
+    "mailparser": "^3.2.0",
+    "moment": "^2.26.0"
+  }
+}

--- a/packages/maillog/graphql/schema-types.js
+++ b/packages/maillog/graphql/schema-types.js
@@ -43,7 +43,7 @@ extend type User {
     before: String
     after: String
     filters: MaiLogFiltersInput
-  ): MailLogConnection
+  ): MailLogConnection @deprecated(reason: "use query \`User.mailbox\` instead")
 }
 
 `

--- a/packages/maillog/graphql/schema.js
+++ b/packages/maillog/graphql/schema.js
@@ -11,7 +11,7 @@ type queries {
     before: String
     after: String
     filters: MaiLogFiltersInput
-  ): MailLogConnection
+  ): MailLogConnection @deprecated(reason: "use query \`mailbox\` instead")
 }
 
 `

--- a/packages/search/lib/indices/index.js
+++ b/packages/search/lib/indices/index.js
@@ -2,6 +2,7 @@ const dict = {
   comments: require('./comments'),
   documents: require('./documents'),
   documentzones: require('./documentzones'),
+  mails: require('./mails'),
   users: require('./users'),
   repos: require('./repos'),
 }

--- a/packages/search/lib/indices/mails.js
+++ b/packages/search/lib/indices/mails.js
@@ -1,0 +1,42 @@
+const type = 'Mail'
+
+const address = {
+  properties: {
+    value: {
+      properties: {
+        address: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              ignore_above: 256,
+              normalizer: 'lowercase',
+            },
+          },
+        },
+        name: {
+          type: 'text',
+          analyzer: 'german',
+        },
+      },
+    },
+  },
+}
+
+module.exports = {
+  type,
+  name: type.toLowerCase(),
+  searchable: false,
+  mapping: {
+    [type]: {
+      dynamic: false,
+      properties: {
+        date: { type: 'date' },
+        from: { ...address },
+        to: { ...address },
+        cc: { ...address },
+        bcc: { ...address },
+      },
+    },
+  },
+}

--- a/packages/search/lib/inserts/index.js
+++ b/packages/search/lib/inserts/index.js
@@ -2,6 +2,7 @@ const dict = {
   comment: require('./comment'),
   document: require('./document'),
   documentzone: require('./documentzone'),
+  mail: require('./mail'),
   repo: require('./repo'),
   user: require('./user'),
 }

--- a/packages/search/lib/inserts/mail.js
+++ b/packages/search/lib/inserts/mail.js
@@ -1,0 +1,64 @@
+const {
+  createFilesIterator,
+  maybeReadMessage,
+} = require('@orbiting/backend-modules-mailbox/lib/index')
+
+const BULK_SIZE = 500
+
+module.exports = {
+  before: () => {},
+  insert: async ({ indexName, type: indexType, elastic, pgdb, redis }) => {
+    const stats = { [indexType]: { added: 0, total: 0 } }
+    const statsInterval = setInterval(() => {
+      console.log(indexName, stats)
+    }, 1 * 1000)
+
+    const bulkInsert = async (dataset) => {
+      await elastic.bulk({
+        body: Array.from(dataset).flatMap((doc) => [
+          { index: { _index: indexName, _type: indexType, _id: doc.id } },
+          doc,
+        ]),
+      })
+    }
+
+    try {
+      const files = await createFilesIterator()
+
+      if (files) {
+        const dataset = new Set()
+
+        for await (const file of files) {
+          const message = await maybeReadMessage(file.path)
+
+          // Skip if message is not a valid email
+          if (!message) {
+            continue
+          }
+
+          dataset.add(message)
+
+          // Insert if we have enough data
+          if (dataset.size >= BULK_SIZE) {
+            await bulkInsert(dataset)
+            stats[indexType].added += dataset.size
+            dataset.clear()
+          }
+        }
+
+        // Last batch
+        if (dataset.size) {
+          await bulkInsert(dataset)
+          stats[indexType].added += dataset.size
+        }
+      }
+    } catch (e) {
+      console.warn(e)
+    }
+
+    clearInterval(statsInterval)
+    console.log(indexName, stats)
+  },
+  after: () => {},
+  final: () => {},
+}

--- a/packages/utils/paginate.js
+++ b/packages/utils/paginate.js
@@ -119,6 +119,30 @@ module.exports.paginator = (args, payloadFn, nodesFn) => {
   }
 }
 
+/**
+ * Util which helps generating an GraphQL Cursor Connection. It allows to
+ * pagination results.
+ *
+ * @see https://relay.dev/graphql/connections.htm
+ *
+ * This util implementation is somewhat superior to previous pagination
+ * implementation ("paginate", "paginator") as it won't require all data and
+ * then slice it.
+ *
+ * Flow:
+ *
+ * 1) Decode after and before cursors in {args}
+ *
+ * 2) Call {countFn} with {args}, after and before cursors. Its expected to
+ *    return total count of nodes.
+ *
+ * 3) Call {nodesFn} with {args}, after and before cursors and total count. Its
+ *    expected to return (sliced) nodes using provided arguments: a page.
+ *
+ * 4) Call {pageInfoFn} with {args}, cursors, total count and nodes. Its
+ *    expected to return whether there is a next or previous page to "pagniate"
+ *    to. Its expected to return start and end cursor.
+ */
 module.exports.pageini = async (args, countFn, nodesFn, pageInfoFn) => {
   const { after: _after, before: _before } = args
 

--- a/packages/utils/paginate.js
+++ b/packages/utils/paginate.js
@@ -118,3 +118,30 @@ module.exports.paginator = (args, payloadFn, nodesFn) => {
     _nodes: nodes,
   }
 }
+
+module.exports.pageini = async (args, countFn, nodesFn, pageInfoFn) => {
+  const { after: _after, before: _before } = args
+
+  const after = _after && base64toObject(_after)
+  const before = _before && base64toObject(_before)
+
+  const totalCount = (await countFn({ ...args, after, before })) || 0
+  const nodes =
+    (await nodesFn({ ...args, after, before }, { totalCount })) || []
+  const { hasNextPage, end, hasPreviousPage, start } =
+    (await pageInfoFn({ ...args, after, before }, { totalCount, nodes })) || {}
+
+  const startCursor = start && objectToBase64(start)
+  const endCursor = end && objectToBase64(end)
+
+  return {
+    pageInfo: {
+      hasNextPage,
+      endCursor,
+      hasPreviousPage,
+      startCursor,
+    },
+    totalCount,
+    nodes,
+  }
+}

--- a/servers/graphql/server.js
+++ b/servers/graphql/server.js
@@ -31,6 +31,7 @@ const { graphql: cards } = require('@orbiting/backend-modules-cards')
 const { graphql: maillog } = require('@orbiting/backend-modules-maillog')
 const { graphql: embeds } = require('@orbiting/backend-modules-embeds')
 const { graphql: gsheets } = require('@orbiting/backend-modules-gsheets')
+const { graphql: mailbox } = require('@orbiting/backend-modules-mailbox')
 
 const loaderBuilders = {
   ...require('@orbiting/backend-modules-voting/loaders'),
@@ -112,6 +113,7 @@ const run = async (workerId, config) => {
     maillog,
     embeds,
     gsheets,
+    mailbox,
   ])
 
   // middlewares

--- a/yarn.lock
+++ b/yarn.lock
@@ -2713,6 +2713,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
+
 autolinker@^3.14.1:
   version "3.14.3"
   resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-3.14.3.tgz#c61c424bc6077bcf2fc62803803ec2f58e15a7ec"
@@ -4920,6 +4925,11 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encoding-japanese@1.0.30:
+  version "1.0.30"
+  resolved "https://registry.yarnpkg.com/encoding-japanese/-/encoding-japanese-1.0.30.tgz#537c4d62881767925d601acb4c79fb14db81703a"
+  integrity sha512-bd/DFLAoJetvv7ar/KIpE3CNO8wEuyrt9Xuw6nSMiZ+Vrz/Q21BPsMHvARL2Wz6IKHKXgb+DWZqtRg1vql9cBg==
+
 encoding@^0.1.11:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
@@ -5622,6 +5632,16 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-redact@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.0.1.tgz#d6015b971e933d03529b01333ba7f22c29961e92"
+  integrity sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw==
+
+fast-safe-stringify@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz#dc2af48c46cf712b683e849b2bbd446b32de936f"
+  integrity sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==
+
 fast-text-encoding@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
@@ -5875,6 +5895,11 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
+flatstr@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
+  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
+
 flatted@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
@@ -6031,6 +6056,15 @@ fs-extra@8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -6459,7 +6493,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -6705,7 +6739,7 @@ hash-stream-validation@^0.2.2:
   resolved "https://registry.yarnpkg.com/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz#ee68b41bf822f7f44db1142ec28ba9ee7ccb7512"
   integrity sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ==
 
-he@^1.2.0:
+he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -6795,6 +6829,16 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+html-to-text@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-7.0.0.tgz#97ff0bcf34241c282f78f5c1baa05dfa44d9d3c3"
+  integrity sha512-UR/WMSHRN8m+L7qQUhbSoxylwBovNPS+xURn/pHeJvbnemhyMiuPYBTBGqB6s8ajAARN5jzKfF0d3CY86VANpA==
+  dependencies:
+    deepmerge "^4.2.2"
+    he "^1.2.0"
+    htmlparser2 "^6.0.0"
+    minimist "^1.2.5"
+
 html-to-text@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-7.1.1.tgz#69de8d85b91646b4bc14fdf4f850e9e046efff15"
@@ -6805,7 +6849,7 @@ html-to-text@^7.1.1:
     htmlparser2 "^6.1.0"
     minimist "^1.2.5"
 
-htmlparser2@^6.1.0:
+htmlparser2@^6.0.0, htmlparser2@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
   integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
@@ -6950,10 +6994,17 @@ iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.2:
+iconv-lite@0.6.2, iconv-lite@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
   integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
@@ -6986,6 +7037,19 @@ ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+imapflow@^1.0.66:
+  version "1.0.66"
+  resolved "https://registry.yarnpkg.com/imapflow/-/imapflow-1.0.66.tgz#dcb3d6473191eb106ba5deffe4d93da8aad3fb98"
+  integrity sha512-WS3c3gsi1+tEl9mHSK71AqBlw8FkQ3MMGraTWHZMGArlHDXUbY2Sk7SzhdRc91TYevkORHgLEEy+ZLFOFknETA==
+  dependencies:
+    encoding-japanese "1.0.30"
+    iconv-lite "0.6.3"
+    libbase64 "1.2.1"
+    libmime "5.0.0"
+    libqp "1.1.0"
+    mailsplit "5.0.1"
+    pino "6.13.0"
 
 immutable@~3.7.6:
   version "3.7.6"
@@ -8262,6 +8326,15 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -8358,6 +8431,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
+  integrity sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==
+  dependencies:
+    graceful-fs "^4.1.9"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -8401,10 +8481,30 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+libbase64@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/libbase64/-/libbase64-1.2.1.tgz#fb93bf4cb6d730f29b92155b6408d1bd2176a8c8"
+  integrity sha512-l+nePcPbIG1fNlqMzrh68MLkX/gTxk/+vdvAb388Ssi7UuUN31MI44w4Yf33mM3Cm4xDfw48mdf3rkdHszLNew==
+
+libmime@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/libmime/-/libmime-5.0.0.tgz#4759c76eb219985c5d4057b3a9359922194d9ff7"
+  integrity sha512-2Bm96d5ktnE217Ib1FldvUaPAaOst6GtZrsxJCwnJgi9lnsoAKIHyU0sae8rNx6DNYbjdqqh8lv5/b9poD8qOg==
+  dependencies:
+    encoding-japanese "1.0.30"
+    iconv-lite "0.6.2"
+    libbase64 "1.2.1"
+    libqp "1.1.0"
+
 libphonenumber-js@^1.7.52:
   version "1.9.17"
   resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.17.tgz#fef2e6fd7a981be69ba358c24495725ee8daf331"
   integrity sha512-ElJki901OynMg1l+evooPH1VyHrECuLqpgc12z2BkK25dFU5lUKTuMHEYV2jXxvtns/PIuJax56cBeoSK7ANow==
+
+libqp@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/libqp/-/libqp-1.1.0.tgz#f5e6e06ad74b794fb5b5b66988bf728ef1dedbe8"
+  integrity sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=
 
 linebreak@^1.0.2:
   version "1.0.2"
@@ -8419,6 +8519,13 @@ lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+linkify-it@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
+  integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
+  dependencies:
+    uc.micro "^1.0.1"
 
 lint-staged@^10.2.9:
   version "10.5.4"
@@ -8696,6 +8803,30 @@ magic-string@0.25.1:
   integrity sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==
   dependencies:
     sourcemap-codec "^1.4.1"
+
+mailparser@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mailparser/-/mailparser-3.2.0.tgz#cb0c4794590ba491ba2c920669ed72e472e51531"
+  integrity sha512-UpAC45oeYjp4Aa/z7XuG+PpElI+pkHpuomGcSeL1zH8gEo7anqoFY0X58ZHf0CdQIpFzp2qCPa5h905VDVUUgQ==
+  dependencies:
+    encoding-japanese "1.0.30"
+    he "1.2.0"
+    html-to-text "7.0.0"
+    iconv-lite "0.6.2"
+    libmime "5.0.0"
+    linkify-it "3.0.2"
+    mailsplit "5.0.1"
+    nodemailer "6.5.0"
+    tlds "1.219.0"
+
+mailsplit@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mailsplit/-/mailsplit-5.0.1.tgz#070bd883bddc0c6c7f5c6ea4a54847729d95dc6f"
+  integrity sha512-CcGy1sv8j9jdjKiNIuMZYIKhq4s47nUj9Q98BZfptabH/whmiQX7EvrHx36O4DcyPEsnG152GVNyvqPi9FNIew==
+  dependencies:
+    libbase64 "1.2.1"
+    libmime "5.0.0"
+    libqp "1.1.0"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -9169,6 +9300,11 @@ node-releases@^1.1.71:
   version "1.1.71"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
+
+nodemailer@6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.5.0.tgz#d12c28d8d48778918e25f1999d97910231b175d9"
+  integrity sha512-Tm4RPrrIZbnqDKAvX+/4M+zovEReiKlEXWDzG4iwtpL9X34MJY+D5LnQPH/+eghe8DLlAVshHAJZAZWBGhkguw==
 
 nodemailer@^6.4.8:
   version "6.6.0"
@@ -9903,6 +10039,23 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pino-std-serializers@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz#b56487c402d882eb96cd67c257868016b61ad671"
+  integrity sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==
+
+pino@6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.13.0.tgz#41810b9be213af6f8f7c23a1b17058d880267e7b"
+  integrity sha512-mRXSTfa34tbfrWqCIp1sUpZLqBhcoaGapoyxfEwaWwJGMpLijlRdDKIQUyvq4M3DUfFH5vEglwSw8POZYwbThA==
+  dependencies:
+    fast-redact "^3.0.0"
+    fast-safe-stringify "^2.0.8"
+    flatstr "^1.0.12"
+    pino-std-serializers "^3.1.0"
+    quick-format-unescaped "^4.0.3"
+    sonic-boom "^1.0.2"
+
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -10288,6 +10441,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+quick-format-unescaped@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz#6d6b66b8207aa2b35eef12be1421bb24c428f652"
+  integrity sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==
 
 quote-stream@^1.0.1:
   version "1.0.2"
@@ -11376,6 +11534,14 @@ snoowrap@^1.21.0:
     request-promise "^4.2.6"
     ws "^3.3.1"
 
+sonic-boom@^1.0.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-1.4.1.tgz#d35d6a74076624f12e6f917ade7b9d75e918f53e"
+  integrity sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    flatstr "^1.0.12"
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -12088,6 +12254,11 @@ tiny-lru@7.0.6:
   resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
   integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
 
+tlds@1.219.0:
+  version "1.219.0"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.219.0.tgz#7e636062386a1f3c9184356de93d40842ffe91d9"
+  integrity sha512-o4g9c8kXCmTDwUnK/9HpTT9o/GNH85KCvs+S5SgUw5yILdECvMmTGzK7ngoWMp97P5tfYr8fZeF16YhgV/l90A==
+
 tlds@^1.217.0:
   version "1.221.1"
   resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.221.1.tgz#6cf6bff5eaf30c5618c5801c3f425a6dc61ca0ad"
@@ -12429,6 +12600,11 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
+uc.micro@^1.0.1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
 uglify-js@^3.1.4:
   version "3.13.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.9.tgz#4d8d21dcd497f29cfd8e9378b9df123ad025999b"
@@ -12620,6 +12796,11 @@ universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unixify@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This Pull Request adds [`mailbox` queries to root and `User.mailbox`](https://github.com/orbiting/backends/compare/pae/feat-zat?expand=1#diff-69df5e7dfca0bc0e0a1ef244a5233a9571ec27938974adbf1ee28238159cbf83) to query (new) mail index and `mailLog` table at once and thus [deprecating `mailLog` queries](https://github.com/orbiting/backends/compare/pae/feat-zat?expand=1#diff-b941647b52246b2ad69ba7b26189886545bea78af20782344e25adcbc6e7992f).

It changes [session cookie attribute `SameSite` to `None`](https://github.com/orbiting/backends/compare/pae/feat-zat?expand=1#diff-192366cb64dcd51bed8ffd63a9aaddc48d8fee59d907daa1e7f553ed9bc0abc2) if not in production. (This might pose an inadvertent security risk and we've to dig into that one deeper.)

It implements a [new pagination approach ("pageini")](https://github.com/orbiting/backends/compare/pae/feat-zat?expand=1#diff-46877d066b4f0b57ea3b90b1c5b4518946152680f44878f245c8c0e1833b6b11): more generic, memory friendly way