### PR TITLE
auto sorting of discussion comments

### DIFF
--- a/packages/discussions/graphql/resolvers/Discussion/comments.js
+++ b/packages/discussions/graphql/resolvers/Discussion/comments.js
@@ -244,6 +244,12 @@ module.exports = async (discussion, args, context, info) => {
     }
   }
 
+  /* 
+    AUTO = comments are sorted 
+    - by date if the first comment was created in the last 24 hours 
+    - or by votes otherwise 
+    the property resolvedOrderBy is just needed when DiscussionOrder === AUTO
+  */
   let resolvedOrderBy
   if (orderBy === 'AUTO') {
     const sortedComments = [...comments].sort(

--- a/packages/discussions/graphql/resolvers/Discussion/comments.js
+++ b/packages/discussions/graphql/resolvers/Discussion/comments.js
@@ -252,20 +252,23 @@ module.exports = async (discussion, args, context, info) => {
     - or by votes otherwise 
     the property resolvedOrderBy is just needed when DiscussionOrder === AUTO
   */
-  const oldestComment = comments?.reduce((oldest, current) => {
-    if (!oldest) {
-      return current
-    }
-    return oldest.createdAt < current.createdAt ? oldest : current
-  }, false)
+  let resolvedOrderBy
+  if (orderBy === 'AUTO') {
+    const oldestComment = comments?.reduce((oldest, current) => {
+      if (!oldest) {
+        return current
+      }
+      return oldest.createdAt < current.createdAt ? oldest : current
+    }, false)
 
-  const thresholdOldDiscussion =
-    new Date().getTime() - THRESHOLD_OLD_DISCUSSION_IN_MS
+    const thresholdOldDiscussion =
+      new Date().getTime() - THRESHOLD_OLD_DISCUSSION_IN_MS
 
-  const resolvedOrderBy =
-    oldestComment && oldestComment.createdAt?.getTime() < thresholdOldDiscussion
-      ? 'VOTES'
-      : 'DATE'
+    resolvedOrderBy =
+      oldestComment?.createdAt?.getTime() < thresholdOldDiscussion
+        ? 'VOTES'
+        : 'DATE'
+  }
 
   let tree = parentId ? comments.find((c) => c.id === parentId) : {}
 

--- a/packages/discussions/graphql/resolvers/Discussion/comments.js
+++ b/packages/discussions/graphql/resolvers/Discussion/comments.js
@@ -255,7 +255,7 @@ module.exports = async (discussion, args, context, info) => {
         new Date().getTime() - 24 * 60 * 60 * 1000,
       )
       resolvedOrderBy =
-        firstCommentCreatedAt > twentyFourHoursAgo ? 'DATE' : 'VOTE'
+        firstCommentCreatedAt > twentyFourHoursAgo ? 'DATE' : 'VOTES'
     } else {
       resolvedOrderBy = 'DATE'
     }

--- a/packages/discussions/graphql/resolvers/_queries/comments.js
+++ b/packages/discussions/graphql/resolvers/_queries/comments.js
@@ -13,9 +13,8 @@ module.exports = async (_, args, context, info) => {
         first: args.first,
       }
     : args
-  let { orderBy = 'DATE' } = options
-  orderBy = orderBy === 'AUTO' ? 'DATE' : orderBy
   const {
+    orderBy = 'DATE',
     orderDirection = 'DESC',
     first: limit = 40,
     offset = 0,
@@ -27,6 +26,8 @@ module.exports = async (_, args, context, info) => {
     featured,
     featuredTarget = featured && getDefaultFeaturedTarget(),
   } = options
+
+  const resolvedOrderBy = orderBy === 'AUTO' ? 'DATE' : null
 
   if (limit > MAX_LIMIT) {
     throw new Error(t('api/discussion/args/first/tooBig', { max: MAX_LIMIT }))
@@ -135,5 +136,6 @@ module.exports = async (_, args, context, info) => {
       focusId && comments.length && focusId === comments[0].id
         ? comments[0]
         : null,
+    resolvedOrderBy,
   }
 }

--- a/packages/discussions/graphql/resolvers/_queries/comments.js
+++ b/packages/discussions/graphql/resolvers/_queries/comments.js
@@ -13,8 +13,9 @@ module.exports = async (_, args, context, info) => {
         first: args.first,
       }
     : args
+  let { orderBy = 'DATE' } = options
+  orderBy = orderBy === 'AUTO' ? 'DATE' : orderBy
   const {
-    orderBy = 'DATE',
     orderDirection = 'DESC',
     first: limit = 40,
     offset = 0,
@@ -27,6 +28,7 @@ module.exports = async (_, args, context, info) => {
     featuredTarget = featured && getDefaultFeaturedTarget(),
   } = options
 
+  console.log(orderBy)
   if (limit > MAX_LIMIT) {
     throw new Error(t('api/discussion/args/first/tooBig', { max: MAX_LIMIT }))
   }

--- a/packages/discussions/graphql/resolvers/_queries/comments.js
+++ b/packages/discussions/graphql/resolvers/_queries/comments.js
@@ -28,7 +28,6 @@ module.exports = async (_, args, context, info) => {
     featuredTarget = featured && getDefaultFeaturedTarget(),
   } = options
 
-  console.log(orderBy)
   if (limit > MAX_LIMIT) {
     throw new Error(t('api/discussion/args/first/tooBig', { max: MAX_LIMIT }))
   }

--- a/packages/discussions/graphql/schema-types.js
+++ b/packages/discussions/graphql/schema-types.js
@@ -72,6 +72,7 @@ input DiscussionPreferencesInput {
 }
 
 enum DiscussionOrder {
+  AUTO
   DATE
   VOTES
   HOT
@@ -105,6 +106,7 @@ type CommentConnection {
   pageInfo: DiscussionPageInfo
   nodes: [Comment]!
   focus: Comment
+  resolvedOrderBy: DiscussionOrder
 }
 
 type Discussion {


### PR DESCRIPTION
* adds `AUTO` to `DiscussionOrder` enum in schema
* adds `resolvedOrderBy` property to `CommentConnection` in schema
* when auto sorting is requested in Discussion.comments it will check creation date of first comment:
  * if it's within the last 24 hours it will sort by `DATE`
  * if it's older than 24 hours it will sort by `VOTES`
  * and returns it as `resolvedOrderBy`

can be tested on love