### PR TITLE
feat(Document): resolve meta seo title and seo description

### DIFF
--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -56,6 +56,8 @@ type Meta {
   twitterTitle: String
   twitterImage: String
   twitterDescription: String
+  seoTitle: String
+  seoDescription: String
   shareText: String
   shareFontSize: Int
   shareInverted: Boolean


### PR DESCRIPTION
Publikator introduces new seo fields which also should be exposed via graphql:
https://github.com/orbiting/publikator-frontend/pull/302

<img width="1152" alt="Screenshot 2021-10-05 at 17 40 27" src="https://user-images.githubusercontent.com/410211/136056186-04ea57ca-28ce-4166-8630-4e3750b11252.png">

@patrickvenetz do you want to add the fields to our elastic index? Maybe we should also add twitter title and lead then? Will be used for search engines if seo fields are not filled.

