### PR TITLE
feat(documents): query by repo id

### DIFF
--- a/packages/documents/graphql/resolvers/_queries/document.js
+++ b/packages/documents/graphql/resolvers/_queries/document.js
@@ -3,6 +3,10 @@ const getDocuments = require('./documents')
 module.exports = async (_, args, context, info) => {
   const { id, path, repoId } = args
 
+  if (!path && !id && !repoId) {
+    throw new Error('Please provide a path or repoId')
+  }
+
   return getDocuments(_, { id, path, repoId }, context, info).then(
     (docCon) => docCon.nodes[0],
   )

--- a/packages/documents/graphql/schema.js
+++ b/packages/documents/graphql/schema.js
@@ -24,6 +24,9 @@ type queries {
     after: String
   ): DocumentConnection!
   # (pre)published document
-  document(path: String!): Document
+  document(
+    path: String
+    repoId: ID
+  ): Document
 }
 `


### PR DESCRIPTION
We want to refactor the action bar in the frontend to do it's own query — client-side only and batched. In order to not rely on path that can change over time we'd like to query by repo id.

For batching we'll use [`BatchHttpLink`](https://www.apollographql.com/docs/react/api/link/apollo-link-batch-http/) which already works fine with our backend.

I did consider exposing querying by document id as well but don't have a use case for it and decided against it because it is probably better to use the more stable repo id.

<img width="1339" alt="Screenshot 2021-10-07 at 18 26 21" src="https://user-images.githubusercontent.com/410211/136425536-bb6827f9-2051-4b4d-8953-981ba68eb337.png">

```gql
{
  viaPath: document(path: "/2021/03/11/entweder-du-machst-den-witz-oder-du-bist-der-witz") {
    repoId
    meta {
      title
    }
  }
  viaRepoId: document(repoId: "republik/article-interview-somm") {
    repoId
    meta {
      title
    }
  }
  nada: document {
    repoId
  }
}
```
