### PR TITLE
fix(publikator): Handle redirections only if publication is not scheduled

### DIFF
--- a/packages/publikator/graphql/resolvers/_mutations/publish.js
+++ b/packages/publikator/graphql/resolvers/_mutations/publish.js
@@ -223,7 +223,7 @@ module.exports = async (
   }
 
   // remember if slug changed
-  if (!prepublication) {
+  if (!prepublication && !scheduledAt) {
     await handleRedirection(repoId, doc.content.meta, context)
   }
 


### PR DESCRIPTION
This Pull Request changes publish mutation. Mutation should only handle redirections if document is published immediatly. (Publication scheduler will take care of redirection handling for scheduled publications.)

It fixes a bug which pointed existing redirection records to a not-yet-published document.