### PR TITLE
fix(voting): Require allowed membership to be active

### DIFF
--- a/packages/voting/lib/queries.js
+++ b/packages/voting/lib/queries.js
@@ -225,7 +225,7 @@ const buildQueries = (tableName) => {
 
     const where = [
       allowedRoles && 'u.roles ?| :roles',
-      allowedMembershipsQuery && `(${allowedMembershipsQuery})`,
+      allowedMembershipsQuery && `((${allowedMembershipsQuery}) AND m.active = TRUE)`,
       userId && 'u.id = :userId',
     ]
       .filter(Boolean)


### PR DESCRIPTION
This Pull Request will require either of allowed memberships on a user to be active.

If not, a user with an inactive membership – either used or new – might be eligable to submit a ballot or answer.