### PR TITLE
fix(publikator): Set terms.size to phases count

### DIFF
--- a/packages/publikator/lib/cache/search.ts
+++ b/packages/publikator/lib/cache/search.ts
@@ -3,6 +3,8 @@ const debug = require('debug')('publikator:cache:search')
 import { GraphqlContext } from '@orbiting/backend-modules-types'
 const utils = require('@orbiting/backend-modules-search/lib/utils')
 
+import { getPhases } from '../../lib/phases'
+
 const getSort = (args: any) => {
   // Default sorting
   if (!args.orderBy) {
@@ -107,6 +109,7 @@ const find = async (args: any, { elastic }: GraphqlContext) => {
       terms: {
         field: 'currentPhase.keyword',
         min_doc_count: 0,
+        size: getPhases().length,
       },
     },
   }

--- a/packages/publikator/lib/phases.ts
+++ b/packages/publikator/lib/phases.ts
@@ -187,7 +187,7 @@ const runChecks = (repo: Repo, milestones: Milestone[], checks: Check[]) => {
   return hasAllPassed
 }
 
-const getPhases = () => [...phases]
+export const getPhases = () => [...phases]
 
 const hasReachedPhase = (repo: Repo, milestones: Milestone[], phase: Phase) => {
   const checks: Check[] = [


### PR DESCRIPTION
This Pull Request ensures all phases are returned. It sets aggregation size to amount of plausable phases.

ElasticSearch terms aggregation returned up to 10 buckets which coincidentally matched amount of phases.

After [introducing "tribe chief" phase](https://github.com/orbiting/backends/pull/657) recently, there are 11 phases. Aggregation however kept returning 10 phases only (in fact, 10 "top phases", meaning, most documents matched).
