### PR TITLE
fix: Check overview is linked to a series master

### DIFF
--- a/packages/publikator/graphql/resolvers/_queries/reposSearch.js
+++ b/packages/publikator/graphql/resolvers/_queries/reposSearch.js
@@ -47,6 +47,8 @@ module.exports = async (__, args, context) => {
     phases,
     orderBy,
     isTemplate,
+    isSeriesMaster,
+    isSeriesEpisode,
     publishDateRange,
     // last - "last" parameter is not implemented in search API
   } = options
@@ -60,6 +62,8 @@ module.exports = async (__, args, context) => {
       phases,
       orderBy,
       isTemplate,
+      isSeriesMaster,
+      isSeriesEpisode,
       publishDateRange,
     },
     context,
@@ -92,6 +96,8 @@ module.exports = async (__, args, context) => {
             phases,
             orderBy,
             isTemplate,
+            isSeriesMaster,
+            isSeriesEpisode,
             publishDateRange,
           })
         : null,
@@ -105,6 +111,8 @@ module.exports = async (__, args, context) => {
             phases,
             orderBy,
             isTemplate,
+            isSeriesMaster,
+            isSeriesEpisode,
             publishDateRange,
           })
         : null,

--- a/packages/publikator/graphql/schema.js
+++ b/packages/publikator/graphql/schema.js
@@ -24,6 +24,8 @@ type queries {
     phases: [RepoPhaseKey!]
     orderBy: RepoOrderBy
     isTemplate: Boolean
+    isSeriesMaster: Boolean
+    isSeriesEpisode: Boolean
   ): RepoConnection!
 }
 

--- a/packages/publikator/lib/cache/search.ts
+++ b/packages/publikator/lib/cache/search.ts
@@ -3,7 +3,7 @@ const debug = require('debug')('publikator:cache:search')
 import { GraphqlContext } from '@orbiting/backend-modules-types'
 const utils = require('@orbiting/backend-modules-search/lib/utils')
 
-import { getPhases } from '../../lib/phases'
+import { getPhases } from '../../lib/phases'
 
 const getSort = (args: any) => {
   // Default sorting
@@ -45,7 +45,7 @@ const getSourceFilter = () => ({
 
 const find = async (args: any, { elastic }: GraphqlContext) => {
   debug('args: %o', args)
-  const { isTemplate } = args
+  const { isTemplate, isSeriesMaster, isSeriesEpisode } = args
 
   const fields = [
     'id',
@@ -67,6 +67,18 @@ const find = async (args: any, { elastic }: GraphqlContext) => {
     query.bool.must.push({ term: { 'meta.isTemplate': true } })
   } else if (isTemplate === false) {
     query.bool.must_not.push({ term: { 'meta.isTemplate': true } })
+  }
+
+  if ([true, false].includes(isSeriesMaster)) {
+    query.bool[isSeriesMaster ? 'must' : 'must_not'].push({
+      exists: { field: 'commit.meta.seriesMaster' },
+    })
+  }
+
+  if ([true, false].includes(isSeriesEpisode)) {
+    query.bool[isSeriesEpisode ? 'must' : 'must_not'].push({
+      exists: { field: 'commit.meta.seriesEpisode' },
+    })
   }
 
   if (args.id) {

--- a/packages/publikator/lib/cache/search.ts
+++ b/packages/publikator/lib/cache/search.ts
@@ -45,7 +45,6 @@ const getSourceFilter = () => ({
 
 const find = async (args: any, { elastic }: GraphqlContext) => {
   debug('args: %o', args)
-  const { isTemplate, isSeriesMaster, isSeriesEpisode } = args
 
   const fields = [
     'id',
@@ -63,20 +62,20 @@ const find = async (args: any, { elastic }: GraphqlContext) => {
     },
   }
 
-  if (isTemplate) {
-    query.bool.must.push({ term: { 'meta.isTemplate': true } })
-  } else if (isTemplate === false) {
-    query.bool.must_not.push({ term: { 'meta.isTemplate': true } })
+  if ([true, false].includes(args.isTemplate)) {
+    query.bool[args.isTemplate ? 'must' : 'must_not'].push({
+      term: { 'meta.isTemplate': true },
+    })
   }
 
-  if ([true, false].includes(isSeriesMaster)) {
-    query.bool[isSeriesMaster ? 'must' : 'must_not'].push({
+  if ([true, false].includes(args.isSeriesMaster)) {
+    query.bool[args.isSeriesMaster ? 'must' : 'must_not'].push({
       exists: { field: 'commit.meta.seriesMaster' },
     })
   }
 
-  if ([true, false].includes(isSeriesEpisode)) {
-    query.bool[isSeriesEpisode ? 'must' : 'must_not'].push({
+  if ([true, false].includes(args.isSeriesEpisode)) {
+    query.bool[args.isSeriesEpisode ? 'must' : 'must_not'].push({
       exists: { field: 'commit.meta.seriesEpisode' },
     })
   }

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -1725,6 +1725,10 @@
       "value": "Repo-slug required for templates"
     },
     {
+      "key": "api/commit/seriesMaster/required",
+      "value": "Es ist keine Serienübersicht verlinkt."
+    },
+    {
       "key": "api/commit/parentId/required",
       "value": "Please provide a parentId to commit to the existing repo \"{repoId}\"."
     },


### PR DESCRIPTION
This Pull Request will throw an error on commit if overiew points to anything but a series master document. It also allows to search for repos on which last commit indicates a series master or episode document.

Each document in a series should point to a series master.

In a master document, `meta.series.overview` should contain a repo URL (and is usually a self-reference). In an episode document, `meta.series` should contain a repo URL.

`meta.series` is either an object (when master) or a string (when episode).

`repoSearch` can query for `isSeriesMaster` or `isSeriesEpisode`.