### PR TITLE
fix(assets): Return 400 w/ error message on failed resize parsing

### DIFF
--- a/packages/assets/lib/returnImage.js
+++ b/packages/assets/lib/returnImage.js
@@ -61,7 +61,7 @@ module.exports = async ({
     try {
       ;({ width, height } = getWidthHeight(resize))
     } catch (e) {
-      res.status(400).end(e.message)
+      return res.status(400).send(e.message)
     }
   }
 


### PR DESCRIPTION
Exit early and send error message as plain text.

Setting "forward filtered headers" once response is send to client (`.end(...)`) will throw an error.