### PR TITLE
fix(search): create redirects independent of scheduleAt

### DIFF
--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -792,10 +792,7 @@ const findPublished = async function (elastic, repoId) {
                   { term: { '__state.published': true } },
                   {
                     bool: {
-                      must: [
-                        { term: { 'meta.prepublication': false } },
-                        { exists: { field: 'meta.scheduledAt' } },
-                      ],
+                      must: [{ term: { 'meta.prepublication': false } }],
                     },
                   },
                 ],


### PR DESCRIPTION
Schedule at is nulled when a newer version get scheduled. But the previous could still have been uploaded to MailChimp. Therefore we can not rely on scheduleAt being present.

Fixes this case:
https://piratinnen.slack.com/archives/C8T08FYFR/p1639837278345600