### PR TITLE
chore: Unused indices in Postgres, ElasticSearch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -252,6 +252,9 @@ GITHUB_LOGIN=
 # maintenance: disable publishing
 # DISABLE_PUBLISH=true
 
+# Prefix to path for prepublished documents
+PREFIX_PREPUBLICATION_PATH=vorschau
+
 #############
 # republik
 #############
@@ -350,6 +353,9 @@ SEARCH_PG_LISTENER=true
 
 # Suppress Document.estimatedReadingMinutes
 #SUPPRESS_READING_MINUTES='{"series":["A Series Title"],"format":["repo/id"]}'
+
+# Suppress downloading and measuring audio files while indexing a document
+#SUPPRESS_AUDIO_DURATION_MEASURE=true
 
 #############
 # dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
   elastic:
     # in order to get elastic to work, see https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
     container_name: elasticsearch
     environment:
       - cluster.routing.allocation.disk.threshold_enabled=false
@@ -10,6 +10,12 @@ services:
       - ELASTIC_PASSWORD=elastic
       - 'discovery.type=single-node'
       - TAKE_FILE_OWNERSHIP=true
+      - xpack.security.enabled=false
+      # - xpack.graph.enabled=false
+      # - xpack.ml.enabled=false
+      # - xpack.monitoring.enabled=false
+      # - xpack.security.enabled=false
+      # - xpack.watcher.enabled=false
     ulimits:
       memlock:
         soft: -1
@@ -20,7 +26,7 @@ services:
       - 9200:9200
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.10.2
+    image: docker.elastic.co/kibana/kibana:7.16.2
     container_name: kibana
     ports:
       - 5601:5601

--- a/packages/maillog/migrations/sqls/20220111160117-drop-unused-indices-down.sql
+++ b/packages/maillog/migrations/sqls/20220111160117-drop-unused-indices-down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "mail_log_email_lower_idx" ON "mailLog"(lower("email")) ;

--- a/packages/maillog/migrations/sqls/20220111160117-drop-unused-indices-up.sql
+++ b/packages/maillog/migrations/sqls/20220111160117-drop-unused-indices-up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "mail_log_email_lower_idx" ;

--- a/packages/migrations/migrations/20220111155837-drop-unused-indices.js
+++ b/packages/migrations/migrations/20220111155837-drop-unused-indices.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/subscriptions/migrations/sqls'
+const file = '20220111155837-drop-unused-indices'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)

--- a/packages/migrations/migrations/20220111160117-drop-unused-indices.js
+++ b/packages/migrations/migrations/20220111160117-drop-unused-indices.js
@@ -1,0 +1,10 @@
+const run = require('../run.js')
+
+const dir = 'packages/maillog/migrations/sqls'
+const file = '20220111160117-drop-unused-indices'
+
+exports.up = (db) =>
+  run(db, dir, `${file}-up.sql`)
+
+exports.down = (db) =>
+  run(db, dir, `${file}-down.sql`)

--- a/packages/publikator/lib/Document.js
+++ b/packages/publikator/lib/Document.js
@@ -18,7 +18,7 @@ const { updateRepo } = require('./postgres')
 
 const slugDateFormat = timeFormat('%Y/%m/%d')
 
-const PREFIX_PREPUBLICATION_PATH = 'vorschau'
+const { PREFIX_PREPUBLICATION_PATH, SUPPRESS_AUDIO_DURATION_MEASURE } = process.env
 
 const getPath = ({ slug, template, publishDate, prepublication, path }) => {
   if (path) {
@@ -114,7 +114,7 @@ const prepareMetaForPublish = async ({
 
   const { audioSourceMp3, audioSourceAac, audioSourceOgg } = doc.content.meta
   let durationMs = 0
-  if (audioSourceMp3) {
+  if (audioSourceMp3 && !SUPPRESS_AUDIO_DURATION_MEASURE) {
     debug(repoId, 'fetching audio source', audioSourceMp3)
     durationMs = await fetch(audioSourceMp3)
       .then((res) => res.buffer())

--- a/packages/search/lib/indices/comments.js
+++ b/packages/search/lib/indices/comments.js
@@ -50,27 +50,8 @@ module.exports = {
           properties: {
             user: {
               properties: {
-                facebookId: {
-                  type: 'keyword',
-                },
-                firstName: {
-                  type: 'text',
-                },
-                lastName: {
-                  type: 'text',
-                },
                 name: {
                   type: 'text',
-                },
-                credential: {
-                  type: 'text',
-                  analyzer: 'german',
-                },
-                twitterHandle: {
-                  type: 'keyword',
-                },
-                username: {
-                  type: 'keyword',
                 },
               },
             },
@@ -82,15 +63,6 @@ module.exports = {
               },
             },
           },
-        },
-        discussionId: {
-          type: 'keyword',
-        },
-        parentIds: {
-          type: 'keyword',
-        },
-        userId: {
-          type: 'keyword',
         },
 
         contentString: {
@@ -109,56 +81,12 @@ module.exports = {
             },
           },
         },
-        content: {
-          type: 'text',
-          analyzer: 'german',
-          fields: {
-            count: {
-              type: 'token_count',
-              analyzer: 'standard',
-            },
-            keyword: {
-              type: 'keyword',
-              ignore_above: 256,
-            },
-          },
-        },
-
-        upVotes: {
-          type: 'integer',
-        },
-        downVotes: {
-          type: 'integer',
-        },
-
-        votes: {
-          properties: {
-            vote: {
-              type: 'integer',
-            },
-            userid: {
-              type: 'keyword',
-            },
-          },
-        },
-        hotness: {
-          type: 'float',
-        },
-        depth: {
-          type: 'integer',
-        },
 
         published: {
           type: 'boolean',
         },
         adminUnpublished: {
           type: 'boolean',
-        },
-        createdAt: {
-          type: 'date',
-        },
-        updatedAt: {
-          type: 'date',
         },
       },
     },

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -306,7 +306,7 @@ module.exports = {
             section: {
               type: 'keyword',
             },
-            kind: { // @TOOD: Maybe drop
+            kind: {
               type: 'keyword',
             },
             template: {

--- a/packages/search/lib/indices/documents.js
+++ b/packages/search/lib/indices/documents.js
@@ -202,16 +202,6 @@ module.exports = {
                           type: 'text',
                           analyzer: 'german_with_stopwords',
                         },
-                        description: {
-                          type: 'text',
-                          analyzer: 'german',
-                        },
-                        kind: {
-                          type: 'keyword',
-                        },
-                        template: {
-                          type: 'keyword',
-                        },
                       },
                     },
                   },
@@ -224,14 +214,7 @@ module.exports = {
                           type: 'text',
                           analyzer: 'german_with_stopwords',
                         },
-                        description: {
-                          type: 'text',
-                          analyzer: 'german',
-                        },
                         kind: {
-                          type: 'keyword',
-                        },
-                        template: {
                           type: 'keyword',
                         },
                       },
@@ -245,16 +228,6 @@ module.exports = {
                         title: {
                           type: 'text',
                           analyzer: 'german_with_stopwords',
-                        },
-                        description: {
-                          type: 'text',
-                          analyzer: 'german',
-                        },
-                        kind: {
-                          type: 'keyword',
-                        },
-                        template: {
-                          type: 'keyword',
                         },
                       },
                     },
@@ -283,11 +256,6 @@ module.exports = {
             },
           },
         },
-        content: {
-          type: 'object',
-          dynamic: false,
-          enabled: false,
-        },
 
         meta: {
           properties: {
@@ -309,18 +277,11 @@ module.exports = {
             publishDate: {
               type: 'date',
             },
-            lastPublishedAt: {
-              type: 'date',
-            },
             scheduledAt: {
               type: 'date',
             },
             prepublication: {
               type: 'boolean',
-            },
-            slug: {
-              type: 'text',
-              ...keywordPartial,
             },
             path: {
               type: 'text',
@@ -336,11 +297,6 @@ module.exports = {
             credits: {
               ...mdastPartial,
             },
-            authors: {
-              type: 'text',
-              analyzer: 'german_with_stopwords',
-              ...keywordPartial,
-            },
             dossier: {
               type: 'keyword',
             },
@@ -350,7 +306,7 @@ module.exports = {
             section: {
               type: 'keyword',
             },
-            kind: {
+            kind: { // @TOOD: Maybe drop
               type: 'keyword',
             },
             template: {
@@ -372,38 +328,6 @@ module.exports = {
                   type: 'text',
                   analyzer: 'german_with_stopwords',
                 },
-                description: {
-                  type: 'text',
-                  analyzer: 'german',
-                },
-                overview: {
-                  type: 'keyword', // Document
-                },
-                episodes: {
-                  properties: {
-                    document: {
-                      type: 'keyword',
-                    },
-                    image: {
-                      type: 'keyword',
-                    },
-                    publishDate: {
-                      type: 'date',
-                    },
-                    lead: {
-                      type: 'text',
-                      analyzer: 'german_with_stopwords',
-                    },
-                    title: {
-                      type: 'text',
-                      analyzer: 'german_with_stopwords',
-                    },
-                    label: {
-                      type: 'text',
-                      analyzer: 'german_with_stopwords',
-                    },
-                  },
-                },
               },
             },
             hasAudio: {
@@ -424,9 +348,6 @@ module.exports = {
                   type: 'keyword',
                 },
               },
-            },
-            color: {
-              type: 'keyword',
             },
           },
         },

--- a/packages/search/lib/indices/users.js
+++ b/packages/search/lib/indices/users.js
@@ -69,16 +69,6 @@ module.exports = {
           },
         },
 
-        addressId: {
-          type: 'keyword',
-        },
-        adminNotes: {
-          type: 'text',
-          analyzer: 'german',
-        },
-        ageAccessRole: {
-          type: 'keyword',
-        },
         biography: {
           type: 'text',
           analyzer: 'german',
@@ -89,88 +79,18 @@ module.exports = {
             },
           },
         },
-        birthday: {
-          type: 'date',
-        },
-        createdAt: {
-          type: 'date',
-        },
-        defaultDiscussionNotificationOption: {
-          type: 'keyword',
-        },
-        discussionNotificationChannels: {
-          type: 'keyword',
-        },
-        email: {
-          type: 'keyword',
-        },
-        emailAccessRole: {
-          type: 'keyword',
-        },
-        facebookId: {
-          type: 'keyword',
-        },
-        firstName: {
-          type: 'text',
-        },
         hasPublicProfile: {
           type: 'boolean',
         },
-        id: {
-          type: 'keyword',
-        },
-        isAdminUnlisted: {
-          type: 'boolean',
-        },
-        isListed: {
-          type: 'boolean',
-        },
-        lastName: {
-          type: 'text',
-        },
         name: {
           type: 'text',
-        },
-        pgpPublicKey: {
-          type: 'text',
-        },
-        phoneNumber: {
-          type: 'keyword',
-        },
-        phoneNumberAccessRole: {
-          type: 'keyword',
-        },
-        phoneNumberNote: {
-          type: 'text',
-          analyzer: 'german',
-        },
-        portraitUrl: {
-          type: 'keyword',
-        },
-        publicUrl: {
-          type: 'keyword',
-        },
-        roles: {
-          type: 'keyword',
         },
         statement: {
           type: 'text',
           analyzer: 'german',
         },
-        testimonialId: {
-          type: 'keyword',
-        },
-        twitterHandle: {
-          type: 'keyword',
-        },
-        updatedAt: {
-          type: 'date',
-        },
         username: {
           type: 'text',
-        },
-        verified: {
-          type: 'boolean',
         },
       },
     },

--- a/packages/search/lib/inserts/documentzone.js
+++ b/packages/search/lib/inserts/documentzone.js
@@ -9,6 +9,7 @@ const { getElasticDoc } = require('../Documents')
 const { createPublish } = require('../DocumentZones')
 
 const loaderBuilders = {
+  ...require('@orbiting/backend-modules-embeds/loaders'),
   ...require('@orbiting/backend-modules-publikator/loaders'),
 }
 

--- a/packages/subscriptions/migrations/sqls/20220111155837-drop-unused-indices-down.sql
+++ b/packages/subscriptions/migrations/sqls/20220111155837-drop-unused-indices-down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "notifications_event_id_idx" ON "notifications"("eventId") ;

--- a/packages/subscriptions/migrations/sqls/20220111155837-drop-unused-indices-up.sql
+++ b/packages/subscriptions/migrations/sqls/20220111155837-drop-unused-indices-up.sql
@@ -1,0 +1,1 @@
+DROP INDEX public."notifications_event_id_idx" ;


### PR DESCRIPTION
`heroku pg:diagnose` reports unused Postgres indices `notifications::notifications_event_id_idx` and `mailLog::mail_log_email_lower_idx`. In ElasticSearch mappings on documents, comment and users, some more indices are never used either.

This Pull Request drops these mercilessly.

Other changes include:
- Prefix to path for prepublished documents is exposed as ENV variable `PREFIX_PREPUBLICATION_PATH` (instead of hardcoded).
- For development purposes, one can suppresses downloading and measuring audio files while indexing a document with ENV variable`SUPPRESS_AUDIO_DURATION_MEASURE`.
- Due to licensing changes, ElasticSearch is not publishing an OSS version anymore. 
- Fixes missing Embed dataloader when indexing document zones