### PR TITLE
fix(mail): updated account urls, fix if construct in template

### DIFF
--- a/packages/mail/lib/sendMailTemplate.js
+++ b/packages/mail/lib/sendMailTemplate.js
@@ -96,7 +96,7 @@ const envMergeVars = [
   },
   {
     name: 'link_account_newsletter',
-    content: `${FRONTEND_BASE_URL}/konto#newsletter`,
+    content: `${FRONTEND_BASE_URL}/konto/newsletter`,
   },
   {
     name: 'link_account_share',
@@ -108,11 +108,15 @@ const envMergeVars = [
   },
   {
     name: 'link_account_notifications',
-    content: `${FRONTEND_BASE_URL}/benachrichtigungen/einstellungen`,
+    content: `${FRONTEND_BASE_URL}/konto/benachrichtigungen`,
   },
   {
     name: 'link_account_progress',
-    content: `${FRONTEND_BASE_URL}/konto#position`,
+    content: `${FRONTEND_BASE_URL}/konto/einstellungen#position`,
+  },
+  {
+    name: 'link_account_signin_method',
+    content: `${FRONTEND_BASE_URL}/konto/einstellungen#anmeldung`,
   },
   {
     name: 'link_profile',

--- a/packages/mail/templates/membership_giver_prolong_notice.html
+++ b/packages/mail/templates/membership_giver_prolong_notice.html
@@ -106,11 +106,11 @@
                       Tage nichts unternehmen, erlauben wir uns, {{#if
                       `gifted_memberships_count == 1`}} die beschenkte
                       Person{{elseif `gifted_memberships_count > 1`}}die
-                      beschenkten Personen{{/if}} direkt anzufragen, ob
-                      sie{{/if}} ein weiteres Jahr an Bord sein {{#if
-                      `gifted_memberships_count == 1`}}möchte{{elseif
-                      `gifted_memberships_count > 1`}}möchten{{/if}}. Dies dann
-                      natürlich auf eigene Rechnung.
+                      beschenkten Personen{{/if}} direkt anzufragen, ob sie ein
+                      weiteres Jahr an Bord sein {{#if `gifted_memberships_count
+                      == 1`}}möchte{{elseif `gifted_memberships_count >
+                      1`}}möchten{{/if}}. Dies dann natürlich auf eigene
+                      Rechnung.
                     </p>
                     <p>Wir danken Ihnen herzlich für die Unterstützung!</p>
                     <p>Ihre Crew der Republik</p>

--- a/packages/mail/templates/membership_giver_prolong_notice.txt
+++ b/packages/mail/templates/membership_giver_prolong_notice.txt
@@ -35,9 +35,9 @@ Jetzt weiter die Republik verschenken {{prolong_url}}
 Falls Sie innerhalb der nächsten {{inform_claimers_days}} Tage nichts
 unternehmen, erlauben wir uns, {{#if `gifted_memberships_count == 1`}} die
 beschenkte Person{{elseif `gifted_memberships_count > 1`}}die beschenkten
-Personen{{/if}} direkt anzufragen, ob sie{{/if}} ein weiteres Jahr an Bord sein
-{{#if `gifted_memberships_count == 1`}}möchte{{elseif `gifted_memberships_count
-> 1`}}möchten{{/if}}. Dies dann natürlich auf eigene Rechnung.
+Personen{{/if}} direkt anzufragen, ob sie ein weiteres Jahr an Bord sein {{#if
+`gifted_memberships_count == 1`}}möchte{{elseif `gifted_memberships_count >
+1`}}möchten{{/if}}. Dies dann natürlich auf eigene Rechnung.
 
 Wir danken Ihnen herzlich für die Unterstützung!
 

--- a/packages/mail/templates/signin_app_notice.html
+++ b/packages/mail/templates/signin_app_notice.html
@@ -54,7 +54,7 @@
                     <p>
                       Möchten Sie Ihre Zugriffsanfragen auch weiterhin lieber
                       via E-Mail bestätigen? Dann können Sie
-                      <a href="https://www.republik.ch/konto#anmeldung"
+                      <a href="{{link_account_signin_method}}"
                         >in Ihrem Konto</a
                       >
                       «E-Mail» als bevorzugtes Anmeldeverfahren auswählen.

--- a/packages/mail/templates/signin_app_notice.txt
+++ b/packages/mail/templates/signin_app_notice.txt
@@ -7,8 +7,8 @@ Diese E-Mail schicken wir Ihnen nur noch dieses eine Mal. Es dient lediglich
 Ihrer Information.
 
 Möchten Sie Ihre Zugriffsanfragen auch weiterhin lieber via E-Mail bestätigen?
-Dann können Sie in Ihrem Konto https://www.republik.ch/konto#anmeldung «E-Mail»
-als bevorzugtes Anmeldeverfahren auswählen.
+Dann können Sie in Ihrem Konto {{link_account_signin_method}} «E-Mail» als
+bevorzugtes Anmeldeverfahren auswählen.
 
 Bei Fragen helfen wir Ihnen gerne unter kontakt@republik.ch weiter.
 

--- a/packages/translate/translations.json
+++ b/packages/translate/translations.json
@@ -790,11 +790,11 @@
     },
     {
       "key": "api/newsletters/update/failed",
-      "value": "Ihre Newsletter-Einstellunge konnten nicht aktualisiert werden, bitte versuchen Sie es später noch einmal."
+      "value": "Ihre Newsletter-Einstellungen konnten nicht aktualisiert werden, bitte versuchen Sie es später noch einmal."
     },
     {
       "key": "api/newsletters/update/token/invalid",
-      "value": "Ihre Newsletter-Einstellunge konnten nicht aktualisiert werden, bitte melden Sie sich bei kontakt@republik.ch."
+      "value": "Ihre Newsletter-Einstellungen konnten nicht aktualisiert werden, bitte melden Sie sich bei kontakt@republik.ch."
     },
     {
       "key": "api/newsletters/update/interestIdNotSupported",


### PR DESCRIPTION
* with [account revision in frontend](https://github.com/orbiting/republik-frontend/pull/702/) some urls change, this PR updates these urls accordingly 
* fixes some other tiny stuff along the way:
  * translation for newsletter settings error
  * remove unwanted closing if in mail template

! Deploy note: Do not ship on prod before frontend changes have been deployed