### PR TITLE
fix(publikator): Handle redirection upsert sequentially

### DIFF
--- a/packages/publikator/lib/Document.js
+++ b/packages/publikator/lib/Document.js
@@ -25,7 +25,7 @@ const getPath = ({ slug, template, publishDate, prepublication, path }) => {
       !!prepublication && PREFIX_PREPUBLICATION_PATH,
       ...path.split('/'),
     ]
-  
+
     return `/${parts.filter(Boolean).join('/')}`
   }
 

--- a/packages/publikator/lib/Document.js
+++ b/packages/publikator/lib/Document.js
@@ -2,6 +2,7 @@ const visit = require('unist-util-visit')
 const debug = require('debug')('publikator:lib:Document')
 const mp3Duration = require('@rocka/mp3-duration')
 const fetch = require('isomorphic-unfetch')
+const Promise = require('bluebird')
 
 const { timeFormat } = require('@orbiting/backend-modules-formats')
 const { mdastToString } = require('@orbiting/backend-modules-utils')
@@ -211,30 +212,34 @@ const prepareMetaForPublish = async ({
 const handleRedirection = async (repoId, newDocMeta, context) => {
   const {
     lib: {
-      Documents: { findPublished },
+      Documents: { findPublications },
     },
   } = require('@orbiting/backend-modules-search')
 
   const newPath = newDocMeta.path
   const { elastic } = context
 
-  const docs = await findPublished(elastic, repoId)
+  const docs = await findPublications(elastic, repoId)
 
-  await Promise.all(
-    docs.map(async (doc) => {
-      if (doc.meta.path !== newPath) {
-        debug('upsertRedirection', { source: doc.meta.path, target: newPath })
-        return upsertRedirection(
-          {
-            source: doc.meta.path,
-            target: newPath,
-            resource: { repo: { id: repoId } },
-          },
-          context,
-        )
-      }
-    }),
-  )
+  const previousPaths = docs
+    .map((doc) => doc.meta.path)
+    .filter((path) => path !== newPath)
+
+  if (!previousPaths.length) {
+    return
+  }
+
+  await Promise.each([...new Set(previousPaths)], (previousPath) => {
+    debug('upsertRedirection', { source: previousPath, target: newPath, repoId })
+    return upsertRedirection(
+      {
+        source: previousPath,
+        target: newPath,
+        resource: { repo: { id: repoId } },
+      },
+      context,
+    )
+  })
 }
 
 module.exports = {

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -778,6 +778,27 @@ const isPathUsed = async function (elastic, path, repoId) {
   return totalCount > 0
 }
 
+/**
+ * Return all publications stored in ElasticSearch for a particualr repo ID
+ */
+const findPublications = async function (elastic, repoId) {
+  const { body } = await elastic.search({
+    ...indexRef,
+    body: {
+      query: {
+        bool: {
+          must: [
+            { term: { 'meta.repoId': repoId } },
+            { term: { 'meta.prepublication': false } },
+          ],
+        },
+      },
+    },
+  })
+
+  return body.hits.hits.map((hit) => hit._source)
+}
+
 const findPublished = async function (elastic, repoId) {
   const { body } = await elastic.search({
     ...indexRef,
@@ -858,6 +879,7 @@ module.exports = {
   prepublishScheduled,
   createPublish,
   isPathUsed,
+  findPublications,
   findPublished,
   findTemplates,
   getResourceUrls,

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -792,7 +792,10 @@ const findPublished = async function (elastic, repoId) {
                   { term: { '__state.published': true } },
                   {
                     bool: {
-                      must: [{ term: { 'meta.prepublication': false } }],
+                      must: [
+                        { term: { 'meta.prepublication': false } },
+                        { exists: { field: 'meta.scheduledAt' } },
+                      ],
                     },
                   },
                 ],

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -779,7 +779,7 @@ const isPathUsed = async function (elastic, path, repoId) {
 }
 
 /**
- * Return all publications stored in ElasticSearch for a particualr repo ID
+ * Return all publications for a given repo ID, stored in ElasticSearch.
  */
 const findPublications = async function (elastic, repoId) {
   const { body } = await elastic.search({

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -799,6 +799,10 @@ const findPublications = async function (elastic, repoId) {
   return body.hits.hits.map((hit) => hit._source)
 }
 
+/**
+ * Return published and scheduled publications for a given repo ID, store
+ * in ElasticSearch.
+ */
 const findPublished = async function (elastic, repoId) {
   const { body } = await elastic.search({
     ...indexRef,

--- a/packages/search/lib/Documents.js
+++ b/packages/search/lib/Documents.js
@@ -773,7 +773,7 @@ const isPathUsed = async function (elastic, path, repoId) {
   const total = body.hits.total
   const totalCount = Number.isFinite(total?.value) ? total.value : total
 
-  debug('findUsedPath', { path, repoId, totalCount })
+  debug('isPathUsed', { path, repoId, totalCount })
 
   return totalCount > 0
 }


### PR DESCRIPTION
Upserting redirections while publishing let to multiple rows with same `source`. To prevent, this Pull Request switches to `Promise.each` instead of `Promise.all`, and it uniquifies previous paths before upserting.

Adds `findPublications`, which returns all "publication" docs stored in ElasticSearch. These are docs that were once published or scheduled to be published.

We want to generate a redirection record for each publication, since a path in a scheduled publication might have been hardcoded elswhere (e.g. a newsletter) while a path might change again before a scheduled publication is actually published.

(It reverts `findPublished`, as it should return actually published or currently scheduled docs.)