### PR TITLE
Feat election candidacy

### DIFF
--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.html
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.html
@@ -57,18 +57,19 @@
                     </p>
                     <p>
                       Bis zum 29. Oktober
-                      <a href="{{frontend_base_url}}/vote/2021/kandidieren?edit"
-                        >können Sie Ihre Angaben ändern oder ergänzen</a
-                      >, falls Ihnen noch etwas einfallen sollte.
+                      <a
+                        href="{{frontend_base_url}}/vote/2021/kandidieren?edit=true"
+                        >können Sie Ihre Angaben ändern</a
+                      >, falls Sie das wünschen.
                     </p>
                     <p>
                       Die Wahl selbst dauert vom 12. bis zum 28. November.
                       Zeitgleich zur Wahl findet eine Online-Debatte statt. Dort
                       wird Ihr Statement in Ihrem Namen veröffentlicht. Während
-                      dieser Zeit können die Mitglieder Ihnen Fragen stellen.
-                      Wir freuen uns, wenn Sie in der Debatte präsent sind. Und
-                      wenn Sie sich für die eine oder andere Antwort Zeit
-                      nehmen.
+                      der Dauer der Wahl können die Mitglieder Ihnen Fragen
+                      stellen und Sie so ein bisschen besser kennenlernen. Wir
+                      freuen uns, wenn Sie in der Debatte präsent sind. Und wenn
+                      Sie sich für die eine oder andere Antwort Zeit nehmen.
                     </p>
                     <p>
                       Wir werden die Debatte moderieren und dafür sorgen, dass

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.html
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!--[if gte mso 15]>
+      <xml>
+        <o:officedocumentsettings>
+          <o:allowpng />
+          <o:pixelsperinch>96</o:pixelsperinch>
+        </o:officedocumentsettings>
+      </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table
+              align="center"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              width="100%"
+              style="max-width:640px;color:#444;font-size:18px;{{sg_font_style_sans_serif_regular}}"
+            >
+              <tbody>
+                <tr>
+                  <td style="padding: 20px">
+                    <p>Guten Tag</p>
+                    <p>
+                      Herzlichen Dank für die Einreichung Ihrer Kandidatur für
+                      den Genossenschaftsrat.
+                    </p>
+                    <p>Herzlich</p>
+                    <p>Ihre Crew der Republik</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 20px">
+                    <p
+                      style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <img
+                        height="79"
+                        src="{{frontend_base_url}}/static/logo_republik_newsletter.png"
+                        style="
+                          border: 0px;
+                          width: 180px !important;
+                          height: 79px !important;
+                          margin: 0px;
+                        "
+                        width="180"
+                        alt=""
+                      />
+                      <br />
+                      Republik AG<br />
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br />
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.html
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.html
@@ -41,20 +41,79 @@
               <tbody>
                 <tr>
                   <td style="padding: 20px">
-                    <p>Guten Tag</p>
                     <p>
-                      Herzlichen Dank für die Einreichung Ihrer Kandidatur für
-                      den Genossenschaftsrat.
+                      Sehr geehrte Verlegerin<br />
+                      sehr geehrter Verleger
                     </p>
-                    <p>Herzlich</p>
-                    <p>Ihre Crew der Republik</p>
+                    <p>
+                      Vielen Dank für Ihr Engagement und herzlichen Glückwunsch:
+                      Sie sind offiziell Kandidatin oder Kandidat für den
+                      Genossenschaftsrat von Project R und Republik.
+                    </p>
+                    <p>
+                      Zu Ihrer Information: Alle notwendigen Angaben haben wir
+                      erfasst.
+                    </p>
+                    <p>
+                      Bis zum 30. Oktober
+                      <a
+                        href="{{frontend_base_url}}/vote/genossenschaft/kandidieren?edit"
+                        >können Sie Ihre Angaben ändern oder ergänzen</a
+                      >, falls Ihnen noch etwas einfallen sollte.
+                    </p>
+                    <p>
+                      Die Wahl selbst dauert vom 12. bis zum 28. November.
+                      Zeitgleich zur Wahl findet eine Online-Debatte statt. Dort
+                      wird Ihr Statement in Ihrem Namen veröffentlicht. Während
+                      dieser Zeit können die Mitglieder Ihnen Fragen stellen.
+                      Wir freuen uns, wenn Sie in der Debatte präsent sind. Und
+                      wenn Sie sich für die eine oder andere Antwort Zeit
+                      nehmen.
+                    </p>
+                    <p>
+                      Wir werden die Debatte moderieren und dafür sorgen, dass
+                      <a href="{{frontend_base_url}}/etikette"
+                        >unsere Etikette</a
+                      >
+                      eingehalten wird.
+                    </p>
+                    <p>
+                      Das Resultat der Wahl geben wir anfangs Dezember in einem
+                      Project-R-Newsletter bekannt.
+                    </p>
+                    <p>
+                      Wir wünschen Ihnen viel Erfolg und freuen uns auf eine
+                      interessante Wahl.
+                    </p>
+                    <p>Ihre Crew von Project R und Republik</p>
                   </td>
                 </tr>
                 <tr>
                   <td style="padding: 20px">
-                    <p
-                      style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
-                    >
+                    <p style="font-size: 14px; line-height: 20px">
+                      <img
+                        src="https://assets.project-r.construction/images/project_r_logo_newsletter.png"
+                        style="
+                          border: 0px;
+                          width: 50px !important ;
+                          height: 50px !important ;
+                          margin: 0px;
+                        "
+                        width="50"
+                        height="50"
+                        alt="Project R Genossenschaft Logo"
+                      />
+                      <br />
+                      <br />
+                      Project R Genossenschaft<br />
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      <a href="{{link_projectr}}">www.project-r.construction</a
+                      ><br />
+                      <a href="mailto:office@project-r.construction"
+                        >office@project-r.construction</a
+                      >
+                    </p>
+                    <p style="font-size: 14px; line-height: 20px">
                       <img
                         height="79"
                         src="{{frontend_base_url}}/static/logo_republik_newsletter.png"
@@ -65,7 +124,7 @@
                           margin: 0px;
                         "
                         width="180"
-                        alt=""
+                        alt="Republik AG Logo"
                       />
                       <br />
                       Republik AG<br />

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.html
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.html
@@ -106,7 +106,7 @@
                       <br />
                       <br />
                       Project R Genossenschaft<br />
-                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      Sihlhallenstrasse 1, 8004 Zürich<br />
                       <a href="{{link_projectr}}">www.project-r.construction</a
                       ><br />
                       <a href="mailto:office@project-r.construction"
@@ -128,7 +128,7 @@
                       />
                       <br />
                       Republik AG<br />
-                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      Sihlhallenstrasse 1, 8004 Zürich<br />
                       <a href="{{frontend_base_url}}">www.republik.ch</a><br />
                       <a href="mailto:kontakt@republik.ch"
                         >kontakt@republik.ch</a

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.html
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.html
@@ -43,19 +43,20 @@
                   <td style="padding: 20px">
                     <p>
                       Sehr geehrte Verlegerin<br />
-                      sehr geehrter Verleger
+                      sehr geehrter Verleger<br />
+                      and everyone beyond
                     </p>
                     <p>
                       Vielen Dank für Ihr Engagement und herzlichen Glückwunsch:
-                      Sie sind offiziell Kandidatin oder Kandidat für den
-                      Genossenschaftsrat von Project R.
+                      Sie kandidieren offiziell für den Genossenschaftsrat von
+                      Project R.
                     </p>
                     <p>
                       Zu Ihrer Information: Alle notwendigen Angaben haben wir
                       erfasst.
                     </p>
                     <p>
-                      Bis zum 30. Oktober
+                      Bis zum 29. Oktober
                       <a href="{{frontend_base_url}}/vote/2021/kandidieren?edit"
                         >können Sie Ihre Angaben ändern oder ergänzen</a
                       >, falls Ihnen noch etwas einfallen sollte.

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.html
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.html
@@ -56,8 +56,7 @@
                     </p>
                     <p>
                       Bis zum 30. Oktober
-                      <a
-                        href="{{frontend_base_url}}/vote/genossenschaft/kandidieren?edit"
+                      <a href="{{frontend_base_url}}/vote/2021/kandidieren?edit"
                         >können Sie Ihre Angaben ändern oder ergänzen</a
                       >, falls Ihnen noch etwas einfallen sollte.
                     </p>

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.html
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.html
@@ -48,7 +48,7 @@
                     <p>
                       Vielen Dank für Ihr Engagement und herzlichen Glückwunsch:
                       Sie sind offiziell Kandidatin oder Kandidat für den
-                      Genossenschaftsrat von Project R und Republik.
+                      Genossenschaftsrat von Project R.
                     </p>
                     <p>
                       Zu Ihrer Information: Alle notwendigen Angaben haben wir

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
@@ -7,15 +7,15 @@ offiziell für den Genossenschaftsrat von Project R.
 
 Zu Ihrer Information: Alle notwendigen Angaben haben wir erfasst.
 
-Bis zum 29. Oktober können Sie Ihre Angaben ändern oder ergänzen
-{{frontend_base_url}}/vote/2021/kandidieren?edit , falls Ihnen noch etwas
-einfallen sollte.
+Bis zum 29. Oktober können Sie Ihre Angaben ändern
+{{frontend_base_url}}/vote/2021/kandidieren?edit=true , falls Sie das wünschen.
 
 Die Wahl selbst dauert vom 12. bis zum 28. November. Zeitgleich zur Wahl findet
 eine Online-Debatte statt. Dort wird Ihr Statement in Ihrem Namen
-veröffentlicht. Während dieser Zeit können die Mitglieder Ihnen Fragen stellen.
-Wir freuen uns, wenn Sie in der Debatte präsent sind. Und wenn Sie sich für die
-eine oder andere Antwort Zeit nehmen.
+veröffentlicht. Während der Dauer der Wahl können die Mitglieder Ihnen Fragen
+stellen und Sie so ein bisschen besser kennenlernen. Wir freuen uns, wenn Sie in
+der Debatte präsent sind. Und wenn Sie sich für die eine oder andere Antwort
+Zeit nehmen.
 
 Wir werden die Debatte moderieren und dafür sorgen, dass unsere Etikette
 {{frontend_base_url}}/etikette eingehalten wird.

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
@@ -2,7 +2,7 @@ Sehr geehrte Verlegerin
 sehr geehrter Verleger
 
 Vielen Dank für Ihr Engagement und herzlichen Glückwunsch: Sie sind offiziell
-Kandidatin oder Kandidat für den Genossenschaftsrat von Project R und Republik.
+Kandidatin oder Kandidat für den Genossenschaftsrat von Project R.
 
 Zu Ihrer Information: Alle notwendigen Angaben haben wir erfasst.
 

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
@@ -1,0 +1,13 @@
+Guten Tag
+
+Herzlichen Dank für die Einreichung Ihrer Kandidatur für den Genossenschaftsrat.
+
+Herzlich
+
+Ihre Crew der Republik
+
+
+Republik AG
+Sihlhallenstrasse 1, CH-8004 Zürich
+{{frontend_base_url}}
+kontakt@republik.ch

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
@@ -1,10 +1,37 @@
-Guten Tag
+Sehr geehrte Verlegerin
+sehr geehrter Verleger
 
-Herzlichen Dank für die Einreichung Ihrer Kandidatur für den Genossenschaftsrat.
+Vielen Dank für Ihr Engagement und herzlichen Glückwunsch: Sie sind offiziell
+Kandidatin oder Kandidat für den Genossenschaftsrat von Project R und Republik.
 
-Herzlich
+Zu Ihrer Information: Alle notwendigen Angaben haben wir erfasst.
 
-Ihre Crew der Republik
+Bis zum 30. Oktober können Sie Ihre Angaben ändern oder ergänzen
+{{frontend_base_url}}/vote/genossenschaft/kandidieren?edit , falls Ihnen noch
+etwas einfallen sollte.
+
+Die Wahl selbst dauert vom 12. bis zum 28. November. Zeitgleich zur Wahl findet
+eine Online-Debatte statt. Dort wird Ihr Statement in Ihrem Namen
+veröffentlicht. Während dieser Zeit können die Mitglieder Ihnen Fragen stellen.
+Wir freuen uns, wenn Sie in der Debatte präsent sind. Und wenn Sie sich für die
+eine oder andere Antwort Zeit nehmen.
+
+Wir werden die Debatte moderieren und dafür sorgen, dass unsere Etikette
+{{frontend_base_url}}/etikette eingehalten wird.
+
+Das Resultat der Wahl geben wir anfangs Dezember in einem Project-R-Newsletter
+bekannt.
+
+Wir wünschen Ihnen viel Erfolg und freuen uns auf eine interessante Wahl.
+
+Ihre Crew von Project R und Republik
+
+
+
+Project R Genossenschaft
+Sihlhallenstrasse 1, CH-8004 Zürich
+www.project-r.construction {{link_projectr}}
+office@project-r.construction
 
 
 Republik AG

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
@@ -30,12 +30,12 @@ Ihre Crew von Project R und Republik
 
 
 Project R Genossenschaft
-Sihlhallenstrasse 1, CH-8004 Zürich
+Sihlhallenstrasse 1, 8004 Zürich
 www.project-r.construction {{link_projectr}}
 office@project-r.construction
 
 
 Republik AG
-Sihlhallenstrasse 1, CH-8004 Zürich
+Sihlhallenstrasse 1, 8004 Zürich
 {{frontend_base_url}}
 kontakt@republik.ch

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
@@ -7,8 +7,8 @@ Kandidatin oder Kandidat für den Genossenschaftsrat von Project R.
 Zu Ihrer Information: Alle notwendigen Angaben haben wir erfasst.
 
 Bis zum 30. Oktober können Sie Ihre Angaben ändern oder ergänzen
-{{frontend_base_url}}/vote/genossenschaft/kandidieren?edit , falls Ihnen noch
-etwas einfallen sollte.
+{{frontend_base_url}}/vote/2021/kandidieren?edit , falls Ihnen noch etwas
+einfallen sollte.
 
 Die Wahl selbst dauert vom 12. bis zum 28. November. Zeitgleich zur Wahl findet
 eine Online-Debatte statt. Dort wird Ihr Statement in Ihrem Namen

--- a/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
+++ b/packages/mail/templates/election_candidacy_confirmation_gen21m.txt
@@ -1,12 +1,13 @@
 Sehr geehrte Verlegerin
 sehr geehrter Verleger
+and everyone beyond
 
-Vielen Dank für Ihr Engagement und herzlichen Glückwunsch: Sie sind offiziell
-Kandidatin oder Kandidat für den Genossenschaftsrat von Project R.
+Vielen Dank für Ihr Engagement und herzlichen Glückwunsch: Sie kandidieren
+offiziell für den Genossenschaftsrat von Project R.
 
 Zu Ihrer Information: Alle notwendigen Angaben haben wir erfasst.
 
-Bis zum 30. Oktober können Sie Ihre Angaben ändern oder ergänzen
+Bis zum 29. Oktober können Sie Ihre Angaben ändern oder ergänzen
 {{frontend_base_url}}/vote/2021/kandidieren?edit , falls Ihnen noch etwas
 einfallen sollte.
 

--- a/packages/migrations/migrations/20210818173518-election-candidacies-credential.js
+++ b/packages/migrations/migrations/20210818173518-election-candidacies-credential.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/voting/migrations/sqls'
+const file = '20210818173518-election-candidacies-credential'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/migrations/migrations/20210819162118-user-gender.js
+++ b/packages/migrations/migrations/20210819162118-user-gender.js
@@ -1,0 +1,8 @@
+const run = require('../run.js')
+
+const dir = 'packages/republik/migrations/sqls'
+const file = '20210819162118-user-gender'
+
+exports.up = (db) => run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) => run(db, dir, `${file}-down.sql`)

--- a/packages/republik/graphql/resolvers/User.js
+++ b/packages/republik/graphql/resolvers/User.js
@@ -11,39 +11,35 @@ const { isEligible } = require('../../lib/profile')
 
 const canAccessBasics = (user, me) => Roles.userIsMeOrProfileVisible(user, me)
 
-const exposeProfileField = (key, format) => (
-  user,
-  args,
-  { pgdb, user: me },
-) => {
-  if (canAccessBasics(user, me) || isFieldExposed(user, key)) {
-    return format
-      ? format(user._raw[key] || user[key], args)
-      : user._raw[key] || user[key]
+const exposeProfileField =
+  (key, format) =>
+  (user, args, { pgdb, user: me }) => {
+    if (canAccessBasics(user, me) || isFieldExposed(user, key)) {
+      return format
+        ? format(user._raw[key] || user[key], args)
+        : user._raw[key] || user[key]
+    }
+    return null
   }
-  return null
-}
 
-const exposeAccessField = (accessRoleKey, key, format) => (
-  user,
-  args,
-  { pgdb, user: me },
-) => {
-  if (
-    user._raw[accessRoleKey] === 'PUBLIC' ||
-    Roles.userIsMeOrInRoles(user, me, [
-      user._raw[accessRoleKey].toLowerCase(),
-      'admin',
-      'supporter',
-    ]) ||
-    isFieldExposed(user, key)
-  ) {
-    return format
-      ? format(user._raw[key] || user[key])
-      : user._raw[key] || user[key]
+const exposeAccessField =
+  (accessRoleKey, key, format) =>
+  (user, args, { pgdb, user: me }) => {
+    if (
+      user._raw[accessRoleKey] === 'PUBLIC' ||
+      Roles.userIsMeOrInRoles(user, me, [
+        user._raw[accessRoleKey].toLowerCase(),
+        'admin',
+        'supporter',
+      ]) ||
+      isFieldExposed(user, key)
+    ) {
+      return format
+        ? format(user._raw[key] || user[key])
+        : user._raw[key] || user[key]
+    }
+    return null
   }
-  return null
-}
 
 module.exports = {
   name(user, args, { user: me }) {
@@ -66,6 +62,7 @@ module.exports = {
   publicUrl: exposeProfileField('publicUrl'),
   disclosures: exposeProfileField('disclosures'),
   statement: exposeProfileField('statement'),
+  gender: exposeProfileField('gender'),
   isListed: (user) => user._raw.isListed,
   slug(user, args, { user: me }) {
     if (canAccessBasics(user, me)) {

--- a/packages/republik/graphql/resolvers/_mutations/updateMe.js
+++ b/packages/republik/graphql/resolvers/_mutations/updateMe.js
@@ -162,8 +162,6 @@ module.exports = async (_, args, context) => {
 
   if (await isInCandidacy(me._raw, pgdb)) {
     if (await isInCandidacyInCandidacyPhase(me._raw, pgdb)) {
-      // TODO: clarify if biography and gender should be mandatory and not changeable
-      // during election, if so inlcude both below
       if (args.hasPublicProfile === false) {
         throw new Error(t('profile/candidacy/needed'))
       }
@@ -178,12 +176,22 @@ module.exports = async (_, args, context) => {
       if ('statement' in args && args.statement.length < 1) {
         throw new Error(t('profile/candidacy/statement/needed'))
       }
+
+      if ('biography' in args && args.statement.length < 1) {
+        throw new Error(t('profile/candidacy/biography/needed'))
+      }
+
+      if ('gender' in args && args.statement.length < 1) {
+        throw new Error(t('profile/candidacy/gender/needed'))
+      }
     }
     if (await isInCandidacyInElectionPhase(me._raw, pgdb)) {
       if (
         'hasPublicProfile' in args ||
         'birthday' in args ||
-        'statement' in args
+        'statement' in args ||
+        'biography' in args ||
+        'gender' in args
       ) {
         throw new Error(t('profile/candidacy/electionPhase'))
       }

--- a/packages/republik/graphql/resolvers/_mutations/updateMe.js
+++ b/packages/republik/graphql/resolvers/_mutations/updateMe.js
@@ -177,12 +177,19 @@ module.exports = async (_, args, context) => {
         throw new Error(t('profile/candidacy/statement/needed'))
       }
 
-      if ('biography' in args && args.statement.length < 1) {
+      if ('biography' in args && args.biography.length < 1) {
         throw new Error(t('profile/candidacy/biography/needed'))
       }
 
-      if ('gender' in args && args.statement.length < 1) {
+      if ('gender' in args && args.gender.length < 1) {
         throw new Error(t('profile/candidacy/gender/needed'))
+      }
+
+      if (
+        'portrait' in args &&
+        !(args.portrait === undefined && me._raw.portraitUrl)
+      ) {
+        throw new Error(t('profile/candidacy/portrait/needed'))
       }
     }
     if (await isInCandidacyInElectionPhase(me._raw, pgdb)) {

--- a/packages/republik/graphql/resolvers/_mutations/updateMe.js
+++ b/packages/republik/graphql/resolvers/_mutations/updateMe.js
@@ -147,6 +147,7 @@ module.exports = async (_, args, context) => {
     'isListed',
     'statement',
     'disclosures',
+    'gender',
   ]
 
   if (
@@ -161,6 +162,8 @@ module.exports = async (_, args, context) => {
 
   if (await isInCandidacy(me._raw, pgdb)) {
     if (await isInCandidacyInCandidacyPhase(me._raw, pgdb)) {
+      // TODO: clarify if biography and gender should be mandatory and not changeable
+      // during election, if so inlcude both below
       if (args.hasPublicProfile === false) {
         throw new Error(t('profile/candidacy/needed'))
       }

--- a/packages/republik/graphql/schema-types.js
+++ b/packages/republik/graphql/schema-types.js
@@ -62,6 +62,7 @@ extend type User {
   twitterHandle: String
   publicUrl: String
   disclosures: String
+  gender: String
 
   statement: String
   isListed: Boolean!

--- a/packages/republik/graphql/schema.js
+++ b/packages/republik/graphql/schema.js
@@ -56,6 +56,7 @@ type mutations {
     twitterHandle: String
     publicUrl: String
     disclosures: String
+    gender: String
   ): User!
 
   updateAddress(

--- a/packages/republik/migrations/sqls/20210819162118-user-gender-down.sql
+++ b/packages/republik/migrations/sqls/20210819162118-user-gender-down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "users"
+  DROP COLUMN "gender"
+;

--- a/packages/republik/migrations/sqls/20210819162118-user-gender-up.sql
+++ b/packages/republik/migrations/sqls/20210819162118-user-gender-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "users"
+  ADD COLUMN "gender" text 
+;

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1,6 +1,4 @@
 {
-  "updated": "2020-10-23T08:52:18.814Z",
-  "title": "live",
   "data": [
     {
       "key": "api/unexpected",
@@ -317,14 +315,6 @@
     {
       "key": "api/users/delete/claimedMembershipsNotSupported",
       "value": "User, welche eine Membership eingelöst habe können zurzeit nicht gelöscht werden. Bitte wenden Sie sich an die IT."
-    },
-    {
-      "key": "api/payment/paymentMethod/404",
-      "value": "Die PaymentMethod konnte nicht gefunden werden."
-    },
-    {
-      "key": "api/payment/paymentIntent/404",
-      "value": "Der PaymentIntent konnte nicht gefunden werden."
     },
     {
       "key": "api/payment/paymentMethod/404",
@@ -1233,6 +1223,10 @@
     {
       "key": "api/access/request/campaign/error",
       "value": "Kampagne «{campaignId}» ist ungültig."
+    },
+    {
+      "key": "api/election/email/election_candidacy_confirmation_gen21m/subject",
+      "value": "Vielen Dank für Ihre Kandidatur"
     },
     {
       "key": "api/election/email/election_candidacy_confirmation_gen18m/subject",

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -825,6 +825,10 @@
       "value": "Ihr Profil ist im Moment mindestens einer Kandidatur zugeordnet, weshalb wir ein Geschlecht zwingend benötigen."
     },
     {
+      "key": "profile/candidacy/portrait/needed",
+      "value": "Ihr Profil ist im Moment mindestens einer Kandidatur zugeordnet, weshalb wir ein Porträtbild zwingend benötigen."
+    },
+    {
       "key": "profile/candidacy/needed",
       "value": "Ihr Profil ist im Moment mindestens einer Kandidatur zugeordnet und kann im Moment nicht zurückgenommen werden."
     },

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -817,12 +817,20 @@
       "value": "Ihr Profil ist im Moment mindestens einer Kandidatur zugeordnet, weshalb wir das Geburtsdatum zwingend benötigen."
     },
     {
+      "key": "profile/candidacy/biography/needed",
+      "value": "Ihr Profil ist im Moment mindestens einer Kandidatur zugeordnet, weshalb wir einen Steckbrief zwingend benötigen."
+    },
+    {
+      "key": "profile/candidacy/gender/needed",
+      "value": "Ihr Profil ist im Moment mindestens einer Kandidatur zugeordnet, weshalb wir ein Geschlecht zwingend benötigen."
+    },
+    {
       "key": "profile/candidacy/needed",
       "value": "Ihr Profil ist im Moment mindestens einer Kandidatur zugeordnet und kann im Moment nicht zurückgenommen werden."
     },
     {
       "key": "profile/candidacy/electionPhase",
-      "value": "Sie sind zur Zeit Kandidatin in mind. einer Wahl. Deshalb können Sie Profil nicht anpassen. Bitte warten Sie bis die Wahl abgeschlossen ist."
+      "value": "Sie sind zur Zeit Kandidatin in mind. einer Wahl. Deshalb können Sie Ihr Profil nicht anpassen. Bitte warten Sie bis die Wahl abgeschlossen ist."
     },
     {
       "key": "profile/notEligible",

--- a/packages/voting/graphql/resolvers/Candidacy.js
+++ b/packages/voting/graphql/resolvers/Candidacy.js
@@ -24,4 +24,15 @@ module.exports = {
 
     return candidacy.user.address.city
   },
+  credential: (candidacy, args, { user: me, pgdb }) => {
+    if (!Roles.userIsInRoles(me, ['admin', 'supporter', 'associate'])) {
+      return
+    }
+
+    if (!candidacy.credentialId) {
+      return
+    }
+
+    return pgdb.public.credentials.findOne({ id: candidacy.credentialId })
+  },
 }

--- a/packages/voting/graphql/resolvers/_mutations/submitCandidacy.js
+++ b/packages/voting/graphql/resolvers/_mutations/submitCandidacy.js
@@ -5,7 +5,7 @@ const { findBySlug } = require('../../../lib/Election')
 const { findById } = require('../../../lib/Candidacy')
 const mailLib = require('../../../lib/mail')
 
-module.exports = async (_, { slug }, { pgdb, user: me, t }) => {
+module.exports = async (_, { slug, credential }, { pgdb, user: me, t }) => {
   Roles.ensureUserIsInRoles(me, ['admin', 'associate'])
 
   const election = await findBySlug(slug, pgdb)
@@ -32,12 +32,19 @@ module.exports = async (_, { slug }, { pgdb, user: me, t }) => {
     { userId: me.id, discussionId: election.discussionId },
   )
 
+  const { entity: credentialEntity } = await upsert(
+    pgdb.public.credentials,
+    { userId: me.id, description: credential },
+    { userId: me.id, description: credential },
+  )
+
   const { entity, isNew } = await upsert(
     pgdb.public.electionCandidacies,
     {
       userId: me.id,
       electionId: election.id,
       commentId: comment.id,
+      credentialId: credentialEntity.id,
     },
     { userId: me.id, electionId: election.id },
   )

--- a/packages/voting/graphql/schema-types.js
+++ b/packages/voting/graphql/schema-types.js
@@ -146,6 +146,7 @@ type Candidacy {
 
   yearOfBirth: Int
   city: String
+  credential: Credential
 }
 
 type ElectionTurnout {

--- a/packages/voting/graphql/schema.js
+++ b/packages/voting/graphql/schema.js
@@ -31,7 +31,7 @@ type mutations {
   ): VotingResult!
 
   createElection(electionInput: ElectionInput!): Election!
-  submitCandidacy(slug: String!): Candidacy!
+  submitCandidacy(slug: String!, credential: String!): Candidacy!
   cancelCandidacy(slug: String!): Election!
   submitElectionBallot(
     electionId: ID!

--- a/packages/voting/lib/Candidacy.js
+++ b/packages/voting/lib/Candidacy.js
@@ -46,11 +46,16 @@ const findById = async (id, pgdb) => {
     id: candidacy.electionId,
   })
 
+  const credential = await pgdb.public.credentials.findOne({
+    id: candidacy.credentialId,
+  })
+
   return {
     ...candidacy,
     user,
     election,
     comment,
+    credential,
   }
 }
 

--- a/packages/voting/migrations/sqls/20210818173518-election-candidacies-credential-down.sql
+++ b/packages/voting/migrations/sqls/20210818173518-election-candidacies-credential-down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "electionCandidacies"
+  DROP COLUMN "credentialId"
+;

--- a/packages/voting/migrations/sqls/20210818173518-election-candidacies-credential-up.sql
+++ b/packages/voting/migrations/sqls/20210818173518-election-candidacies-credential-up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "electionCandidacies"
+  ADD COLUMN "credentialId" uuid references "credentials" on update cascade on delete cascade
+;


### PR DESCRIPTION
TODOs:

- [x] clarify if and add gender and biography to candidate checks in `updateMe.js`
- [x] ~~add INSERT statement to PR for new elections (gen21p & gen21m) as soon as candidacy time range and discussionId are defined~~ there is a mutation `createElection` for that purpose 
- [x] replace dummy confirmation mail text with definite text
- [x] add translations (e.g. subject of confirmation mail)

maybe there are some more things needed to implement / finalize frontend