### PR TITLE
fix(assets): Harden "Accept" header check

### DIFF
--- a/packages/assets/lib/returnImage.js
+++ b/packages/assets/lib/returnImage.js
@@ -136,7 +136,7 @@ module.exports = async ({
 
     if (format === 'auto') {
       res.set('Vary', 'Accept')
-      if (req.get('Accept').includes('image/webp')) {
+      if (req.get('Accept')?.includes('image/webp')) {
         format = 'webp'
       } else {
         format = null


### PR DESCRIPTION
A missing Accept header led to a type error ("Cannot read property 'includes' of undefined").