### PR TITLE
fix(discussions): Remove userId in submitComments

### DIFF
--- a/packages/discussions/graphql/resolvers/_mutations/submitComment.js
+++ b/packages/discussions/graphql/resolvers/_mutations/submitComment.js
@@ -13,11 +13,8 @@ const Promise = require('bluebird')
 
 const { submitComment: notify } = require('../../../lib/Notifications')
 
-module.exports = async (_, args, context) => {
-  const { pgdb, loaders, user, t, pubsub } = context
-  const userId = user.id
-
-  Roles.ensureUserHasRole(user, 'member')
+module.exports = async (_, args, { pgdb, loaders, user: me, t, pubsub }) => {
+  Roles.ensureUserHasRole(me, 'member')
 
   const {
     id,
@@ -85,7 +82,7 @@ module.exports = async (_, args, context) => {
       id,
       discussionId: discussion.id,
       parentId,
-      userId,
+      userId: me.id,
       content,
       tags,
       now: args.now,
@@ -112,7 +109,7 @@ module.exports = async (_, args, context) => {
     if (discussionPreferences) {
       await setDiscussionPreferences({
         discussionPreferences,
-        userId,
+        userId: me.id,
         discussion,
         transaction,
         t,
@@ -121,7 +118,7 @@ module.exports = async (_, args, context) => {
     } else {
       ensureAnonymousDifferentiator({
         transaction,
-        userId,
+        userId: me.id,
         discussion,
         t,
         loaders,


### PR DESCRIPTION
If user is not logged in, calling `submitComment` throw and `id is undefined` error because `user` is not defined in context.

This Pull Request fixes that. `Roles.ensureUserHasRole` will throw error if `me` aka. `user` is not defined. If that checked is passed, it is safe to access `me.id`.