### PR TITLE
fix(utils): Harden against missing value

### DIFF
--- a/packages/utils/__snapshots__/mdastCollapseLink.u.jest.js.snap
+++ b/packages/utils/__snapshots__/mdastCollapseLink.u.jest.js.snap
@@ -68,6 +68,27 @@ Object {
       ],
       "type": "paragraph",
     },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Hack",
+                },
+              ],
+              "type": "emphasis",
+            },
+          ],
+          "title": null,
+          "type": "link",
+          "url": "https://de.wikipedia.org/wiki/Hack",
+        },
+      ],
+      "type": "paragraph",
+    },
   ],
   "type": "root",
 }
@@ -137,6 +158,27 @@ Object {
         Object {
           "type": "text",
           "value": "Textpassage",
+        },
+      ],
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Hack",
+                },
+              ],
+              "type": "emphasis",
+            },
+          ],
+          "title": null,
+          "type": "link",
+          "url": "https://de.wikipedia.org/wiki/Hack",
         },
       ],
       "type": "paragraph",

--- a/packages/utils/mdastCollapseLink.js
+++ b/packages/utils/mdastCollapseLink.js
@@ -17,7 +17,7 @@ module.exports = function mdastCollapseLink(node_, options = {}) {
   visit(node, 'link', (node) => {
     if (
       node.children.length === 1 &&
-      node.children[0].value.length > prefixLength + postfixLength + 1 &&
+      node.children[0].value?.length > prefixLength + postfixLength + 1 &&
       node.children[0].value === node.url
     ) {
       node.children[0].value = [

--- a/packages/utils/mdastCollapseLink.u.jest.js
+++ b/packages/utils/mdastCollapseLink.u.jest.js
@@ -69,6 +69,27 @@ const node = {
         },
       ],
     },
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'link',
+          title: null,
+          url: 'https://de.wikipedia.org/wiki/Hack',
+          children: [
+            {
+              type: 'emphasis',
+              children: [
+                {
+                  type: 'text',
+                  value: 'Hack',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
 }
 


### PR DESCRIPTION
`child.value` is not always present in MDAST when formatting a link itself. In such cases, do not collapse link.