### PR TITLE
feat(auth): Post slack message on addUserToRole, removeUserFromRole

### DIFF
--- a/packages/auth/graphql/resolvers/_mutations/removeUserFromRole.js
+++ b/packages/auth/graphql/resolvers/_mutations/removeUserFromRole.js
@@ -1,6 +1,4 @@
-const t = require('../../../lib/t')
-const transformUser = require('../../../lib/transformUser')
-
+const { publishMonitor } = require('../../../lib/slack')
 const {
   ensureUserHasRole,
   userHasRole,
@@ -8,15 +6,15 @@ const {
   isRoleClaimableByMe,
 } = require('../../../lib/Roles')
 
-module.exports = async (_, args, { pgdb, signInHooks, user: me }) => {
-  const { userId = me && me.id, role } = args
+module.exports = async (_, args, { pgdb, loaders, user: me, req, t }) => {
+  const { userId, role } = args
+  const isMyself = !userId || me.id === userId
 
-  if (!(me && me.id === userId && isRoleClaimableByMe(role, me))) {
+  if (!(isMyself && isRoleClaimableByMe(role, me))) {
     ensureUserHasRole(me, 'admin')
   }
 
-  const user =
-    me.id !== userId ? await pgdb.public.users.findOne({ id: userId }) : me
+  const user = isMyself ? me : await loaders.User.byId.load(userId)
   if (!user) {
     throw new Error(t('api/users/404'))
   }
@@ -25,5 +23,20 @@ module.exports = async (_, args, { pgdb, signInHooks, user: me }) => {
     return user
   }
 
-  return removeUserFromRole(user.id, role, pgdb).then(transformUser)
+  await removeUserFromRole(user.id, role, pgdb)
+
+  try {
+    const { id, name, email } = user
+    await publishMonitor(
+      me,
+      `:key: removeUserFromRole \`${role}\` ` +
+        `from *<{ADMIN_FRONTEND_BASE_URL}/users/${id}|${name || email}>*`,
+    )
+  } catch (e) {
+    // swallow slack message
+    console.warn('publish to slack failed', { req: req._log(), args, error: e })
+  }
+
+  await loaders.User.byId.clear(userId)
+  return loaders.User.byId.load(userId)
 }

--- a/packages/auth/lib/slack.js
+++ b/packages/auth/lib/slack.js
@@ -1,0 +1,20 @@
+const { publish } = require('@orbiting/backend-modules-slack')
+
+const transformUser = require('../lib/transformUser')
+
+const { SLACK_CHANNEL_IT_MONITOR, ADMIN_FRONTEND_BASE_URL } = process.env
+
+exports.publishMonitor = async (user, message) => {
+  const { id, name, email } = transformUser(user)
+
+  try {
+    const content = [
+      `*<${ADMIN_FRONTEND_BASE_URL}/users/${id}|${name || email}>*:`,
+      message.replace(/{ADMIN_FRONTEND_BASE_URL}/g, ADMIN_FRONTEND_BASE_URL),
+    ].join(' ')
+
+    return await publish(SLACK_CHANNEL_IT_MONITOR, content)
+  } catch (e) {
+    console.warn(e)
+  }
+}

--- a/packages/auth/lib/transformUser.ts
+++ b/packages/auth/lib/transformUser.ts
@@ -18,9 +18,15 @@ interface User {
   [key: string]: any
 }
 
-export = (user: UserRow, additionalFields = {}): User | null => {
+export = (user: UserRow | User, additionalFields = {}): User | null => {
   if (!user) {
     return null
+  }
+  if ('_raw' in user) {
+    return {
+      ...(user as User),
+      ...additionalFields,
+    }
   }
   const name = naming.getName(user)
   return {


### PR DESCRIPTION
Posts a slack message if mutations `addUserToRole` or `removeUserFromRole` are called.

It also updates `transformUser`: If `_raw` is available, user object has been transformed already and returns early with already transformed user.