### PR TITLE
fix(mail): Revert apply enforceSubscriptions on Mailchimp webhook call

### DIFF
--- a/packages/mail/express/mailchimp.js
+++ b/packages/mail/express/mailchimp.js
@@ -1,10 +1,6 @@
 const bodyParser = require('body-parser')
 const moment = require('moment')
 
-const {
-  enforceSubscriptions,
-} = require('@orbiting/backend-modules-republik-crowdfundings/lib/Mail')
-
 const { MAIL_EXPRESS_MAILCHIMP_SECRET } = process.env
 
 module.exports = async (server, pgdb) => {
@@ -35,7 +31,6 @@ module.exports = async (server, pgdb) => {
       switch (type) {
         case 'subscribe':
           Object.assign(record, handleSubscribe(data))
-          await applyEnforceSubscriptions(record, pgdb)
           break
         case 'unsubscribe':
           Object.assign(record, handleUnsubscribe(data))
@@ -183,14 +178,4 @@ const getGroups = (name, data) => {
     .split(',')
     .map((g) => g.trim())
     .filter(Boolean)
-}
-
-const applyEnforceSubscriptions = async (record, pgdb) => {
-  try {
-    const { email } = record
-    const userId = await pgdb.public.users.findOneFieldOnly({ email }, 'id')
-    await enforceSubscriptions({ pgdb, userId, email })
-  } catch (e) {
-    console.warn('applyEnforceSubscriptions failed:', e)
-  }
 }


### PR DESCRIPTION
This is a temporary fix to prevent an undesired race condition with `enforceSubscriptions` in Access Grants.

It reverts https://github.com/orbiting/backends/commit/0134140c13b7c0740ae22e93618b1c784a291bdc partially.