### PR TITLE
(mail) cleaned user mail

### DIFF
--- a/packages/mail/express/mailchimp.js
+++ b/packages/mail/express/mailchimp.js
@@ -98,7 +98,7 @@ const handleUnsubscribe = (data) => {
     email: data.email,
     action: data.action,
     reason: data.reason,
-    campaign: data['campaign_id'],
+    campaign: data.campaign_id,
     customer: getGroups('Customer', data),
     newsletter: getGroups('Republik NL', data),
   }
@@ -131,8 +131,8 @@ const handleUpemail = (data) => {
   "data[old_email]": "api+old@mailchimp.com"
   */
   return {
-    email: data['new_email'],
-    oldEmail: data['old_email'],
+    email: data.new_email,
+    oldEmail: data.old_email,
   }
 }
 
@@ -146,7 +146,7 @@ const handleCleaned = (data) => {
   return {
     email: data.email,
     reason: data.reason,
-    campaign: data['campaign_id'],
+    campaign: data.campaign_id,
   }
 }
 
@@ -187,9 +187,9 @@ const getGroups = (name, data) => {
 
 const applyEnforceSubscriptions = async (record, pgdb) => {
   try {
-    const { email } = record
-    const user = await pgdb.public.users.findOne({ email })
-    await enforceSubscriptions({ pgdb, userId: user?.id, email })
+    const { email } = record
+    const userId = await pgdb.public.users.findOneFieldOnly({ email }, 'id')
+    await enforceSubscriptions({ pgdb, userId, email })
   } catch (e) {
     console.warn('applyEnforceSubscriptions failed:', e)
   }

--- a/packages/mail/lib/mailLog.js
+++ b/packages/mail/lib/mailLog.js
@@ -3,7 +3,7 @@ const moment = require('moment')
 
 const wasSent = async (onceFor, { pgdb }) => {
   const conditions = Object.keys(onceFor)
-    .filter((key) => ['type', 'userId', 'keys'].includes(key))
+    .filter((key) => ['type', 'userId', 'email', 'keys'].includes(key))
     // if a onceFor value is an array, change the key to `${key} &&`
     // to ensure that if a mail was sent for one array member,
     // it doesn't get sent again

--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -23,6 +23,7 @@
     "await-sleep": "^0.0.1",
     "bluebird": "^3.7.2",
     "check-env": "^1.3.0",
+    "dayjs": "^1.10.7",
     "debug": "^4.1.1",
     "he": "^1.2.0",
     "html-to-text": "^7.1.1",

--- a/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
+++ b/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
@@ -31,7 +31,7 @@ PgDb.connect().then(async (pgdb) => {
     templateName: 'cleaned_user_subscription_invitation',
   }
 
-  const emailAddresses = pgdb.queryOneColumn(
+  const emailAddresses = await pgdb.queryOneColumn(
     `
     WITH records AS (
       WITH data AS (

--- a/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
+++ b/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
@@ -39,7 +39,6 @@ PgDb.connect().then(async (pgdb) => {
           DISTINCT ON ("email")
           "email",
           "createdAt",
-          EXTRACT(DAYS FROM now() - "createdAt") days,
           type
           
         FROM "mailchimpLog"

--- a/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
+++ b/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
@@ -24,8 +24,11 @@ PgDb.connect().then(async (pgdb) => {
     console.warn('In dry-run mode. Use --no-dry-run to send emails to segment.')
   }
 
-  console.log(dayjs(argv.to).format('YYYY-MM-DD'))
-  console.log(dayjs(argv.from).format('YYYY-MM-DD'))
+  console.log(
+    `Fetching cleaned users between ${dayjs(argv.from).format(
+      'YYYY-MM-DD',
+    )} and ${dayjs(argv.to).format('YYYY-MM-DD')}`,
+  )
   const mail = {
     subject: 'Warum Sie von uns keine Newsletter mehr erhalten',
     templateName: 'cleaned_user_subscription_invitation',

--- a/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
+++ b/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
@@ -61,9 +61,7 @@ PgDb.connect().then(async (pgdb) => {
     
     SELECT email 
     FROM records 
-    WHERE 
-      "createdAt" >= :from AND
-      "createdAt" <= :to
+    WHERE "createdAt" BETWEEN :from AND :to
   `,
     { from: argv.from, to: argv.to },
   )

--- a/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
+++ b/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
@@ -42,9 +42,12 @@ PgDb.connect().then(async (pgdb) => {
       
       SELECT data.*
       FROM data
-      JOIN users u ON data.email = u.email
-      JOIN memberships m ON m."userId" = u.id AND m."active" = TRUE
-      WHERE type IN ('cleaned')
+      JOIN users u 
+        ON data.email = u.email
+      JOIN memberships m 
+        ON m."userId" = u.id AND m."active" = TRUE
+      WHERE 
+        type IN ('cleaned')
       ORDER BY data."createdAt" DESC
     )
     

--- a/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
+++ b/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
@@ -1,0 +1,65 @@
+const yargs = require('yargs')
+const PgDb = require('@orbiting/backend-modules-base/lib/PgDb')
+
+const sendMailsToSegment = require('./sendMailsToSegment')
+
+const argv = yargs
+  .option('dry-run', {
+    default: true,
+  })
+  .option('limit', {
+    default: 1000,
+  })
+  .help()
+  .version().argv
+
+PgDb.connect().then(async (pgdb) => {
+  if (argv.dryRun) {
+    console.warn('In dry-run mode. Use --no-dry-run to send scheduled emails.')
+  }
+
+  const mail = {
+    subject: 'Warum Sie von uns keine Newsletter mehr erhalten',
+    templateName: 'cleaned_user_subscription_invitation',
+  }
+
+  const emailAddresses = pgdb.queryOneColumn(
+    `
+    WITH records AS (
+      WITH data AS (
+        SELECT
+          DISTINCT ON ("email")
+          "email",
+          "createdAt",
+          EXTRACT(DAYS FROM now() - "createdAt") days,
+          type
+          
+        FROM "mailchimpLog"
+        WHERE
+          type IN ('subscribe', 'unsubscribe', 'cleaned')
+        ORDER BY "email", "createdAt" DESC
+      )
+      
+      SELECT data.*
+      FROM data
+      JOIN users u ON data.email = u.email
+      JOIN memberships m ON m."userId" = u.id AND m."active" = TRUE
+      WHERE type IN ('cleaned')
+      ORDER BY data."createdAt" DESC
+    )
+    
+    SELECT email 
+    FROM records 
+    WHERE "createdAt" >= now() - '60 days'::interval
+    LIMIT :limit
+  `,
+    { limit: argv.limit },
+  )
+
+  await sendMailsToSegment(emailAddresses, mail, {
+    pgdb,
+    argv,
+  })
+  await pgdb.close()
+  console.log('Done!')
+})

--- a/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
+++ b/packages/mail/script/sendMailsToSegment/cleanedUserSubscriptionInvitation.js
@@ -38,13 +38,13 @@ PgDb.connect().then(async (pgdb) => {
         SELECT
           DISTINCT ON ("email")
           "email",
-          "createdAt",
+          "firedAt",
           type
           
         FROM "mailchimpLog"
         WHERE
           type IN ('subscribe', 'unsubscribe', 'cleaned')
-        ORDER BY "email", "createdAt" DESC
+        ORDER BY "email", "firedAt" DESC
       )
       
       SELECT data.*
@@ -55,12 +55,12 @@ PgDb.connect().then(async (pgdb) => {
         ON m."userId" = u.id AND m."active" = TRUE
       WHERE 
         type IN ('cleaned')
-      ORDER BY data."createdAt" DESC
+      ORDER BY data."firedAt" DESC
     )
     
     SELECT email 
     FROM records 
-    WHERE "createdAt" BETWEEN :from AND :to
+    WHERE "firedAt" BETWEEN :from AND :to
   `,
     { from: argv.from, to: argv.to },
   )

--- a/packages/mail/script/sendMailsToSegment/sendMailsToSegment.js
+++ b/packages/mail/script/sendMailsToSegment/sendMailsToSegment.js
@@ -55,10 +55,6 @@ module.exports = async (segment, mail, context) => {
         // Backup method to send emails
         const nodemailer = NodemailerInterface({ logger: console })
         if (nodemailer.isUsable(mail, message)) {
-          if (argv.dryRun) {
-            return [{ status: 'sent', interface: 'Nodemailer' }]
-          }
-
           return nodemailer.send(message)
         }
 

--- a/packages/mail/script/sendMailsToSegment/sendMailsToSegment.js
+++ b/packages/mail/script/sendMailsToSegment/sendMailsToSegment.js
@@ -61,9 +61,6 @@ module.exports = async (segment, mail, context) => {
         // Default method to send emails
         const mandrill = MandrillInterface({ logger: console })
         if (mandrill.isUsable(mail, message)) {
-          if (argv.dryRun) {
-            return [{ status: 'sent', interface: 'Mandrill' }]
-          }
           return mandrill.send(
             message,
             !message.html ? mail.templateName : false,

--- a/packages/mail/script/sendMailsToSegment/sendMailsToSegment.js
+++ b/packages/mail/script/sendMailsToSegment/sendMailsToSegment.js
@@ -1,0 +1,97 @@
+require('@orbiting/backend-modules-env').config()
+const Promise = require('bluebird')
+
+const { getTemplates, envMergeVars } = require('../../lib/sendMailTemplate')
+const MandrillInterface = require('../../MandrillInterface')
+const NodemailerInterface = require('../../NodemailerInterface')
+const sendResultNormalizer = require('../../utils/sendResultNormalizer')
+const shouldSendMessage = require('../../utils/shouldSendMessage')
+const { send } = require('../../lib/mailLog')
+
+const {
+  DEFAULT_MAIL_FROM_ADDRESS,
+  DEFAULT_MAIL_FROM_NAME,
+  SEND_MAILS_SUBJECT_PREFIX,
+  SEND_MAILS_TAGS,
+} = process.env
+
+module.exports = async (segment, mail, context) => {
+  const { argv, pgdb } = context
+  const tags = []
+    .concat(SEND_MAILS_TAGS && SEND_MAILS_TAGS.split(','))
+    .concat(mail.templateName && mail.templateName)
+    .filter(Boolean)
+  const { html, text } = await getTemplates(mail.templateName)
+
+  const message = {
+    subject:
+      (SEND_MAILS_SUBJECT_PREFIX &&
+        `[${SEND_MAILS_SUBJECT_PREFIX}] ${mail.subject}`) ||
+      mail.subject,
+    from_email: mail.fromEmail || DEFAULT_MAIL_FROM_ADDRESS,
+    from_name: mail.fromName || DEFAULT_MAIL_FROM_NAME,
+    html,
+    text: text || mail.text,
+    merge_language: 'handlebars',
+    global_merge_vars: envMergeVars,
+    auto_text: !text,
+    tags,
+    attachments: mail.attachments,
+  }
+
+  await Promise.each(segment, async (emailAddress) => {
+    message.to = [{ email: emailAddress }]
+
+    const sendFunc = sendResultNormalizer(
+      false, // shouldScheduleMessage
+      shouldSendMessage(message),
+      async () => {
+        // Backup method to send emails
+        const nodemailer = NodemailerInterface({ logger: console })
+        if (nodemailer.isUsable(mail, message)) {
+          if (argv.dryRun) {
+            return [{ status: 'sent', interface: 'Nodemailer' }]
+          }
+
+          return nodemailer.send(message)
+        }
+
+        // Default method to send emails
+        const mandrill = MandrillInterface({ logger: console })
+        if (mandrill.isUsable(mail, message)) {
+          if (argv.dryRun) {
+            return [{ status: 'sent', interface: 'Mandrill' }]
+          }
+          return mandrill.send(
+            message,
+            !message.html ? mail.templateName : false,
+            [],
+          )
+        }
+
+        return [{ error: 'No mailing interface usable', status: 'error' }]
+      },
+    )
+
+    if (argv.dryRun) {
+      console.log(mail.templateName, emailAddress)
+      return
+    }
+    const { result, mailLogId } = await send({
+      sendFunc,
+      message: {
+        ...message,
+        html: !!message.html,
+        text: !!message.text,
+        attachments: message.attachments?.map(({ name, type }) => ({
+          name,
+          type,
+        })),
+      },
+      email: message.to[0].email,
+      template: mail.templateName,
+      context: { pgdb },
+    })
+    console.log(mail.templateName, emailAddress, mailLogId, result)
+  })
+}

--- a/packages/mail/templates/cleaned_user_subscription_invitation.html
+++ b/packages/mail/templates/cleaned_user_subscription_invitation.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <!--[if gte mso 15]>
+      <xml>
+        <o:officedocumentsettings>
+          <o:allowpng />
+          <o:pixelsperinch>96</o:pixelsperinch>
+        </o:officedocumentsettings>
+      </xml>
+    <![endif]-->
+    <style type="text/css">
+      {{sg_font_faces}}
+    </style>
+    <style type="text/css">
+      p {
+        color:#282828;font-size:17px;line-height:24px;
+        {{sg_font_style_sans_serif_regular}}
+      }
+      p strong {
+        {{sg_font_style_sans_serif_medium}}
+      }
+    </style>
+  </head>
+  <body style="margin: 0; padding: 0; background-color: #fff">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tbody>
+        <tr>
+          <td align="center" valign="top">
+            <table
+              align="center"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              width="100%"
+              style="max-width:640px;color:#282828;font-size:17px;line-height:24px;{{sg_font_style_sans_serif_regular}}"
+            >
+              <tbody>
+                <tr>
+                  <td style="padding: 20px">
+                    <p>Guten Tag</p>
+                    <p>
+                      Wahrscheinlich haben Sie bemerkt, dass Sie seit einiger
+                      Zeit keine E-Mail-Newsletter mehr von der Republik
+                      erhalten. Grund dafür ist, dass Sie aus unserem Verteiler
+                      gefallen sind, nachdem einer unserer Newsletter abgewiesen
+                      worden war – vielleicht weil Ihre Inbox voll war oder weil
+                      Ihr E-Mail-Anbieter davon ausging, es handle sich um
+                      unliebsame Werbung. Seither stellen wir Ihnen die
+                      täglichen Newsletter per E-Mail nicht mehr zu.
+                    </p>
+                    <p>
+                      Vermissen Sie den Service, jeden Morgen Post von der
+                      Republik zu erhalten und so auf aktuelle Beiträge
+                      aufmerksam gemacht zu werden? Dann können Sie mit
+                      folgendem Link die Newsletter wieder aktivieren:
+                    </p>
+                    <table
+                      width="100%"
+                      border="0"
+                      cellspacing="0"
+                      cellpadding="0"
+                    >
+                      <tr>
+                        <td>
+                          <table border="0" cellspacing="0" cellpadding="0">
+                            <tr>
+                              <td align="center" bgcolor="#3CAD00">
+                                <!-- TODO Link zum subscribe formular !!!! -->
+                                <a
+                                  href="http://eepurl.com/drh7uL"
+                                  style="font-size:20px;{{sg_font_style_sans_serif_regular}}color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;"
+                                  >E-Mail-Newsletter reaktivieren</a
+                                >
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+                    <p>
+                      Und falls es – was leider nicht ausgeschlossen werden kann
+                      – künftig zu weiteren Ausfällen kommen sollte, helfen wir
+                      Ihnen gerne weiter unter
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >.
+                    </p>
+                    <p>
+                      Wir wünschen Ihnen noch einen angenehmen Tag und weiterhin
+                      anregende Lektüre.
+                    </p>
+                    <p>Herzlich</p>
+                    <p>Ihre Crew der Republik</p>
+                    <p>
+                      PS: Möglicherweise ist das für Sie ja ganz gut, das Leben
+                      ohne Republik-Newsletter. Ja, vielleicht sogar gewollt,
+                      weil Sie sowieso immer direkt über unsere
+                      <a href="{{link_signin}}">Website</a>
+                      oder die
+                      <a href="{{link_faq}}#gibt-es-eine-app">Republik-App</a>
+                      auf die Inhalte zugreifen und die
+                      <a href="{{frontend_base_url}}/newsletter">Newsletter</a>
+                      Ihr Postfach eigentlich nur überflutet haben. Dann müssen
+                      Sie jetzt auch nichts weiter unternehmen und dürfen sich
+                      gerne wieder der Lektüre von Interessanterem als dieser
+                      Nachricht widmen. Bitte entschuldigen Sie die Störung.
+                    </p>
+                    <p>
+                      PPS: Kennen Sie schon unsere
+                      <a href="{{frontend_base_url}}/gebrauchsanleitung"
+                        >Gebrauchsanleitung</a
+                      >? Darin finden Sie einige nützliche Tipps zur Handhabung
+                      unseres Magazins.
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 20px">
+                    <p
+                      style="color:#282828;font-size:14px;line-height:20px;{{sg_font_style_sans_serif_regular}}"
+                    >
+                      <img
+                        height="79"
+                        src="{{frontend_base_url}}/static/logo_republik_newsletter.png"
+                        style="
+                          border: 0px;
+                          width: 180px !important;
+                          height: 79px !important;
+                          margin: 0px;
+                        "
+                        width="180"
+                        alt=""
+                      />
+                      <br />
+                      Republik AG<br />
+                      Sihlhallenstrasse 1, CH-8004 Zürich<br />
+                      <a href="{{frontend_base_url}}">www.republik.ch</a><br />
+                      <a href="mailto:kontakt@republik.ch"
+                        >kontakt@republik.ch</a
+                      >
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/mail/templates/cleaned_user_subscription_invitation.html
+++ b/packages/mail/templates/cleaned_user_subscription_invitation.html
@@ -69,7 +69,6 @@
                           <table border="0" cellspacing="0" cellpadding="0">
                             <tr>
                               <td align="center" bgcolor="#3CAD00">
-                                <!-- TODO Link zum subscribe formular !!!! -->
                                 <a
                                   href="http://eepurl.com/drh7uL"
                                   style="font-size:20px;{{sg_font_style_sans_serif_regular}}color:#ffffff;text-decoration:none;border-radius:0;padding:15px 30px 15px 30px;border:1px solid #3CAD00;display:inline-block;"
@@ -111,10 +110,9 @@
                     </p>
                     <p>
                       PPS: Kennen Sie schon unsere
-                      <a href="{{frontend_base_url}}/gebrauchsanleitung"
-                        >Gebrauchsanleitung</a
-                      >? Darin finden Sie einige nützliche Tipps zur Handhabung
-                      unseres Magazins.
+                      <a href="{{link_manual}}">Gebrauchsanleitung</a>? Darin
+                      finden Sie einige nützliche Tipps zur Handhabung unseres
+                      Magazins.
                     </p>
                   </td>
                 </tr>

--- a/packages/mail/templates/cleaned_user_subscription_invitation.txt
+++ b/packages/mail/templates/cleaned_user_subscription_invitation.txt
@@ -1,0 +1,43 @@
+Guten Tag
+
+Wahrscheinlich haben Sie bemerkt, dass Sie seit einiger Zeit keine
+E-Mail-Newsletter mehr von der Republik erhalten. Grund dafür ist, dass Sie aus
+unserem Verteiler gefallen sind, nachdem einer unserer Newsletter abgewiesen
+worden war – vielleicht weil Ihre Inbox voll war oder weil Ihr E-Mail-Anbieter
+davon ausging, es handle sich um unliebsame Werbung. Seither stellen wir Ihnen
+die täglichen Newsletter per E-Mail nicht mehr zu.
+
+Vermissen Sie den Service, jeden Morgen Post von der Republik zu erhalten und so
+auf aktuelle Beiträge aufmerksam gemacht zu werden? Dann können Sie mit
+folgendem Link die Newsletter wieder aktivieren:
+
+E-Mail-Newsletter reaktivieren http://eepurl.com/drh7uL
+
+Und falls es – was leider nicht ausgeschlossen werden kann – künftig zu weiteren
+Ausfällen kommen sollte, helfen wir Ihnen gerne weiter unter kontakt@republik.ch
+.
+
+Wir wünschen Ihnen noch einen angenehmen Tag und weiterhin anregende Lektüre.
+
+Herzlich
+
+Ihre Crew der Republik
+
+PS: Möglicherweise ist das für Sie ja ganz gut, das Leben ohne
+Republik-Newsletter. Ja, vielleicht sogar gewollt, weil Sie sowieso immer direkt
+über unsere Website {{link_signin}} oder die Republik-App
+{{link_faq}}#gibt-es-eine-app auf die Inhalte zugreifen und die Newsletter
+{{frontend_base_url}}/newsletter Ihr Postfach eigentlich nur überflutet haben.
+Dann müssen Sie jetzt auch nichts weiter unternehmen und dürfen sich gerne
+wieder der Lektüre von Interessanterem als dieser Nachricht widmen. Bitte
+entschuldigen Sie die Störung.
+
+PPS: Kennen Sie schon unsere Gebrauchsanleitung
+{{frontend_base_url}}/gebrauchsanleitung ? Darin finden Sie einige nützliche
+Tipps zur Handhabung unseres Magazins.
+
+
+Republik AG
+Sihlhallenstrasse 1, CH-8004 Zürich
+{{frontend_base_url}}
+kontakt@republik.ch

--- a/packages/mail/templates/cleaned_user_subscription_invitation.txt
+++ b/packages/mail/templates/cleaned_user_subscription_invitation.txt
@@ -32,9 +32,8 @@ Dann müssen Sie jetzt auch nichts weiter unternehmen und dürfen sich gerne
 wieder der Lektüre von Interessanterem als dieser Nachricht widmen. Bitte
 entschuldigen Sie die Störung.
 
-PPS: Kennen Sie schon unsere Gebrauchsanleitung
-{{frontend_base_url}}/gebrauchsanleitung ? Darin finden Sie einige nützliche
-Tipps zur Handhabung unseres Magazins.
+PPS: Kennen Sie schon unsere Gebrauchsanleitung {{link_manual}} ? Darin finden
+Sie einige nützliche Tipps zur Handhabung unseres Magazins.
 
 
 Republik AG

--- a/yarn.lock
+++ b/yarn.lock
@@ -4470,6 +4470,11 @@ date-fns@^2.0.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
+dayjs@^1.10.7:
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
+  integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
+
 dayjs@^1.8.29:
   version "1.10.4"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"


### PR DESCRIPTION
- adds script to send mails to a certain segment of mail addresses
- adds script to get cleaned users and provide specific mail information
- adds mail template for cleaned users to invite them to get back to newsletter subscription

Possible further improvements
- move temporary templates to another location and extend `getTemplates` method so that one could specify a path
- there are some code duplicates in `sendScheduledMails.js` and `sendMailsToSegment.js` - maybe this could be generalized too
- atm one can use `envMergeVars` but cannot specify further vars which will be merged together, this could be done now or whenever it's really needed
- maybe use `queryInBatches` (or as option if number in segment is over certain threshold)